### PR TITLE
fix(config): support frozen hashes

### DIFF
--- a/lib/html2rss/config.rb
+++ b/lib/html2rss/config.rb
@@ -43,6 +43,8 @@ module Html2rss
       # @param params [Hash<Symbol, Object>] the dynamic parameters.
       # @return [Html2rss::Config] the configuration object.
       def from_hash(config, params: nil)
+        config = config.dup
+
         if params
           DynamicParams.call(config[:headers], params)
           DynamicParams.call(config[:channel], params)
@@ -61,7 +63,9 @@ module Html2rss
       end
     end
 
-    def initialize(config)
+    def initialize(config) # rubocop:disable Metrics/AbcSize
+      config = config.dup if config.frozen?
+
       config = handle_deprecated_channel_attributes(config)
       config = apply_default_config(config)
       config = apply_default_selectors_config(config) if config[:selectors]
@@ -71,7 +75,7 @@ module Html2rss
 
       raise InvalidConfig, "Invalid configuration: #{validator.errors.to_h}" unless validator.success?
 
-      @config = validator.to_h
+      @config = validator.to_h.freeze
     end
 
     def strategy = config[:strategy]

--- a/spec/lib/html2rss/config_spec.rb
+++ b/spec/lib/html2rss/config_spec.rb
@@ -91,6 +91,12 @@ RSpec.describe Html2rss::Config do
     it 'returns the configuration' do
       expect(described_class.from_hash(hash)).to be_a(described_class)
     end
+
+    context 'with frozen hash' do
+      it 'returns the configuration' do
+        expect(described_class.from_hash(hash.freeze)).to be_a(described_class)
+      end
+    end
   end
 
   describe '#initialize' do
@@ -123,6 +129,10 @@ RSpec.describe Html2rss::Config do
 
       it 'deep merges with the default configuration' do
         expect(instance.url).to eq('http://example.com')
+      end
+
+      it 'freezes @config ivar' do
+        expect(instance.instance_variable_get(:@config)).to be_frozen
       end
     end
 


### PR DESCRIPTION
This commit modifies the initialization of the Html2rss::Config class to duplicate the configuration hash if it is frozen. This prevents modification errors when attempting to alter a frozen object. Additionally, the @config instance variable is explicitly frozen after validation to enhance immutability, ensuring that configuration remains consistent throughout its lifecycle. Corresponding tests have been added to verify these changes.