### PR TITLE
feat!(selectors): remove deprecated template `method` support

### DIFF
--- a/spec/fixtures/feeds.test.yml
+++ b/spec/fixtures/feeds.test.yml
@@ -22,7 +22,7 @@ feeds:
         selector: '.release-header .text-normal a'
         post_process:
           - name: 'template'
-            string: '%{self} (%{author})'
+            string: '%<self>s (%<author>s)'
       author:
         selector: '.avatar'
         extractor: 'attribute'

--- a/spec/fixtures/single.test.yml
+++ b/spec/fixtures/single.test.yml
@@ -11,7 +11,7 @@ selectors:
     selector: ".release-header .text-normal a"
     post_process:
       - name: "template"
-        string: "%{self} (%{author})"
+        string: "%<self>s (%<author>)"
   author:
     selector: ".avatar"
     extractor: "attribute"

--- a/spec/lib/html2rss/selectors/post_processors/template_spec.rb
+++ b/spec/lib/html2rss/selectors/post_processors/template_spec.rb
@@ -22,13 +22,7 @@ RSpec.describe Html2rss::Selectors::PostProcessors::Template do
     end
   end
 
-  context 'with methods present (simple formatting)' do
-    let(:options) { { string: '%s! %s is %s! %s', methods: %i[self name author returns_nil] } }
-
-    it { is_expected.to eq 'Hi! My name is Slim Shady! ' }
-  end
-
-  context 'with methods absent (complex formatting)' do
+  context 'with mixed complex formatting notation' do
     let(:options) { { string: '%{self}! %<name>s is %{author}! %{returns_nil}' } } # rubocop:disable Style/FormatStringToken
 
     it { is_expected.to eq 'Hi! My name is Slim Shady! ' }


### PR DESCRIPTION
**BREAKING CHANGES**:

- removes support of providing methods in `selectors` `post_processor` `template`.
