### PR TITLE
feat(auto_source): enable integration with html2rss-web

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Gem Version](https://badge.fury.io/rb/html2rss.svg)](http://rubygems.org/gems/html2rss/) [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/gems/html2rss) ![Retro Badge: valid RSS](https://validator.w3.org/feed/images/valid-rss-rogers.png)
 
-`html2rss` is a Ruby gem that generates RSS 2.0 feeds from a _feed config_.
+`html2rss` is a Ruby gem that generates RSS 2.0 feeds from websites automatically, and as a fallback via _feed config_.
 
 With the _feed config_, you provide a URL to scrape and CSS selectors for extracting information (like title, URL, etc.). The gem builds the RSS feed accordingly. [Extractors](#using-extractors) and chainable [post processors](#using-post-processors) make information extraction, processing, and sanitizing a breeze. The gem also supports [scraping JSON](#scraping-and-handling-json-responses) responses and [setting HTTP request headers](#set-any-http-header-in-the-request).
 
@@ -26,9 +26,9 @@ You can also install it as a dependency in your Ruby project:
 
 ## Generating a feed on the CLI
 
-### using automatic scraping
+### using automatic generation
 
-html2rss offers an automatic scrapting feature. Try it with:
+html2rss offers an automatic RSS generation feature. Try it with:
 
 `html2rss auto https://unmatchedstyle.com/`
 

--- a/lib/html2rss.rb
+++ b/lib/html2rss.rb
@@ -106,10 +106,18 @@ module Html2rss
   # Scrapes the provided URL and returns an RSS object.
   # No need for a "feed config".
   #
-  # @param url [String] the URL to automatically source the feed from
   # @return [RSS::Rss]
   def self.auto_source(url)
-    Html2rss::AutoSource.new(url).build
+    unless url.is_a?(String) || url.is_a?(Addressable::URI)
+      raise ArgumentError,
+            'URL must be a String or Addressable::URI'
+    end
+
+    url = Addressable::URI.parse(url)
+
+    response = Html2rss::Utils.request_url(url)
+
+    Html2rss::AutoSource.new(url, body: response.body, headers: response.headers).build
   end
 
   private_class_method :load_yaml, :find_feed_config

--- a/lib/html2rss.rb
+++ b/lib/html2rss.rb
@@ -108,11 +108,6 @@ module Html2rss
   #
   # @return [RSS::Rss]
   def self.auto_source(url)
-    unless url.is_a?(String) || url.is_a?(Addressable::URI)
-      raise ArgumentError,
-            'URL must be a String or Addressable::URI'
-    end
-
     url = Addressable::URI.parse(url)
 
     response = Html2rss::Utils.request_url(url)

--- a/lib/html2rss.rb
+++ b/lib/html2rss.rb
@@ -43,7 +43,7 @@ module Html2rss
   # @param params [Hash] Dynamic parameters for the feed configuration.
   # @return [RSS::Rss] RSS object generated from the configuration.
   def self.feed_from_yaml_config(file, name = nil, global_config: {}, params: {})
-    yaml = load_yaml(file)
+    yaml = YAML.safe_load_file(file, symbolize_names: true)
     feeds = yaml[CONFIG_KEY_FEEDS] || {}
 
     feed_config = find_feed_config(yaml, feeds, name, global_config)
@@ -74,15 +74,6 @@ module Html2rss
   end
 
   ##
-  # Loads and parses the YAML file.
-  #
-  # @param file [String] Path to the YAML file.
-  # @return [Hash] Parsed YAML content.
-  def self.load_yaml(file)
-    YAML.safe_load_file(file, symbolize_names: true)
-  end
-
-  ##
   # Builds the feed configuration based on the provided parameters.
   #
   # @param yaml [Hash] Parsed YAML content.
@@ -106,6 +97,7 @@ module Html2rss
   # Scrapes the provided URL and returns an RSS object.
   # No need for a "feed config".
   #
+  # @param url [String] the URL to automatically source the feed from
   # @return [RSS::Rss]
   def self.auto_source(url)
     url = Addressable::URI.parse(url)
@@ -115,5 +107,5 @@ module Html2rss
     Html2rss::AutoSource.new(url, body: response.body, headers: response.headers).build
   end
 
-  private_class_method :load_yaml, :find_feed_config
+  private_class_method :find_feed_config
 end

--- a/lib/html2rss/auto_source.rb
+++ b/lib/html2rss/auto_source.rb
@@ -71,7 +71,11 @@ module Html2rss
     # Parses the HTML body of the response using Nokogiri.
     # @return [Nokogiri::HTML::Document]
     def parsed_body
-      @parsed_body ||= Nokogiri.HTML(response.body).freeze
+      @parsed_body ||= Nokogiri.HTML(response.body)
+                               .tap do |doc|
+        # Remove comments from the document
+        doc.xpath('//comment()').each(&:remove)
+      end.freeze
     end
   end
 end

--- a/lib/html2rss/auto_source.rb
+++ b/lib/html2rss/auto_source.rb
@@ -36,6 +36,8 @@ module Html2rss
       Reducer.call(articles, url:)
       Cleanup.call(articles, url:, keep_different_domain: true)
 
+      channel.articles = articles
+
       Html2rss::AutoSource::RssBuilder.new(
         channel:,
         articles:
@@ -59,7 +61,7 @@ module Html2rss
     end
 
     def channel
-      Channel.new(parsed_body, headers: @headers, url:, articles:)
+      @channel ||= Channel.new(parsed_body, headers: @headers, url:)
     end
 
     private

--- a/lib/html2rss/auto_source.rb
+++ b/lib/html2rss/auto_source.rb
@@ -16,7 +16,11 @@ module Html2rss
 
     SUPPORTED_URL_SCHEMES = %w[http https].to_set.freeze
 
-    def initialize(url)
+    def self.build_from_response(response, url)
+      new(url, response:).build
+    end
+
+    def initialize(url, response: nil)
       unless url.is_a?(String) || url.is_a?(Addressable::URI)
         raise ArgumentError,
               'URL must be a String or Addressable::URI'
@@ -26,6 +30,8 @@ module Html2rss
 
       raise ArgumentError, 'URL must be absolute' unless @url.absolute?
       raise UnsupportedUrlScheme, "#{@url.scheme} not supported" unless SUPPORTED_URL_SCHEMES.include?(@url.scheme)
+
+      @response = response if response
     end
 
     def build

--- a/lib/html2rss/auto_source/channel.rb
+++ b/lib/html2rss/auto_source/channel.rb
@@ -13,12 +13,16 @@ module Html2rss
       # @param url [Addressable::URI] The URL of the channel.
       # @param headers [Hash<String, String>] the http headers
       # @param articles [Array<Html2rss::AutoSource::Article>] The articles.
-      def initialize(parsed_body, url:, headers:, articles: [])
+      def initialize(parsed_body, url:, headers:, articles: [], stylesheets: [])
         @parsed_body = parsed_body
         @url = url
         @headers = headers
         @articles = articles
+        @stylesheets = stylesheets
       end
+
+      attr_writer :articles
+      attr_reader :stylesheets
 
       def url = extract_url
       def title = extract_title

--- a/lib/html2rss/auto_source/rss_builder.rb
+++ b/lib/html2rss/auto_source/rss_builder.rb
@@ -31,6 +31,8 @@ module Html2rss
 
       def call
         RSS::Maker.make('2.0') do |maker|
+          Html2rss::RssBuilder::Stylesheet.add(maker, channel.stylesheets)
+
           make_channel(maker.channel)
           make_items(maker)
         end

--- a/lib/html2rss/auto_source/scraper/schema.rb
+++ b/lib/html2rss/auto_source/scraper/schema.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require 'json'
+require 'nokogiri'
+require 'set'
+
 module Html2rss
   class AutoSource
     module Scraper
@@ -99,6 +103,8 @@ module Html2rss
         # @yield [Hash] Each scraped article_hash
         # @return [Array<Hash>] the scraped article_hashes
         def each(&)
+          return enum_for(:each) unless block_given?
+
           schema_objects.filter_map do |schema_object|
             next unless (klass = self.class.scraper_for_schema_object(schema_object))
             next unless (article_hash = klass.new(schema_object, url:).call)

--- a/lib/html2rss/auto_source/scraper/semantic_html/extractor.rb
+++ b/lib/html2rss/auto_source/scraper/semantic_html/extractor.rb
@@ -74,7 +74,7 @@ module Html2rss
           def find_heading
             heading_tags = article_tag.css(HEADING_TAGS.join(',')).group_by(&:name)
             smallest_heading = heading_tags.keys.min
-            heading_tags[smallest_heading]&.max_by { |tag| tag.text.size }
+            heading_tags[smallest_heading]&.max_by { |tag| visible_text_from_tag(tag)&.size }
           end
 
           def extract_title

--- a/lib/html2rss/config.rb
+++ b/lib/html2rss/config.rb
@@ -18,9 +18,6 @@ module Html2rss
     # Thrown when the feed config does not contain a value at `:channel`.
     class ChannelMissing < Html2rss::Error; end
 
-    # Struct to store XML Stylesheet attributes
-    Stylesheet = Struct.new(:href, :type, :media, keyword_init: true)
-
     def_delegator :@channel, :author
     def_delegator :@channel, :ttl
     def_delegator :@channel, :title
@@ -75,7 +72,7 @@ module Html2rss
     #
     # @return [Array<Stylesheet>] Array of Stylesheet structs.
     def stylesheets
-      @global.fetch(:stylesheets, []).map { |attributes| Stylesheet.new(attributes) }
+      @global.fetch(:stylesheets, []).map { |attributes| Html2rss::RssBuilder::Stylesheet.new(**attributes) }
     end
 
     # Provides read-only access to the channel object.

--- a/lib/html2rss/item.rb
+++ b/lib/html2rss/item.rb
@@ -19,7 +19,7 @@ module Html2rss
     ##
     # Fetches items from a given URL using configuration settings.
     #
-    # @param url [String] URL to fetch items from.
+    # @param url [Addressable::URI] URL to fetch items from.
     # @param config [Html2rss::Config] Configuration object.
     # @return [Array<Html2rss::Item>] list of items fetched.
     def self.from_url(url, config)

--- a/lib/html2rss/rss_builder/stylesheet.rb
+++ b/lib/html2rss/rss_builder/stylesheet.rb
@@ -3,35 +3,50 @@
 module Html2rss
   module RssBuilder
     ##
-    # Adds XML stylesheet tags (with the provided maker).
+    # Represents a stylesheet.
     class Stylesheet
-      ##
-      # Adds the stylesheet XML tags to the RSS.
-      #
-      # @param maker [RSS::Maker::RSS20] RSS maker object.
-      # @param stylesheets [Array<Html2rss::Config::Stylesheet>] Array of stylesheet configurations.
-      # @return [nil]
-      def self.add(maker, stylesheets)
-        stylesheets.each do |stylesheet|
-          add_stylesheet(maker, stylesheet)
+      class << self
+        ##
+        # Adds the stylesheet XML tags to the RSS.
+        #
+        # @param maker [RSS::Maker::RSS20] RSS maker object.
+        # @param stylesheets [Array<Html2rss::Config::Stylesheet>] Array of stylesheet configurations.
+        # @return [nil]
+        def add(maker, stylesheets)
+          stylesheets.each do |stylesheet|
+            add_stylesheet(maker, stylesheet)
+          end
+        end
+
+        private
+
+        ##
+        # Adds a single Stylesheet to the RSS.
+        #
+        # @param maker [RSS::Maker::RSS20] RSS maker object.
+        # @param stylesheet [Html2rss::Config::Stylesheet] Stylesheet configuration.
+        # @return [nil]
+        def add_stylesheet(maker, stylesheet)
+          maker.xml_stylesheets.new_xml_stylesheet do |xss|
+            xss.href = stylesheet.href
+            xss.type = stylesheet.type
+            xss.media = stylesheet.media
+          end
         end
       end
 
-      ##
-      # Adds a single Stylesheet to the RSS.
-      #
-      # @param maker [RSS::Maker::RSS20] RSS maker object.
-      # @param stylesheet [Html2rss::Config::Stylesheet] Stylesheet configuration.
-      # @return [nil]
-      def self.add_stylesheet(maker, stylesheet)
-        maker.xml_stylesheets.new_xml_stylesheet do |xss|
-          xss.href = stylesheet.href
-          xss.type = stylesheet.type
-          xss.media = stylesheet.media
-        end
-      end
+      TYPES = ['text/css', 'text/xsl'].freeze
 
-      private_class_method :add_stylesheet
+      def initialize(href:, type:, media: 'all')
+        raise ArgumentError, 'stylesheet.href must be a String' unless href.is_a?(String)
+        raise ArgumentError, 'stylesheet.type invalid' unless TYPES.include?(type)
+        raise ArgumentError, 'stylesheet.media must be a String' unless media.is_a?(String)
+
+        @href = href
+        @type = type
+        @media = media
+      end
+      attr_reader :href, :type, :media
     end
   end
 end

--- a/lib/html2rss/utils.rb
+++ b/lib/html2rss/utils.rb
@@ -44,6 +44,7 @@ module Html2rss
     #
     # @param time_zone [String]
     # @param default_time_zone [String]
+    # @yield block to execute with the given time zone
     # @return [Object] whatever the given block returns
     def self.use_zone(time_zone, default_time_zone: Time.now.getlocal.zone)
       raise ArgumentError, 'a block is required' unless block_given?
@@ -74,6 +75,11 @@ module Html2rss
     # @param headers [Hash] additional HTTP request headers to use for the request
     # @return [Faraday::Response] body of the HTTP response
     def self.request_url(url, headers: {})
+      url = Addressable::URI.parse(url.to_s) unless url.is_a?(Addressable::URI)
+
+      raise ArgumentError, 'URL must be absolute' unless url.absolute?
+      raise ArgumentError, 'URL must not contain an @ characater' if url.to_s.include?('@')
+
       Faraday.new(url:, headers:) do |faraday|
         faraday.use Faraday::FollowRedirects::Middleware
         faraday.adapter Faraday.default_adapter

--- a/spec/lib/html2rss/auto_source/channel_spec.rb
+++ b/spec/lib/html2rss/auto_source/channel_spec.rb
@@ -1,18 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.describe Html2rss::AutoSource::Channel do
-  subject(:instance) { described_class.new(parsed_body, url:, response:) }
+  subject(:instance) { described_class.new(parsed_body, url:, headers:, articles: []) }
 
   let(:parsed_body) { Nokogiri::HTML('') }
   let(:url) { Addressable::URI.parse('https://example.com') }
-  let(:response) do
-    instance_double(Faraday::Response,
-                    body: '',
-                    headers: {
-                      'content-type' => 'text/html',
-                      'cache-control' => 'max-age=120, private, must-revalidate',
-                      'last-modified' => 'Tue, 01 Jan 2019 00:00:00 GMT'
-                    })
+  let(:headers) do
+    {
+      'content-type' => 'text/html',
+      'cache-control' => 'max-age=120, private, must-revalidate',
+      'last-modified' => 'Tue, 01 Jan 2019 00:00:00 GMT'
+    }
   end
 
   describe '#title' do
@@ -101,11 +99,10 @@ RSpec.describe Html2rss::AutoSource::Channel do
     end
 
     context 'without a last-modified header' do
-      let(:response) do
-        instance_double(Faraday::Response,
-                        headers: {
-                          'cache-control' => 'max-age=120, private, must-revalidate'
-                        })
+      let(:headers) do
+        {
+          'cache-control' => 'max-age=120, private, must-revalidate'
+        }
       end
 
       it 'extracts nil' do

--- a/spec/lib/html2rss/auto_source/rss_builder_spec.rb
+++ b/spec/lib/html2rss/auto_source/rss_builder_spec.rb
@@ -30,15 +30,26 @@ RSpec.describe Html2rss::AutoSource::RssBuilder do
                     generator: "html2rss V. #{Html2rss::VERSION} (using auto_source scrapers: [RSpec=2])",
                     image: 'http://example.com/image.jpg',
                     ttl: 12,
-                    last_build_date: 'Tue, 01 Jan 2019 00:00:00 GMT')
+                    last_build_date: 'Tue, 01 Jan 2019 00:00:00 GMT',
+                    stylesheets: [
+                      Html2rss::RssBuilder::Stylesheet.new(href: 'rss.xsl', type: 'text/xsl')
+                    ])
   end
 
   describe '#call' do
     subject(:rss) { instance.call }
 
+    let(:rss_feed) do
+      <<~RSS.strip
+        <?xml version="1.0" encoding="UTF-8"?>
+        <?xml-stylesheet href="rss.xsl" type="text/xsl" media="all"?>
+        <rss version="2.0"\n
+      RSS
+    end
+
     it 'returns an RSS 2.0 Rss object', :aggregate_failures do
       expect(rss).to be_a(RSS::Rss)
-      expect(rss.to_s).to start_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<rss version=\"2.0\"")
+      expect(rss.to_s).to start_with(rss_feed)
     end
 
     context 'with <channel> tag' do

