### PR TITLE
refactor: do not use URI directly

### DIFF
--- a/lib/html2rss/attribute_post_processors/sanitize_html.rb
+++ b/lib/html2rss/attribute_post_processors/sanitize_html.rb
@@ -83,11 +83,7 @@ module Html2rss
           url_attribute = URL_ELEMENTS_WITH_URL_ATTRIBUTE[env[:node_name]]
           url = env[:node][url_attribute]
 
-          return if URI(url).absolute?
-
-          absolute_url = Html2rss::Utils.build_absolute_url_from_relative(url, @channel_url)
-
-          env[:node][url_attribute] = absolute_url
+          env[:node][url_attribute] = Html2rss::Utils.build_absolute_url_from_relative(url, @channel_url)
         end
       end
 

--- a/lib/html2rss/item.rb
+++ b/lib/html2rss/item.rb
@@ -86,7 +86,7 @@ module Html2rss
     end
 
     ##
-    # @return [URI::HTTPS, URI::HTTP]
+    # @return [Addressable::URI]
     def enclosure_url
       enclosure = Html2rss::Utils.sanitize_url(method_missing(:enclosure))
 
@@ -94,7 +94,7 @@ module Html2rss
     end
 
     ##
-    # @param url [URI::HTTPS, URI::HTTP, Addressable::URI]
+    # @param url [String, Addressable::URI]
     # @param config [Html2rss::Config]
     # @return [Array<Html2rss::Item>]
     def self.from_url(url, config)

--- a/lib/html2rss/item_extractors/href.rb
+++ b/lib/html2rss/item_extractors/href.rb
@@ -34,7 +34,7 @@ module Html2rss
         @href = Html2rss::Utils.sanitize_url(element.attr('href'))
       end
 
-      # @return [URI::HTTPS, URI::HTTP]
+      # @return [Addressable::URI]
       def get
         Html2rss::Utils.build_absolute_url_from_relative(@href, @options.channel.url)
       end

--- a/lib/html2rss/utils.rb
+++ b/lib/html2rss/utils.rb
@@ -95,7 +95,7 @@ module Html2rss
     end
 
     ##
-    # @param url [String, URI::HTTPS, URI::HTTP, Addressable::URI]
+    # @param url [String, Addressable::URI]
     # @param convert_json_to_xml [true, false] Should JSON be converted to XML
     # @param headers [Hash] additional HTTP request headers to use for the request
     # @return [String]


### PR DESCRIPTION
we've been using Addressable for a while and handles many edge cases
better than ruby's own URI.