### PR TITLE
feat!(selectors): allow automatic item enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,8 @@ channel:
 selectors:
   items:
     selector: "article[id^='post-']"
-  title:
-    selector: h2
-  url:
-    selector: a
-    extractor: href
-  description:
-    selector: ".post-content"
-auto_source: {} # this enables auto_source additionally. Remove if you don't want that.
+    enhance: true
+# auto_source: {} # Enables auto_source additionally when uncommented
 ```
 
 Build the feed from this config with: `html2rss feed ./my_config_file.yml`.
@@ -84,7 +78,7 @@ Alright, let's dive in.
 | `language`    | optional     | String  | auto-generated | Determined by `lang` attribute                     |
 | `time_zone`   | optional     | String  | `'UTC'`        | TimeZone name                                      |
 
-### The `auto_source`: automatically find the items
+### The scraper `auto_source`: automatically find the items
 
 The `auto_source` scraper finds items automatically. To find them its scrapers search for:
 
@@ -112,13 +106,14 @@ auto_source:
     keep_different_domain: false # default: true
 ```
 
-### The `selectors`: specify CSS selectors
+### The scraper `selectors`: more control
 
-The `selectors` scraper requires you to specify CSS selectors.
+> [!INFO]
+> To build a [valid RSS 2.0 item](http://www.rssboard.org/rss-profile#element-channel-item), you need at least a `title` **or** a `description` in your item. You can, of course, have both.
+
+The `selectors` scraper allows you to specify CSS selectors and by this giving you full control of extraction.
 
 You must give an **`items`** selector hash, which contains the CSS selector. The items selector selects a collection of HTML tags from which the RSS feed items are built. Except for the `items` selector, all other keys are scoped to each item of the collection.
-
-To build a [valid RSS 2.0 item](http://www.rssboard.org/rss-profile#element-channel-item), you need at least a `title` **or** a `description` in your item. You can, of course, have both.
 
 **Having an `items` and a `title` selector is enough** to build a simple feed:
 
@@ -131,6 +126,23 @@ selectors:
   title:
     selector: "h1"
 ```
+
+#### Automatically enhance items
+
+Specifying the `title`, `url` or `image` selector in every config quickly becomes cumbersome.
+html2rss enhances every item automatically.
+However, if you specify a selector, its value will be used.
+
+```yml
+channel:
+  url: "https://example.com"
+selectors:
+  items:
+    selector: ".article"
+    enhance: true # default: true
+```
+
+#### Selectors which will be included in the the RSS feed
 
 Your `selectors` hash can contain arbitrary named selectors, but only a few will make it into the RSS feed (due to the RSS 2.0 specification):
 

--- a/lib/html2rss.rb
+++ b/lib/html2rss.rb
@@ -83,12 +83,17 @@ module Html2rss
   #
   # @param url [String] the URL to automatically source the feed from
   # @param strategy [Symbol] the request strategy to use
+  # @param items_selector [String] CSS selector for items (will be enhanced) (optional)
   # @return [RSS::Rss]
-  def self.auto_source(url, strategy: :faraday)
-    Html2rss.feed(
+  def self.auto_source(url, strategy: :faraday, items_selector: nil)
+    config = {
       strategy:,
       channel: { url: url },
       auto_source: {}
-    )
+    }
+
+    config[:selectors] = { items: { selector: items_selector, enhance: true } } if items_selector
+
+    feed(config)
   end
 end

--- a/lib/html2rss/cli.rb
+++ b/lib/html2rss/cli.rb
@@ -40,9 +40,11 @@ module Html2rss
                   desc: 'The strategy to request the URL',
                   enum: RequestService.strategy_names,
                   default: RequestService.default_strategy_name
+    method_option :items_selector, type: :string, desc: 'CSS selector for items (will be enhanced) (optional)'
     def auto(url)
       strategy = options.fetch(:strategy) { RequestService.default_strategy_name }.to_sym
-      puts Html2rss.auto_source(url, strategy:)
+
+      puts Html2rss.auto_source(url, strategy:, items_selector: options[:items_selector])
     end
   end
 end

--- a/lib/html2rss/config.rb
+++ b/lib/html2rss/config.rb
@@ -62,6 +62,7 @@ module Html2rss
     def initialize(config)
       config = handle_deprecated_channel_attributes(config)
       config = apply_default_config(config)
+      config = apply_default_selectors_config(config) if config[:selectors]
       config = apply_default_auto_source_config(config) if config[:auto_source]
 
       validator = Validator.new.call(config)
@@ -102,6 +103,10 @@ module Html2rss
 
     def apply_default_config(config)
       deep_merge(self.class.default_config, config)
+    end
+
+    def apply_default_selectors_config(config)
+      deep_merge({ selectors: Selectors::DEFAULT_CONFIG }, config)
     end
 
     def apply_default_auto_source_config(config)

--- a/lib/html2rss/selectors/config.rb
+++ b/lib/html2rss/selectors/config.rb
@@ -15,6 +15,7 @@ module Html2rss
         params do
           required(:selector).filled(:string)
           optional(:order).filled(included_in?: %w[reverse])
+          optional(:enhance).filled(:bool?)
         end
       end
 

--- a/spec/lib/html2rss_spec.rb
+++ b/spec/lib/html2rss_spec.rb
@@ -235,5 +235,20 @@ RSpec.describe Html2rss do
       expect(feed_return.channel.link).to eq 'https://www.welt.de/'
       expect(feed_return.items.size >= 29).to be true
     end
+
+    context 'with items_selector' do
+      before do
+        allow(described_class).to receive(:feed).and_return(nil)
+      end
+
+      let(:items_selector) { '.css.selector' }
+
+      it 'adds selectors.items selector and enhance to config' do
+        described_class.auto_source(url, items_selector:)
+        expect(described_class).to have_received(:feed).with(
+          hash_including(selectors: { items: { selector: items_selector, enhance: true } })
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
**BREAKING CHANGE**: enhancement is enabled by default

Added an `enhance` option to the selectors configuration, allowing automatic enhancement of article items. This improves usability by reducing the need for repetitive selector definitions while ensuring existing values are preserved. The enhancement employs semantic HTML extraction from the auto_source.

Closes #206.