### PR TITLE
feat(auto_source): add RSS feed detection

### DIFF
--- a/lib/html2rss/auto_source.rb
+++ b/lib/html2rss/auto_source.rb
@@ -29,6 +29,9 @@ module Html2rss
           enabled: true,
           minimum_selector_frequency: Scraper::Html::DEFAULT_MINIMUM_SELECTOR_FREQUENCY,
           use_top_selectors: Scraper::Html::DEFAULT_USE_TOP_SELECTORS
+        },
+        rss_feed_detector: {
+          enabled: true
         }
       },
       cleanup: Cleanup::DEFAULT_CONFIG
@@ -46,6 +49,9 @@ module Html2rss
           optional(:enabled).filled(:bool)
           optional(:minimum_selector_frequency).filled(:integer, gt?: 0)
           optional(:use_top_selectors).filled(:integer, gt?: 0)
+        end
+        optional(:rss_feed_detector).hash do
+          optional(:enabled).filled(:bool)
         end
       end
 

--- a/lib/html2rss/auto_source/scraper.rb
+++ b/lib/html2rss/auto_source/scraper.rb
@@ -12,7 +12,8 @@ module Html2rss
       SCRAPERS = [
         Html,
         Schema,
-        SemanticHtml
+        SemanticHtml,
+        RssFeedDetector
       ].freeze
 
       ##

