### PR TITLE
fix(parse_uri): update config structure to use channel for URL

### DIFF
--- a/lib/html2rss/selectors/post_processors/parse_uri.rb
+++ b/lib/html2rss/selectors/post_processors/parse_uri.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'addressable'
+
 module Html2rss
   class Selectors
     module PostProcessors
@@ -27,7 +29,7 @@ module Html2rss
           url_types = [String, URI::HTTP, Addressable::URI].freeze
 
           assert_type(value, url_types, :value, context:)
-          assert_type(context.dig(:config, :url), url_types, :url, context:)
+          assert_type(context.dig(:config, :channel, :url), url_types, :url, context:)
 
           raise ArgumentError, 'The `value` option is missing or empty.' if value.to_s.empty?
         end
@@ -35,7 +37,7 @@ module Html2rss
         ##
         # @return [String]
         def get
-          config_url = context.dig(:config, :url)
+          config_url = context.dig(:config, :channel, :url)
 
           Html2rss::Utils.build_absolute_url_from_relative(value, config_url).to_s
         end

--- a/spec/lib/html2rss/selectors/post_processors/parse_uri_spec.rb
+++ b/spec/lib/html2rss/selectors/post_processors/parse_uri_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Html2rss::Selectors::PostProcessors::ParseUri do
 
   let(:context) do
     Html2rss::Selectors::Context.new(
-      config: { url: 'http://example.com' }
+      config: { channel: { url: 'http://example.com' } }
     )
   end
 

--- a/spec/lib/html2rss/selectors/post_processors_spec.rb
+++ b/spec/lib/html2rss/selectors/post_processors_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Html2rss::Selectors::PostProcessors do
 
     context 'with known post processor name' do
       it do
-        expect(described_class.get('parse_uri', 'http://example.com/', { config: { url: '' } })).to be_a(String)
+        expect(described_class.get('parse_uri', 'http://example.com/',
+                                   { config: { channel: { url: '' } } })).to be_a(String)
       end
     end
   end


### PR DESCRIPTION
Refactor the configuration structure in ParseUri to access the URL through the `channel` key instead of directly from `config`. This change aligns with recent updates to the configuration schema and ensures consistency across the codebase. All relevant tests have been updated accordingly to reflect this new structure.