### PR TITLE
fix(auto_source): do not extract when article_tag is not found

### DIFF
--- a/lib/html2rss/auto_source/scraper/html.rb
+++ b/lib/html2rss/auto_source/scraper/html.rb
@@ -49,9 +49,10 @@ module Html2rss
           frequent_selectors.each do |selector|
             parsed_body.xpath(selector).each do |selected_tag|
               article_tag = self.class.parent_until_condition(selected_tag, method(:article_condition))
-              article_hash = SemanticHtml::Extractor.new(article_tag, url: @url).call
 
-              yield article_hash if article_hash
+              if article_tag && (article_hash = SemanticHtml::Extractor.new(article_tag, url: @url).call)
+                yield article_hash
+              end
             end
           end
         end

--- a/lib/html2rss/auto_source/scraper/semantic_html.rb
+++ b/lib/html2rss/auto_source/scraper/semantic_html.rb
@@ -106,9 +106,10 @@ module Html2rss
           SemanticHtml.anchor_tag_selector_pairs.each do |tag_name, selector|
             parsed_body.css(selector).each do |selected_tag|
               article_tag = SemanticHtml.find_tag_in_ancestors(selected_tag, tag_name)
-              article_hash = Extractor.new(article_tag, url: @url).call
 
-              yield article_hash if article_hash
+              if article_tag && (article_hash = Extractor.new(article_tag, url: @url).call)
+                yield article_hash
+              end
             end
           end
         end

--- a/lib/html2rss/auto_source/scraper/semantic_html/extractor.rb
+++ b/lib/html2rss/auto_source/scraper/semantic_html/extractor.rb
@@ -31,6 +31,8 @@ module Html2rss
           end
 
           def initialize(article_tag, url:)
+            raise ArgumentError, 'article_tag is required' unless article_tag
+
             @article_tag = article_tag
             @url = url
           end


### PR DESCRIPTION
Updated the HTML and semantic HTML scrapers to ensure article tags are not nil before processing. Added a guard clause in the Extractor initialization to raise an error if `article_tag` is missing, improving robustness against invalid input.

(cherry picked from commit 20ca4ed0b048b5d7563bc452e1bc7a422bdeab03)