--- a/lib/html2rss/auto_source/scraper/rss_feed_detector.rb
+++ b/lib/html2rss/auto_source/scraper/rss_feed_detector.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+module Html2rss
+  class AutoSource
+    module Scraper
+      ##
+      # Detects RSS, Atom, and JSON feeds in HTML link tags and creates articles for them.
+      # This scraper is used as a fallback when no other scrapers can find articles.
+      #
+      # Features:
+      # - Detects RSS, Atom, and JSON feeds via <link rel="alternate"> tags
+      # - Creates helpful articles with clickable links to discovered feeds
+      # - Uses monthly rotating GUIDs to keep articles visible in feed readers
+      # - Includes security measures to prevent XSS attacks
+      # - Optimized for performance with cached operations
+      #
+      # @example HTML that will be detected
+      #   <link rel="alternate" type="application/rss+xml" href="/feed.xml" title="RSS Feed">
+      #   <link rel="alternate" type="application/atom+xml" href="/atom.xml" title="Atom Feed">
+      #   <link rel="alternate" type="application/json" href="/feed.json" title="JSON Feed">
+      class RssFeedDetector
+        include Enumerable
+
+        # CSS selector for detecting feed link tags
+        FEED_LINK_SELECTOR = 'link[rel="alternate"][type*="application/"]'
+
+        # Default categories for all feed articles
+        DEFAULT_CATEGORIES = %w[feed auto-detected].freeze
+
+        # Feed type detection patterns
+        FEED_TYPE_PATTERNS = {
+          json: /\.json$/,
+          atom: /atom/,
+          rss: // # default fallback
+        }.freeze
+
+        def self.options_key = :rss_feed_detector
+
+        ##
+        # Check if the parsed_body contains RSS feed link tags.
+        # This scraper should only be used as a fallback when other scrapers fail.
+        # @param parsed_body [Nokogiri::HTML::Document] The parsed HTML document
+        # @return [Boolean] True if RSS feeds are found, otherwise false.
+        def self.articles?(parsed_body)
+          return false unless parsed_body
+
+          parsed_body.css(FEED_LINK_SELECTOR).any?
+        end
+
+        # @param parsed_body [Nokogiri::HTML::Document] The parsed HTML document.
+        # @param url [String, Html2rss::Url] The base URL.
+        # @param opts [Hash] Additional options (unused but kept for consistency).
+        def initialize(parsed_body, url:, **opts)
+          @parsed_body = parsed_body
+          @url = url.is_a?(Html2rss::Url) ? url : Html2rss::Url.from_relative(url.to_s, url.to_s)
+          @opts = opts
+        end
+
+        attr_reader :parsed_body
+
+        ##
+        # Yields article hashes for each discovered RSS feed.
+        # @yieldparam [Hash] The RSS feed article hash.
+        # @return [Enumerator] Enumerator for the discovered RSS feeds.
+        def each
+          return enum_for(:each) unless block_given?
+
+          @timestamp = Time.now
+          @current_month = @timestamp.strftime('%Y-%m')
+          @site_name = extract_site_name
+
+          @parsed_body.css(FEED_LINK_SELECTOR).each do |link|
+            feed_url = link['href']
+            next if feed_url.nil? || feed_url.empty?
+
+            article_hash = create_article_hash(link, feed_url)
+            yield article_hash if article_hash
+          end
+        end
+
+        private
+
+        def create_article_hash(link, feed_url)
+          absolute_url = Html2rss::Url.from_relative(feed_url, @url)
+          feed_title = link['title']&.strip
+          feed_type = detect_feed_type(feed_url)
+
+          build_article_hash(absolute_url, feed_title, feed_type)
+        rescue StandardError => error
+          Log.warn "RssFeedDetector: Failed to create article for feed URL '#{feed_url}': #{error.message}"
+          nil
+        end
+
+        def build_article_hash(absolute_url, feed_title, feed_type)
+          {
+            title: feed_title || "Subscribe to #{feed_type} Feed",
+            url: absolute_url,
+            description: create_description(absolute_url, feed_type, feed_title),
+            id: generate_monthly_id(absolute_url),
+            published_at: @timestamp,
+            categories: create_categories(feed_type),
+            author: @site_name,
+            scraper: self.class
+          }
+        end
+
+        def generate_monthly_id(absolute_url)
+          # Generate a GUID that changes monthly to ensure articles appear as "unread"
+          # This makes the gem a good internet citizen by periodically reminding users
+          # about available RSS feeds
+          "rss-feed-#{absolute_url.hash.abs}-#{@current_month}"
+        end
+
+        def detect_feed_type(feed_url)
+          url_lower = feed_url.downcase
+
+          case url_lower
+          when FEED_TYPE_PATTERNS[:json] then 'JSON Feed'
+          when FEED_TYPE_PATTERNS[:atom] then 'Atom'
+          else 'RSS'
+          end
+        end
+
+        def create_description(absolute_url, feed_type, feed_title)
+          safe_url = absolute_url.to_s
+
+          html_content = if feed_title
+                           "This website has a #{feed_type} feed available: <a href=\"#{safe_url}\">#{feed_title}</a>"
+                         else
+                           "This website has a #{feed_type} feed available at <a href=\"#{safe_url}\">#{safe_url}</a>"
+                         end
+
+          # Sanitize HTML to allow safe HTML while preventing XSS
+          sanitize_html(html_content)
+        end
+
+        def sanitize_html(html_content)
+          # Use the same sanitization as the rest of the project
+          context = { config: { channel: { url: @url } } }
+          Html2rss::Selectors::PostProcessors::SanitizeHtml.new(html_content, context).get
+        end
+
+        def create_categories(feed_type)
+          categories = DEFAULT_CATEGORIES.dup
+          categories << feed_type.downcase.tr(' ', '-')
+          categories
+        end
+
+        def extract_site_name
+          # Try to extract site name from the HTML title first
+          title = @parsed_body.at_css('title')&.text&.strip
+          return title if title && !title.empty?
+
+          # Fallback to URL using Html2rss::Url#channel_titleized
+          @url.channel_titleized
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/html2rss/auto_source/scraper/rss_feed_detector_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper/rss_feed_detector_spec.rb
@@ -1,0 +1,269 @@
+# frozen_string_literal: true
+
+RSpec.describe Html2rss::AutoSource::Scraper::RssFeedDetector do
+  subject(:instance) { described_class.new(parsed_body, url:) }
+
+  let(:url) { 'https://example.com' }
+  let(:parsed_body) { Nokogiri::HTML(html) }
+
+  describe '.articles?' do
+    context 'when RSS feed links are present' do
+      let(:html) do
+        <<~HTML
+          <html>
+            <head>
+              <link rel="alternate" type="application/rss+xml" href="/feed.xml" title="RSS Feed">
+            </head>
+            <body></body>
+          </html>
+        HTML
+      end
+
+      it 'returns true' do
+        expect(described_class.articles?(parsed_body)).to be true
+      end
+    end
+
+    context 'when no RSS feed links are present' do
+      let(:html) do
+        <<~HTML
+          <html>
+            <head>
+              <link rel="stylesheet" href="/style.css">
+            </head>
+            <body></body>
+          </html>
+        HTML
+      end
+
+      it 'returns false' do
+        expect(described_class.articles?(parsed_body)).to be false
+      end
+    end
+
+    context 'when parsed_body is nil' do
+      it 'returns false' do
+        expect(described_class.articles?(nil)).to be false
+      end
+    end
+  end
+
+  describe '#each' do
+    context 'when RSS feed links are present' do
+      let(:html) do
+        <<~HTML
+          <html>
+            <head>
+              <title>Test Blog</title>
+              <link rel="alternate" type="application/rss+xml" href="/feed.xml" title="Main RSS Feed">
+              <link rel="alternate" type="application/rss+xml" href="/comments.xml" title="Comments Feed">
+            </head>
+            <body></body>
+          </html>
+        HTML
+      end
+
+      let(:html_with_xss) do
+        <<~HTML
+          <html>
+            <head>
+              <title>Test Blog</title>
+              <link rel="alternate" type="application/rss+xml" href="/feed.xml" title="<script>alert('xss')</script>RSS Feed">
+            </head>
+            <body></body>
+          </html>
+        HTML
+      end
+
+      it 'yields the correct number of articles' do
+        articles = instance.each.to_a
+        expect(articles.size).to eq 2
+      end
+
+      it 'yields articles with correct title' do
+        articles = instance.each.to_a
+        first_article = articles.first
+
+        expect(first_article[:title]).to eq 'Main RSS Feed'
+      end
+
+      it 'yields articles with correct URL' do
+        articles = instance.each.to_a
+        first_article = articles.first
+
+        expect(first_article[:url].to_s).to eq 'https://example.com/feed.xml'
+      end
+
+      it 'yields articles with helpful description containing clickable link' do
+        articles = instance.each.to_a
+        first_article = articles.first
+
+        expect(first_article[:description]).to include 'https://example.com/feed.xml'
+      end
+
+      it 'yields articles with clickable link in description', :aggregate_failures do
+        first_article = instance.each.first
+
+        expect(first_article[:description]).to include '<a href="https://example.com/feed.xml"'
+        expect(first_article[:description]).to include('>Main RSS Feed</a>')
+        expect(first_article[:description]).to include('rel="nofollow noopener noreferrer"')
+        expect(first_article[:description]).to include('target="_blank"')
+      end
+
+      it 'yields articles with correct categories' do
+        articles = instance.each.to_a
+        first_article = articles.first
+
+        expect(first_article[:categories]).to include 'feed', 'auto-detected', 'rss'
+      end
+
+      it 'yields articles with correct scraper' do
+        articles = instance.each.to_a
+        first_article = articles.first
+
+        expect(first_article[:scraper]).to eq described_class
+      end
+
+      it 'yields articles with monthly rotating ID' do
+        articles = instance.each.to_a
+        first_article = articles.first
+        current_month = Time.now.strftime('%Y-%m')
+
+        expect(first_article[:id]).to match(/^rss-feed-\d+-#{current_month}$/)
+      end
+
+      it 'generates different IDs for different months' do
+        allow(Time).to receive(:now).and_return(Time.new(2024, 1, 15))
+        jan_id = instance.each.to_a.first[:id]
+
+        allow(Time).to receive(:now).and_return(Time.new(2024, 2, 15))
+        feb_id = instance.each.to_a.first[:id]
+
+        expect(jan_id).not_to eq(feb_id)
+      end
+
+      it 'includes month in January ID' do
+        allow(Time).to receive(:now).and_return(Time.new(2024, 1, 15))
+        articles = instance.each.to_a
+        jan_id = articles.first[:id]
+
+        expect(jan_id).to include('2024-01')
+      end
+
+      it 'includes month in February ID' do
+        allow(Time).to receive(:now).and_return(Time.new(2024, 2, 15))
+        articles = instance.each.to_a
+        feb_id = articles.first[:id]
+
+        expect(feb_id).to include('2024-02')
+      end
+
+      it 'yields articles with author information' do
+        articles = instance.each.to_a
+        first_article = articles.first
+
+        expect(first_article[:author]).to eq 'Test Blog'
+      end
+
+      it 'sanitizes HTML in feed titles for security', :aggregate_failures do
+        xss_instance = described_class.new(Nokogiri::HTML(html_with_xss), url:)
+        first_article = xss_instance.first
+
+        expect(first_article[:description]).to include 'RSS Feed'
+        expect(first_article[:description]).not_to include '<script>'
+        expect(first_article[:description]).not_to include 'alert('
+      end
+
+      it 'yields articles for all RSS feeds' do
+        articles = instance.each.to_a
+        second_article = articles.last
+
+        expect(second_article[:title]).to eq 'Comments Feed'
+      end
+
+      it 'yields articles with correct URLs for all feeds' do
+        articles = instance.each.to_a
+        second_article = articles.last
+
+        expect(second_article[:url].to_s).to eq 'https://example.com/comments.xml'
+      end
+    end
+
+    context 'when different feed types are present' do
+      let(:html) do
+        <<~HTML
+          <html>
+            <head>
+              <title>Test Site</title>
+              <link rel="alternate" type="application/rss+xml" href="/feed.xml" title="Main RSS Feed">
+              <link rel="alternate" type="application/atom+xml" href="/atom.xml" title="Atom News Feed">
+              <link rel="alternate" type="application/json" href="/feed.json" title="JSON Data Feed">
+            </head>
+            <body></body>
+          </html>
+        HTML
+      end
+
+      it 'detects different feed types correctly' do
+        articles = instance.each.to_a
+
+        expect(articles.size).to eq 3
+      end
+
+      it 'categorizes RSS feeds correctly' do
+        articles = instance.each.to_a
+        rss_article = articles.find { |a| a[:url].to_s.include?('feed.xml') }
+
+        expect(rss_article[:categories]).to include 'rss'
+      end
+
+      it 'categorizes Atom feeds correctly' do
+        articles = instance.each.to_a
+        atom_article = articles.find { |a| a[:url].to_s.include?('atom.xml') }
+
+        expect(atom_article[:categories]).to include 'atom'
+      end
+
+      it 'categorizes JSON feeds correctly' do
+        articles = instance.each.to_a
+        json_article = articles.find { |a| a[:url].to_s.include?('feed.json') }
+
+        expect(json_article[:categories]).to include 'json-feed'
+      end
+    end
+
+    context 'when no RSS feed links are present' do
+      let(:html) do
+        <<~HTML
+          <html>
+            <head>
+              <link rel="stylesheet" href="/style.css">
+            </head>
+            <body></body>
+          </html>
+        HTML
+      end
+
+      it 'yields nothing' do
+        expect(instance.each.to_a).to be_empty
+      end
+    end
+
+    context 'when RSS feed link has no href' do
+      let(:html) do
+        <<~HTML
+          <html>
+            <head>
+              <link rel="alternate" type="application/rss+xml" title="Broken Feed">
+            </head>
+            <body></body>
+          </html>
+        HTML
+      end
+
+      it 'yields nothing' do
+        expect(instance.each.to_a).to be_empty
+      end
+    end
+  end
+end

--- a/spec/lib/html2rss/config_spec.rb
+++ b/spec/lib/html2rss/config_spec.rb
@@ -158,7 +158,8 @@ RSpec.describe Html2rss::Config do
               enabled: true,
               minimum_selector_frequency: 3,  # was explicitly set -> overrides default
               use_top_selectors: 5            # wasn't explicitly set -> default
-            }
+            },
+            rss_feed_detector: { enabled: true } # wasn't explicitly set -> default
           },
           cleanup: {
             keep_different_domain: false,     # wasn't explicitly set -> default


### PR DESCRIPTION
This pull request adds a new fallback scraper, `RssFeedDetector`, to the auto-source system for detecting RSS, Atom, and JSON feeds on websites. It updates the configuration and validation logic to support this new scraper, integrates it into the scraping pipeline, and provides comprehensive tests to ensure correct behavior and security. The main goal is to improve feed discovery when other scrapers fail, increasing coverage and usability.

**Auto-source enhancements:**

* Added a new `rss_feed_detector` configuration option to `AutoSource`, allowing users to enable or disable the fallback RSS feed detection feature.
* Updated the configuration validation schema to support the new `rss_feed_detector` option.

**Scraper pipeline integration:**

* Registered the new `RssFeedDetector` scraper in the auto-source scraping pipeline, so it runs after other scrapers.

**New fallback RSS feed scraper:**

* Implemented `RssFeedDetector` in `lib/html2rss/auto_source/scraper/rss_feed_detector.rb`, which:
  * Detects RSS, Atom, and JSON feeds via `<link rel="alternate">` tags.
  * Generates helpful articles with clickable links, monthly rotating IDs, and sanitized HTML for security.
  * Categorizes feeds and extracts author/site name from the page.

**Testing and validation:**

* Added a full test suite for `RssFeedDetector`, covering detection, article generation, feed type categorization, monthly ID rotation, author extraction, and XSS sanitization.

---

Closes #208