### PR TITLE
feat: ignore params when guessing content_type

### DIFF
--- a/lib/html2rss/item.rb
+++ b/lib/html2rss/item.rb
@@ -104,10 +104,8 @@ module Html2rss
 
       raise 'An item.enclosure requires an absolute URL' if !url || !url.absolute?
 
-      content_type = MIME::Types.type_for(File.extname(url).delete('.'))
-
       Enclosure.new(
-        type: content_type.any? ? content_type.first.to_s : 'application/octet-stream',
+        type: Html2rss::Utils.guess_content_type_from_url(url),
         bits_length: 0,
         url:
       )

--- a/lib/html2rss/utils.rb
+++ b/lib/html2rss/utils.rb
@@ -6,6 +6,7 @@ require 'faraday/follow_redirects'
 require 'json'
 require 'regexp_parser'
 require 'tzinfo'
+require 'mime/types'
 
 module Html2rss
   ##
@@ -123,6 +124,13 @@ module Html2rss
       string = string[1..-2] if string[0] == '/' && string[-1] == '/'
 
       Regexp::Parser.parse(string, options: ::Regexp::EXTENDED | ::Regexp::IGNORECASE).to_re
+    end
+
+    def self.guess_content_type_from_url(url)
+      url = url.to_s.split('?').first
+
+      content_type = MIME::Types.type_for(File.extname(url).delete('.'))
+      content_type.any? ? content_type.first.to_s : 'application/octet-stream'
     end
   end
 end

--- a/spec/html2rss/utils_spec.rb
+++ b/spec/html2rss/utils_spec.rb
@@ -98,4 +98,18 @@ RSpec.describe Html2rss::Utils do
       it { expect(described_class.build_regexp_from_string(string)).to eq expected }
     end
   end
+
+  describe '.guess_content_type_from_url(url)' do
+    {
+      'https://example.com/image.jpg' => 'image/jpeg',
+      'https://example.com/image.png' => 'image/png',
+      'https://example.com/image.gif' => 'image/gif',
+      'https://example.com/image.svg' => 'image/svg+xml',
+      'https://example.com/image.webp' => 'image/webp',
+      'https://example.com/image' => 'application/octet-stream',
+      'https://api.PAGE.com/wp-content/photo.jpg?quality=85&w=925&h=617&crop=1&resize=925,617' => 'image/jpeg'
+    }.each_pair do |url, expected|
+      it { expect(described_class.guess_content_type_from_url(url)).to eq expected }
+    end
+  end
 end


### PR DESCRIPTION
& move out of `Item` class