### PR TITLE
feat(config): support dynamic params

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ To support the development, feel free [to donate](https://liberapay.com/gildesma
 
 ## Installation
 
-|     Install | `gem install html2rss` |
-| ----------: | ---------------------- |
-|       Usage | `html2rss help`        |
+| Install | `gem install html2rss` |
+| ------: | ---------------------- |
+|   Usage | `html2rss help`        |
 
 You can also install it as a dependency in your Ruby project:
 
@@ -33,7 +33,6 @@ You can also install it as a dependency in your Ruby project:
 | Add this line to your `Gemfile`: | `gem 'html2rss'`     |
 |                    Then execute: | `bundle`             |
 |                    In your code: | `require 'html2rss'` |
-
 
 ## Generating a feed on the CLI
 
@@ -89,17 +88,46 @@ Alright, let's move on.
 
 ### The `channel`
 
-| attribute     |          | type    |        default | remark                                     |
-| ------------- | -------- | ------- | -------------: | ------------------------------------------ |
+| attribute     |              | type    |        default | remark                                     |
+| ------------- | ------------ | ------- | -------------: | ------------------------------------------ |
 | `url`         | **required** | String  |                |                                            |
-| `title`       | optional | String  | auto-generated |                                            |
-| `description` | optional | String  | auto-generated |                                            |
-| `ttl`         | optional | Integer |          `360` | TTL in _minutes_                           |
-| `time_zone`   | optional | String  |        `'UTC'` | TimeZone name                              |
-| `language`    | optional | String  |         `'en'` | Language code                              |
-| `author`      | optional | String  |                | Format: `email (Name)`                    |
-| `headers`     | optional | Hash    |           `{}` | Set HTTP request headers. See notes below. |
-| `json`        | optional | Boolean |        `false` | Handle JSON response. See notes below.     |
+| `title`       | optional     | String  | auto-generated |                                            |
+| `description` | optional     | String  | auto-generated |                                            |
+| `ttl`         | optional     | Integer |          `360` | TTL in _minutes_                           |
+| `time_zone`   | optional     | String  |        `'UTC'` | TimeZone name                              |
+| `language`    | optional     | String  |         `'en'` | Language code                              |
+| `author`      | optional     | String  |                | Format: `email (Name)`                     |
+| `headers`     | optional     | Hash    |           `{}` | Set HTTP request headers. See notes below. |
+| `json`        | optional     | Boolean |        `false` | Handle JSON response. See notes below.     |
+
+#### Dynamic parameters in `channel` attributes
+
+Sometimes there are structurally equal pages with different URLs. In such a case you can add _dynamic parameters_ to the channel's attributes.
+
+Example of a dynamic `id` parameter in the channel URLs:
+
+```yml
+channel:
+  url: "http://domainname.tld/whatever/%<id>s.html"
+```
+
+Command line usage example:
+
+```
+bundle exec html2rss feed the_feed_config.yml id=42
+```
+
+<details>
+  <summary>See a Ruby example</summary>
+
+```ruby
+config = Html2rss::Config.new({ channel: { url: 'http://domainname.tld/whatever/%<id>s.html' } }, {}, { id: 42 })
+Html2rss.feed(config)
+```
+
+</details>
+
+See the _more complex formatting_ of the [`sprintf` method](https://ruby-doc.org/core/Kernel.html#method-i-sprintf) for formatting options.
 
 ### The `selectors`
 
@@ -114,18 +142,18 @@ Having an `items` and a `title` selector is already enough to build a simple fee
 
 Your `selectors` Hash can contain arbitrary named selectors, but only a few will make it into the RSS feed (This due to the RSS 2.0 specification):
 
-| RSS 2.0 tag   | name in `html2rss` | remark                      |
-| ------------- | ------------------ | --------------------------- |
-| `title`       | `title`            |                             |
-| `description` | `description`      | Supports HTML.              |
-| `link`        | `link`             | A URL.                      |
-| `author`      | `author`           |                             |
-| `category`    | `categories`       | See notes below.            |
-| `enclosure`   | `enclosure`        | See notes below.            |
-| `pubDate`     | `update`           | An instance of `Time`.      |
-| `guid`        | `guid`             | Generated from the `title`. |
-| `comments`    | `comments`         | A URL.                      |
-| `source`      | ~~source~~         | Not yet supported.          |
+| RSS 2.0 tag   | name in `html2rss` | remark                                       |
+| ------------- | ------------------ | -------------------------------------------- |
+| `title`       | `title`            |                                              |
+| `description` | `description`      | Supports HTML.                               |
+| `link`        | `link`             | A URL.                                       |
+| `author`      | `author`           |                                              |
+| `category`    | `categories`       | See notes below.                             |
+| `enclosure`   | `enclosure`        | See notes below.                             |
+| `pubDate`     | `update`           | An instance of `Time`.                       |
+| `guid`        | `guid`             | Generated from the `title` or `description`. |
+| `comments`    | `comments`         | A URL.                                       |
+| `source`      | ~~source~~         | Not yet supported.                           |
 
 ### The `selector` hash
 
@@ -312,7 +340,7 @@ Since `html2rss` does no further inspection of the enclosure, its support comes 
 
 1. The content-type is guessed from the file extension of the URL.
 2. If the content-type guessing fails, it will default to `application/octet-stream`.
-3. The content-length will always be undetermined and thus stated as `0` bytes.
+3. The content-length will always be undetermined and therefore stated as `0` bytes.
 
 Read the [RSS 2.0 spec](http://www.rssboard.org/rss-profile#element-channel-item-enclosure) for further information on enclosing content.
 
@@ -348,7 +376,7 @@ selectors:
 
 ## Scraping and handling JSON responses
 
-Although this gem is called **html**​*2rss*, it's possible to scrape and process JSON.
+Although this gem's name is **html**​*2rss*, it's possible to scrape and process JSON.
 
 Adding `json: true` to the channel config will convert the JSON response to XML.
 
@@ -527,7 +555,6 @@ Your feed configs go below `feeds`. Everything else is part of the global config
 
 Find a full example of a `feeds.yml` at [`spec/feeds.test.yml`](https://github.com/html2rss/html2rss/blob/master/spec/feeds.test.yml).
 
-
 Now you can build your feeds like this:
 
 <details>
@@ -539,6 +566,7 @@ require 'html2rss'
 myfeed = Html2rss.feed_from_yaml_config('feeds.yml', 'myfeed')
 myotherfeed = Html2rss.feed_from_yaml_config('feeds.yml', 'myotherfeed')
 ```
+
 </details>
 
 <details>
@@ -548,6 +576,7 @@ myotherfeed = Html2rss.feed_from_yaml_config('feeds.yml', 'myotherfeed')
 $ html2rss feed feeds.yml myfeed
 $ html2rss feed feeds.yml myotherfeed
 ```
+
 </details>
 
 ## Gotchas and tips & tricks

--- a/lib/html2rss.rb
+++ b/lib/html2rss.rb
@@ -19,10 +19,11 @@ module Html2rss
   #    # => #<RSS::Rss:0x00007fb2f6331228
   #
   # @param file [File] a file object of the yaml file to use
-  # @param name [String] name of the feed to generate from the yaml
+  # @param name [String, nil] name of the feed to generate from the yaml
   # @param global_config [Hash] global options (e.g. HTTP headers) to use
+  # @param params [Hash] if required by feed config, the dynamic parameters for the config
   # @return [RSS::Rss]
-  def self.feed_from_yaml_config(file, name = nil, global_config: {})
+  def self.feed_from_yaml_config(file, name = nil, global_config: {}, params: {})
     # rubocop:disable Security/YAMLLoad
     yaml = YAML.load(File.open(file))
     # rubocop:enable Security/YAMLLoad
@@ -34,7 +35,7 @@ module Html2rss
       feed_config = yaml
     end
 
-    config = Config.new(feed_config, global_config)
+    config = Config.new(feed_config, global_config, params)
     feed(config)
   end
 
@@ -53,10 +54,10 @@ module Html2rss
   #    )
   #    # => #<RSS::Rss:0x00007fb2f48d14a0 ...>
   #
-  # @param config [Html2rss::Config, Hash<String, Object>]
+  # @param config [Html2rss::Config]
   # @return [RSS::Rss]
   def self.feed(config)
-    config = Config.new(config) unless config.is_a?(Config)
+    raise 'given config must be a Html2rss::Config instance' unless config.is_a?(Config)
 
     feed = FeedBuilder.new config
     feed.rss

--- a/lib/html2rss/cli.rb
+++ b/lib/html2rss/cli.rb
@@ -15,7 +15,7 @@ module Html2rss
     def feed(yaml_file, *options)
       raise 'yaml_file file does not exist' unless File.exist?(yaml_file)
 
-      params = options.filter_map { |p| p.split('=') if p.include?('=') }.to_h
+      params = options.map { |p| p.split('=') if p.include?('=') }.compact.to_h
       feed_name = options.first
       puts Html2rss.feed_from_yaml_config(yaml_file, feed_name, params: params)
     end

--- a/lib/html2rss/cli.rb
+++ b/lib/html2rss/cli.rb
@@ -11,11 +11,13 @@ module Html2rss
       true
     end
 
-    desc 'feed YAML_FILE [FEED_NAME]', 'print RSS built from the FEED_CONFIG file to stdout'
-    def feed(yaml_file, feed_name = nil)
+    desc 'feed YAML_FILE [FEED_NAME] [param=value ...]', 'print RSS built from the FEED_CONFIG file to stdout'
+    def feed(yaml_file, *options)
       raise 'yaml_file file does not exist' unless File.exist?(yaml_file)
 
-      puts Html2rss.feed_from_yaml_config(yaml_file, feed_name)
+      params = options.filter_map { |p| p.split('=') if p.include?('=') }.to_h
+      feed_name = options.first
+      puts Html2rss.feed_from_yaml_config(yaml_file, feed_name, params: params)
     end
   end
 end

--- a/lib/html2rss/config.rb
+++ b/lib/html2rss/config.rb
@@ -168,7 +168,7 @@ module Html2rss
     ##
     # Sets the variables used in the feed config's channel.
     #
-    # @param feed_config [Hash<String, Object>]
+    # @param feed_config [Hash<Symbol, Object>]
     # @param feed_config [Hash<Symbol, Object>]
     def process_params(feed_config, params)
       return feed_config if params.keys.none?

--- a/lib/html2rss/config.rb
+++ b/lib/html2rss/config.rb
@@ -173,10 +173,10 @@ module Html2rss
     def process_params(feed_config, params)
       return feed_config if params.keys.none?
 
-      feed_config['channel'].each_key do |attribute_name|
-        next unless feed_config['channel'][attribute_name].is_a?(String)
+      feed_config[:channel].each_key do |attribute_name|
+        next unless feed_config[:channel][attribute_name].is_a?(String)
 
-        feed_config['channel'][attribute_name] = format(feed_config['channel'][attribute_name], params)
+        feed_config[:channel][attribute_name] = format(feed_config[:channel][attribute_name], params)
       end
 
       feed_config

--- a/spec/exe/html2rss_spec.rb
+++ b/spec/exe/html2rss_spec.rb
@@ -33,15 +33,25 @@ RSpec.describe 'exe/html2rss' do
     end
   end
 
-  context 'with arguments: feed YAML_FILE' do
-    it 'generates the RSS' do
-      expect(`#{executable} feed spec/single.test.yml`).to start_with(rss_start)
+  context 'with the nuxt example' do
+    context 'with arguments: feed YAML_FILE' do
+      it 'generates the RSS' do
+        expect(`#{executable} feed spec/single.test.yml`).to start_with(rss_start)
+      end
+    end
+
+    context 'with arguments: feed YAML_FILE FEED_NAME param=value' do
+      it 'generates the RSS' do
+        expect(`#{executable} feed spec/feeds.test.yml 'nuxt-releases'`).to start_with(rss_start)
+      end
     end
   end
 
-  context 'with arguments: feed YAML_FILE FEED_NAME' do
-    it 'generates the RSS' do
-      expect(`#{executable} feed spec/feeds.test.yml 'nuxt-releases'`).to start_with(rss_start)
+  context 'with params: feed YAML_FILE FEED_NAME param=<value>' do
+    it 'proccesses and escapes the params' do
+      expect(`#{executable} feed spec/feeds.test.yml withparams param='<value>' sign=10`)
+        .to include('<description>The value of param is: &lt;value&gt;</description>',
+                    'horoscope-general-daily-today.aspx?sign=10')
     end
   end
 end

--- a/spec/exe/html2rss_spec.rb
+++ b/spec/exe/html2rss_spec.rb
@@ -33,21 +33,21 @@ RSpec.describe 'exe/html2rss' do
     end
   end
 
-  context 'with the nuxt-releases feed config' do
+  context 'with feed config: nuxt-releases' do
     context 'with arguments: feed YAML_FILE' do
       it 'generates the RSS' do
         expect(`#{executable} feed spec/single.test.yml`).to start_with(rss_start)
       end
     end
 
-    context 'with arguments: feed YAML_FILE FEED_NAME param=value' do
+    context 'with arguments: feed YAML_FILE FEED_NAME' do
       it 'generates the RSS' do
-        expect(`#{executable} feed spec/feeds.test.yml 'nuxt-releases'`).to start_with(rss_start)
+        expect(`#{executable} feed spec/feeds.test.yml nuxt-releases`).to start_with(rss_start)
       end
     end
   end
 
-  context 'with params: feed YAML_FILE FEED_NAME param=<value> sign=10' do
+  context 'with feed config: withparams' do
     it 'processes and escapes the params' do
       expect(`#{executable} feed spec/feeds.test.yml withparams param='<value>' sign=10`)
         .to include('<description>The value of param is: &lt;value&gt;</description>',

--- a/spec/exe/html2rss_spec.rb
+++ b/spec/exe/html2rss_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'exe/html2rss' do
     end
   end
 
-  context 'with the nuxt example' do
+  context 'with the nuxt-releases feed config' do
     context 'with arguments: feed YAML_FILE' do
       it 'generates the RSS' do
         expect(`#{executable} feed spec/single.test.yml`).to start_with(rss_start)
@@ -47,8 +47,8 @@ RSpec.describe 'exe/html2rss' do
     end
   end
 
-  context 'with params: feed YAML_FILE FEED_NAME param=<value>' do
-    it 'proccesses and escapes the params' do
+  context 'with params: feed YAML_FILE FEED_NAME param=<value> sign=10' do
+    it 'processes and escapes the params' do
       expect(`#{executable} feed spec/feeds.test.yml withparams param='<value>' sign=10`)
         .to include('<description>The value of param is: &lt;value&gt;</description>',
                     'horoscope-general-daily-today.aspx?sign=10')

--- a/spec/feeds.test.yml
+++ b/spec/feeds.test.yml
@@ -103,3 +103,12 @@ feeds:
       link:
         selector: "#src-horo-today"
         extractor: "href"
+  withparams:
+    channel:
+      url: https://www.horoscope.com/us/horoscopes/general/horoscope-general-daily-today.aspx?sign=%<sign>s
+      description: "The value of param is: %<param>s"
+    selectors:
+      items:
+        selector: "div.main-horoscope"
+      description:
+        selector: "p"

--- a/spec/html2rss/config_spec.rb
+++ b/spec/html2rss/config_spec.rb
@@ -1,6 +1,26 @@
 # frozen_string_literal: true
 
 RSpec.describe Html2rss::Config do
+  describe '.new' do
+    context 'with missing required params' do
+      it 'raises ParamsMissing' do
+        expect do
+          described_class.new(channel: { url: 'http://example.com/%<section>s' })
+        end.to raise_error described_class::ParamsMissing
+      end
+    end
+  end
+
+  describe '.required_params_for_feed_config(feed_config)' do
+    it do
+      expect(
+        described_class.required_params_for_feed_config(
+          channel: { url: 'http://example.com/%<section>s/%<something>d' }
+        )
+      ).to be_a(Set).and include 'section', 'something'
+    end
+  end
+
   describe '#attribute_names' do
     subject { described_class.new(selectors: { items: {}, name: {} }).attribute_names }
 

--- a/spec/html2rss_spec.rb
+++ b/spec/html2rss_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe Html2rss do
   context 'with config having channel headers and json: true' do
     subject(:categories) do
       VCR.use_cassette('httpbin-headers') do
-        described_class.feed(feed_config)
+        described_class.feed(Html2rss::Config.new(feed_config))
       end.items.first.categories.map(&:content)
     end
 


### PR DESCRIPTION
The functionality existed already in the html2rss-web project.
The code was moved and refactored accordingly to allow the CLI
to make use of dynamic params, too.

BREAKING: This breaks the public API of the gem, specifically
`Html2rss.feed` which now requires a Html2rss::Config instance.