### PR TITLE
refactor(utils): return Addressable::URI in .sanitize_url

### DIFF
--- a/lib/html2rss/utils.rb
+++ b/lib/html2rss/utils.rb
@@ -31,12 +31,12 @@ module Html2rss
     ##
     # Removes any space, parses and normalizes the given url.
     # @param url [String]
-    # @return [String, nil] sanitized and normalized URL, or nil if input is empty
+    # @return [Addressable::URI, nil] normalized URL, or nil if input is empty
     def self.sanitize_url(url)
       url = url.to_s.gsub(/\s+/, ' ').strip
       return if url.empty?
 
-      Addressable::URI.parse(url).normalize.to_s
+      Addressable::URI.parse(url).normalize
     end
 
     ##

--- a/spec/html2rss/utils_spec.rb
+++ b/spec/html2rss/utils_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Html2rss::Utils do
 
     it 'sanitizes the url', :aggregate_failures do
       examples.each_pair do |url, out|
-        expect(described_class.sanitize_url(url)).to eq(out), url
+        expect(described_class.sanitize_url(url)).to eq(Addressable::URI.parse(out)), url
       end
     end
   end


### PR DESCRIPTION

Updated sanitize_url to return Addressable::URI object instead of a string. Adjusted test expectations accordingly for consistency.