### PR TITLE
feat: drop support for Ruby 2.6

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1"]
+        ruby: ["2.7", "3.0", "3.1"]
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 # rspec failure tracking
 .rspec_status
 coverage
+docs/

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,8 +1,15 @@
+queue_rules:
+  - name: dependabot
+    conditions:
+      - author=dependabot[bot]
+      - status-success=test
+      - base=master
+
 pull_request_rules:
   - name: automatic merge for Dependabot pull requests
     conditions:
       - author=dependabot[bot]
     actions:
-      merge:
+      queue:
         method: squash
-        strict: smart
+        name: dependabot

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   DisplayCopNames: true
   NewCops: enable
   Exclude:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ supported, too.
 **Searching for a ready to use app which serves generated feeds via HTTP?**
 [Head over to `html2rss-web`!](https://github.com/html2rss/html2rss-web)
 
-To support the development, feel free [to donate](https://liberapay.com/gildesmarais/donate). Thank you! 💓
+To support the development, feel free to sponsor this project on Github. Thank you! 💓
 
 ## Installation
 
@@ -176,7 +176,7 @@ Extractors help with extracting the information from the selected HTML tag.
 - The `static` extractor returns the configured static value (it doesn't extract anything).
 - [See file list of extractors](https://github.com/html2rss/html2rss/tree/master/lib/html2rss/item_extractors).
 
-Extractors might need extra attributes on the selector hash.  
+Extractors might need extra attributes on the selector hash.
 👉 [Read their docs for usage examples](https://www.rubydoc.info/gems/html2rss/Html2rss/ItemExtractors).
 
 <details>
@@ -517,7 +517,7 @@ Use this to e.g. have Cookie or Authorization information sent or to spoof the U
 
 <details>
   <summary>See a Ruby example</summary>
-  
+
   ```ruby
   Html2rss.feed(
     channel: {

--- a/html2rss.gemspec
+++ b/html2rss.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Give the URL to scrape and some CSS selectors. Get a RSS::Rss instance in return.'
   spec.homepage      = 'https://github.com/html2rss/html2rss'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 2.7.0'
 
   if spec.respond_to?(:metadata)
     spec.metadata['allowed_push_host'] = 'https://rubygems.org'

--- a/lib/html2rss/cli.rb
+++ b/lib/html2rss/cli.rb
@@ -15,7 +15,7 @@ module Html2rss
     def feed(yaml_file, *options)
       raise 'yaml_file file does not exist' unless File.exist?(yaml_file)
 
-      params = options.map { |param| param.split('=') if param.include?('=') }.compact.to_h
+      params = options.filter_map { |param| param.split('=') if param.include?('=') }.to_h
       feed_name = options.first
       puts Html2rss.feed_from_yaml_config(yaml_file, feed_name, params: params)
     end


### PR DESCRIPTION
According to https://www.ruby-lang.org/en/downloads/branches/
the ruby 2.6 EOL date is 2022-03-31.

It shouldn't be used anymore, so please upgrade to at least 2.7.

This is a BREAKING change if you're still on ruby <2.7.