### PR TITLE
feat: drop support for ruby <3.1

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["2.7", "3.0", "3.1"]
+        ruby: ["3.1"]
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,6 @@ require:
   - rubocop-md
 
 AllCops:
-  TargetRubyVersion: 2.7
   DisplayCopNames: true
   NewCops: enable
   Exclude:

--- a/html2rss.gemspec
+++ b/html2rss.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Give the URL to scrape and some CSS selectors. Get a RSS::Rss instance in return.'
   spec.homepage      = 'https://github.com/html2rss/html2rss'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>= 2.7.0'
+  spec.required_ruby_version = '>= 3.1'
 
   if spec.respond_to?(:metadata)
     spec.metadata['allowed_push_host'] = 'https://rubygems.org'

--- a/lib/html2rss/cli.rb
+++ b/lib/html2rss/cli.rb
@@ -23,7 +23,7 @@ module Html2rss
 
       params = options.filter_map { |param| param.split('=') if param.include?('=') }.to_h
       feed_name = options.first
-      puts Html2rss.feed_from_yaml_config(yaml_file, feed_name, params: params)
+      puts Html2rss.feed_from_yaml_config(yaml_file, feed_name, params:)
     end
   end
 end

--- a/lib/html2rss/config.rb
+++ b/lib/html2rss/config.rb
@@ -43,7 +43,7 @@ module Html2rss
     # @param global [Hash<Symbol, Object>]
     # @param params [Hash<Symbol, String>]
     def initialize(feed_config, global = {}, params = {})
-      @channel = Channel.new(feed_config[:channel], params: params)
+      @channel = Channel.new(feed_config[:channel], params:)
       @selectors = Selectors.new(feed_config[:selectors])
       @global = global
     end

--- a/lib/html2rss/item.rb
+++ b/lib/html2rss/item.rb
@@ -109,7 +109,7 @@ module Html2rss
       Enclosure.new(
         type: content_type.any? ? content_type.first.to_s : 'application/octet-stream',
         bits_length: 0,
-        url: url
+        url:
       )
     end
 
@@ -142,7 +142,7 @@ module Html2rss
 
       [post_process_options].flatten.each do |options|
         value = AttributePostProcessors.get_processor(options[:name])
-                                       .new(value, Context.new(options: options, item: self, config: config))
+                                       .new(value, Context.new(options:, item: self, config:))
                                        .get
       end
 

--- a/lib/html2rss/utils.rb
+++ b/lib/html2rss/utils.rb
@@ -101,7 +101,7 @@ module Html2rss
     # @param headers [Hash] additional HTTP request headers to use for the request
     # @return [String]
     def self.request_body_from_url(url, convert_json_to_xml: false, headers: {})
-      body = Faraday.new(url: url, headers: headers) do |faraday|
+      body = Faraday.new(url:, headers:) do |faraday|
         faraday.use Faraday::FollowRedirects::Middleware
         faraday.adapter Faraday.default_adapter
       end.get.body

--- a/spec/html2rss/attribute_post_processors/html_to_markdown_spec.rb
+++ b/spec/html2rss/attribute_post_processors/html_to_markdown_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Html2rss::AttributePostProcessors::HtmlToMarkdown do
-  subject { described_class.new(html, config: config).get }
+  subject { described_class.new(html, config:).get }
 
   let(:config) do
     Html2rss::Config.new(

--- a/spec/html2rss/attribute_post_processors/markdown_to_html_spec.rb
+++ b/spec/html2rss/attribute_post_processors/markdown_to_html_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Html2rss::AttributePostProcessors::MarkdownToHtml do
-  subject { described_class.new(markdown, config: config).get }
+  subject { described_class.new(markdown, config:).get }
 
   let(:config) do
     Html2rss::Config.new(channel: { title: 'Example: questions', url: 'https://example.com/questions' },

--- a/spec/html2rss/attribute_post_processors/parse_time_spec.rb
+++ b/spec/html2rss/attribute_post_processors/parse_time_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Html2rss::AttributePostProcessors::ParseTime do
       'Europe/Berlin' => 'Mon, 01 Jul 2019 12:00:00 +0200'
     }.each_pair do |time_zone, expected|
       it "parses in time_zone #{time_zone}" do
-        ctx = Html2rss::Item::Context.new(config: instance_double(Html2rss::Config, time_zone: time_zone))
+        ctx = Html2rss::Item::Context.new(config: instance_double(Html2rss::Config, time_zone:))
 
         expect(described_class.new('2019-07-01 12:00', ctx).get).to eq expected
       end

--- a/spec/html2rss/attribute_post_processors/sanitize_html_spec.rb
+++ b/spec/html2rss/attribute_post_processors/sanitize_html_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Html2rss::AttributePostProcessors::SanitizeHtml do
-  subject { described_class.new(html, config: config).get }
+  subject { described_class.new(html, config:).get }
 
   let(:config) do
     Html2rss::Config.new(

--- a/spec/html2rss/attribute_post_processors/template_spec.rb
+++ b/spec/html2rss/attribute_post_processors/template_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Html2rss::AttributePostProcessors::Template do
-  subject { described_class.new('Hi', options: options, item: item).get }
+  subject { described_class.new('Hi', options:, item:).get }
 
   # An instance_double does not work with method_missing.
   # rubocop:disable RSpec/VerifiedDoubles

--- a/spec/html2rss/item_extractors/href_spec.rb
+++ b/spec/html2rss/item_extractors/href_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Html2rss::ItemExtractors::Href do
   subject { described_class.new(xml, options).get }
 
   let(:channel) { instance_double(::Html2rss::Config::Channel, url: 'https://example.com') }
-  let(:options) { instance_double(Struct::HrefOptions, selector: 'a', channel: channel) }
+  let(:options) { instance_double(Struct::HrefOptions, selector: 'a', channel:) }
 
   context 'with relative href url' do
     let(:xml) { Nokogiri.HTML('<div><a href="/posts/latest-findings">...</a></div>') }

--- a/spec/html2rss/utils_spec.rb
+++ b/spec/html2rss/utils_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Html2rss::Utils do
     let(:connection) { instance_double(Faraday::Connection, get: response) }
 
     it 'uses Faraday for the request' do
-      allow(Faraday).to receive(:new).with(options.merge(url: url)).and_return(connection)
+      allow(Faraday).to receive(:new).with(options.merge(url:)).and_return(connection)
       described_class.request_body_from_url(url, **options.merge(convert_json_to_xml: false))
       expect(response).to have_received(:body)
     end

--- a/spec/lib/html2rss/config/channel_spec.rb
+++ b/spec/lib/html2rss/config/channel_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe Html2rss::Config::Channel do
   describe '#url' do
-    subject { described_class.new(hash, params: params).url }
+    subject { described_class.new(hash, params:).url }
 
     let(:params) { {} }
 


### PR DESCRIPTION
This is a BREAKING CHANGE.

Make sure to use ruby 3.1 (latest). If you're using html2rss-web, there is no need to change anything.