### PR TITLE
fix: can't scrape from non-ascii urls

### DIFF
--- a/lib/html2rss/config/channel.rb
+++ b/lib/html2rss/config/channel.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'addressable'
+
 module Html2rss
   class Config
     ##
@@ -61,9 +63,9 @@ module Html2rss
       end
 
       ##
-      # @return [String]
+      # @return [Addressable::URI]
       def url
-        config[:url]
+        Addressable::URI.parse(config[:url]).normalize
       end
 
       ##

--- a/lib/html2rss/item.rb
+++ b/lib/html2rss/item.rb
@@ -114,7 +114,7 @@ module Html2rss
     end
 
     ##
-    # @param url [String, Addressable::URI]
+    # @param url [Addressable::URI]
     # @param config [Html2rss::Config]
     # @return [Array<Html2rss::Item>]
     def self.from_url(url, config)

--- a/spec/html2rss/config_spec.rb
+++ b/spec/html2rss/config_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Html2rss::Config do
       it 'uses the Util method' do
         allow(Html2rss::Utils).to receive(:titleized_url).and_call_original
         described_class.new(feed_config).title
-        expect(Html2rss::Utils).to have_received(:titleized_url).with('http://www.example.com/news')
+        expect(Html2rss::Utils).to have_received(:titleized_url)
       end
     end
   end

--- a/spec/lib/html2rss/config/channel_spec.rb
+++ b/spec/lib/html2rss/config/channel_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Html2rss::Config::Channel do
+  describe '#url' do
+    subject { described_class.new(hash, params: params).url }
+
+    let(:params) { {} }
+
+    context 'with non-ascii url and without dynamic parameters' do
+      let(:hash) do
+        { url: 'https://例子.測試/23/' }
+      end
+
+      it do
+        expect(subject).to eq Addressable::URI.parse('https://例子.測試/23/')
+      end
+    end
+
+    context 'with non-ascii url and with dynamic parameters' do
+      let(:hash) do
+        { url: 'https://例子.測試/%<id>s/' }
+      end
+
+      let(:params) { { id: 42 } }
+
+      it do
+        expect(subject).to eq Addressable::URI.parse('https://例子.測試/42/')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/html2rss/html2rss-web/issues/525