### PR TITLE
fix(auto_source): handle commas in image srcset URLs

### DIFF
--- a/lib/html2rss/auto_source/scraper/semantic_html/image.rb
+++ b/lib/html2rss/auto_source/scraper/semantic_html/image.rb
@@ -28,14 +28,14 @@ module Html2rss
           # @see <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture>
           def self.from_source(article_tag) # rubocop:disable Metrics/AbcSize
             hash = article_tag.css('img[srcset], picture > source[srcset]')
-                              .flat_map { |source| source['srcset'].to_s.split(',') }
-                              .filter_map do |line|
-              width, url = line.split.reverse
-              next if url.nil? || url.start_with?('data:')
+                              .flat_map do |source|
+              source['srcset'].to_s.scan(/(\S+)\s+(\d+w|\d+h)/).map do |url, width|
+                next if url.nil? || url.start_with?('data:')
 
-              width_value = width.to_i.zero? ? 0 : width.scan(/\d+/).first.to_i
+                width_value = width.to_i.zero? ? 0 : width.scan(/\d+/).first.to_i
 
-              [width_value, url.strip]
+                [width_value, url.strip]
+              end
             end.to_h
 
             hash[hash.keys.max]

--- a/spec/lib/html2rss/auto_source/scraper/semantic_html/image_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper/semantic_html/image_spec.rb
@@ -21,6 +21,20 @@ RSpec.describe Html2rss::AutoSource::Scraper::SemanticHtml::Image do
       end
     end
 
+    context 'when image source is present and image url contains commas' do
+      let(:html) do
+        <<~HTML
+          <article>
+            <img srcset="image,with,commas.jpg 256w, another,image,with,commas.jpg 1w" alt="Image with commas" />
+          </article>
+        HTML
+      end
+
+      it 'returns the absolute URL of the image source' do
+        expect(url).to eq('https://example.com/image,with,commas.jpg')
+      end
+    end
+
     context 'when image source is present in sourceset attribute' do
       let(:html) do
         <<~HTML


### PR DESCRIPTION
Updated the image scraper to correctly parse and handle image URLs containing commas in the srcset attribute. Added test case to ensure functionality with such URLs.