### PR TITLE
fix: handle active support <7 requires

### DIFF
--- a/lib/html2rss/config.rb
+++ b/lib/html2rss/config.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
-require 'active_support/isolated_execution_state'
+begin
+  require 'active_support/isolated_execution_state'
+rescue LoadError => e
+  puts e.message
+end
+
 require 'active_support/core_ext/hash'
 
 module Html2rss


### PR DESCRIPTION
the require statement is necessary for AS7, but on version <7 the
file doesn't exist...

Related: https://github.com/html2rss/html2rss/issues/132