--- a/spec/lib/html2rss/auto_source/scraper/schema_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper/schema_spec.rb
@@ -140,6 +140,14 @@ RSpec.describe Html2rss::AutoSource::Scraper::Schema do
   describe '#each' do
     subject(:new) { described_class.new(parsed_body, url: '') }
 
+    let(:parsed_body) { Nokogiri::HTML('') }
+
+    context 'without a block' do
+      it 'returns an enumerator' do
+        expect(new.each).to be_a(Enumerator)
+      end
+    end
+
     context 'with a NewsArticle' do
       let(:parsed_body) do
         Nokogiri::HTML("<script type=\"application/ld+json\">#{news_article_schema_object.to_json}</script>")
@@ -167,8 +175,6 @@ RSpec.describe Html2rss::AutoSource::Scraper::Schema do
     end
 
     context 'with an empty body' do
-      let(:parsed_body) { Nokogiri::HTML('') }
-
       it 'returns an empty array' do
         expect { |b| new.each(&b) }.not_to yield_with_args
       end

--- a/spec/lib/html2rss/auto_source_spec.rb
+++ b/spec/lib/html2rss/auto_source_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Html2rss::AutoSource do
     instance_double(Faraday::Response, body: '<html>
       <body>
         <article id="article-1">
-          <h2>Article 1</h2>
+          <h2>Article 1 <!-- remove this --></h2>
           <a href="/article1">Read more</a>
         </article>
         </body>

--- a/spec/lib/html2rss/rss_builder/stylesheet_spec.rb
+++ b/spec/lib/html2rss/rss_builder/stylesheet_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+RSpec.describe Html2rss::RssBuilder::Stylesheet do
+  let(:rss_maker) { RSS::Maker::RSS20.new }
+  let(:stylesheet_config) do
+    described_class.new(
+      href: 'http://example.com/style.css',
+      type: 'text/css',
+      media: 'all'
+    )
+  end
+
+  describe '.add' do
+    it 'adds stylesheet XML tags to the RSS maker' do
+      expect do
+        described_class.add(rss_maker, [stylesheet_config])
+      end.to change { rss_maker.xml_stylesheets.size }.by(1)
+    end
+  end
+
+  describe '#initialize' do
+    context 'with valid parameters' do
+      it 'creates a Stylesheet object', :aggregate_failures do
+        stylesheet = described_class.new(href: 'http://example.com/style.css', type: 'text/css')
+
+        expect(stylesheet.href).to eq('http://example.com/style.css')
+        expect(stylesheet.type).to eq('text/css')
+        expect(stylesheet.media).to eq('all')
+      end
+    end
+
+    context 'with an invalid href' do
+      it 'raises an ArgumentError' do
+        expect do
+          described_class.new(href: 123, type: 'text/css')
+        end.to raise_error(ArgumentError, 'stylesheet.href must be a String')
+      end
+    end
+
+    context 'with an invalid type' do
+      it 'raises an ArgumentError' do
+        expect do
+          described_class.new(href: 'http://example.com/style.css', type: 'invalid/type')
+        end.to raise_error(ArgumentError, 'stylesheet.type invalid')
+      end
+    end
+
+    context 'with an invalid media' do
+      it 'raises an ArgumentError' do
+        expect do
+          described_class.new(href: 'http://example.com/style.css', type: 'text/css', media: 123)
+        end.to raise_error(ArgumentError, 'stylesheet.media must be a String')
+      end
+    end
+  end
+end

--- a/spec/lib/html2rss/utils_spec.rb
+++ b/spec/lib/html2rss/utils_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Html2rss::Utils do
   end
 
   describe '.request_url(url, headers: {})' do
-    let(:url) { 'http://example.com' }
+    let(:url) { Addressable::URI.parse 'http://example.com' }
     let(:options) { { headers: {} } }
     let(:response) { instance_double(Faraday::Response, body: '') }
     let(:connection) { instance_double(Faraday::Connection, get: response) }
@@ -62,6 +62,17 @@ RSpec.describe Html2rss::Utils do
       allow(Faraday).to receive(:new).with(options.merge(url:)).and_return(connection)
 
       expect(described_class.request_url(url, **options)).to eq(response)
+    end
+
+    context 'with url contains userinfo' do
+      ['https://user:pass@example.com',
+       'https://example.com/foo?:/@https://www.youtube.com/watch?v=dQw4w9WgXcQ'].each do |url|
+        it do
+          expect do
+            described_class.request_url(Addressable::URI.parse(url), **options)
+          end.to raise_error(ArgumentError, /URL must not contain an @ characater/)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and reliability of the `html2rss` gem. The changes primarily focus on integrating the `auto_source` feature into [html2rss-web](https://github.com/html2rss/html2rss-web/pull/676), refining error handling, and improving the internal structure of the code.

### Enhancements to Automatic RSS Generation:

* Updated `README.md` to clarify that `html2rss` offers automatic RSS generation and updated related sections to reflect this feature. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L29-R31)
* Modified `Html2rss::AutoSource` to accept response body and headers directly, improving flexibility and reliability in automatic RSS generation. (`lib/html2rss.rb` [[1]](diffhunk://#diff-a68158a97e9182c3004a10cfbb397e4d090470ffda51b962769351f5ad6f3eb9L112-R110) `lib/html2rss/auto_source.rb` [[2]](diffhunk://#diff-58f175b10b42f06d3fffce32fccf4f66f0b044fbb69e46ed8c8d1756b0d056c0L19-R30) [[3]](diffhunk://#diff-58f175b10b42f06d3fffce32fccf4f66f0b044fbb69e46ed8c8d1756b0d056c0R39-R40) [[4]](diffhunk://#diff-58f175b10b42f06d3fffce32fccf4f66f0b044fbb69e46ed8c8d1756b0d056c0L60-R77)

### Codebase Simplification and Error Handling:

* Removed the `load_yaml` method and directly used `YAML.safe_load_file` for loading YAML configurations, simplifying the code. (`lib/html2rss.rb` [[1]](diffhunk://#diff-a68158a97e9182c3004a10cfbb397e4d090470ffda51b962769351f5ad6f3eb9L46-R46) [[2]](diffhunk://#diff-a68158a97e9182c3004a10cfbb397e4d090470ffda51b962769351f5ad6f3eb9L76-L84)
* Enhanced error handling in `Html2rss::AutoSource` by validating URL types and ensuring URLs are absolute. (`lib/html2rss/auto_source.rb` [[1]](diffhunk://#diff-58f175b10b42f06d3fffce32fccf4f66f0b044fbb69e46ed8c8d1756b0d056c0L19-R30) `lib/html2rss/utils.rb` [[2]](diffhunk://#diff-5ffb9be3485cbc17fae0be88570644bf3816d76012ca98af2d22dd5cc10d3aefR78-R82)

### Internal Structure Improvements:

* Refactored `Html2rss::AutoSource::Channel` to use headers instead of response objects, ensuring a cleaner separation of concerns. (`lib/html2rss/auto_source/channel.rb` [[1]](diffhunk://#diff-cdf9c1331e1c0cb980f2306f643330d872b4c8f438638e41cdf616cdb37ec3d9L13-R41) [[2]](diffhunk://#diff-cdf9c1331e1c0cb980f2306f643330d872b4c8f438638e41cdf616cdb37ec3d9L61-R67)
* Introduced a new `Html2rss::RssBuilder::Stylesheet` class to handle XML stylesheet tags, improving code organization. (`lib/html2rss/rss_builder/stylesheet.rb` [[1]](diffhunk://#diff-ec4860a6a8404f49b93486ccc75ce6dd0913eb48759c54b380a02a4dfb1a857bL6-R49) [[2]](diffhunk://#diff-ca55607f8388edb9b462b3f5a5318ca8b8c02c14f27d44f803c1014e129e5a86L78-R75)

### Testing and Documentation:

* Updated tests to reflect changes in the `Html2rss::AutoSource::Channel` and added tests for new functionality. (`spec/lib/html2rss/auto_source/channel_spec.rb` [[1]](diffhunk://#diff-cdeb20770f7d130b1c91ffcbb93b28569296cc5c5586fd7f906da8775b28f9a7L4-R13) [[2]](diffhunk://#diff-cdeb20770f7d130b1c91ffcbb93b28569296cc5c5586fd7f906da8775b28f9a7L104-R105) `spec/lib/html2rss/auto_source/rss_builder_spec.rb` [[3]](diffhunk://#diff-64e2c4c9557ce15ff10241217b91f35bc0466083ec8d3e231d47e4a1d1399b78L33-R52)
* Improved documentation by adding missing require statements and enhancing comments for better clarity. (`lib/html2rss/auto_source/scraper/schema.rb` [[1]](diffhunk://#diff-149d8476a8955406351c75b97e9d26f59778c0f4eba9640b0e249801a3239c66R3-R6) [[2]](diffhunk://#diff-149d8476a8955406351c75b97e9d26f59778c0f4eba9640b0e249801a3239c66R106-R107) `lib/html2rss/utils.rb` [[3]](diffhunk://#diff-5ffb9be3485cbc17fae0be88570644bf3816d76012ca98af2d22dd5cc10d3aefR47)

These changes collectively enhance the functionality, reliability, and maintainability of the `html2rss` gem.