### PR TITLE
feat: add a set of default request headers

### DIFF
--- a/lib/html2rss/config/request_headers.rb
+++ b/lib/html2rss/config/request_headers.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+module Html2rss
+  class Config
+    ##
+    # Normalizes HTTP headers for outgoing requests.
+    # Ensures a browser-like baseline while respecting caller overrides.
+    class RequestHeaders
+      DEFAULT_ACCEPT = %w[
+        text/html
+        application/xhtml+xml
+        application/xml;q=0.9
+        image/avif
+        image/webp
+        image/apng
+        */*;q=0.8
+      ].join(',')
+
+      DEFAULT_USER_AGENT = [
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+        'AppleWebKit/537.36 (KHTML, like Gecko)',
+        'Chrome/123.0.0.0',
+        'Safari/537.36'
+      ].join(' ')
+
+      DEFAULT_HEADERS = {
+        'Accept' => DEFAULT_ACCEPT,
+        'Accept-Encoding' => 'gzip, deflate, br, zstd',
+        'Cache-Control' => 'max-age=0',
+        'Connection' => 'keep-alive',
+        'Sec-Fetch-Dest' => 'document',
+        'Sec-Fetch-Mode' => 'navigate',
+        'Sec-Fetch-Site' => 'none',
+        'Sec-Fetch-User' => '?1',
+        'Upgrade-Insecure-Requests' => '1',
+        'User-Agent' => DEFAULT_USER_AGENT
+      }.freeze
+
+      class << self
+        ##
+        # @return [Hash<String, String>] the unmodified default header set
+        def browser_defaults
+          DEFAULT_HEADERS.dup
+        end
+
+        ##
+        # Normalizes the provided headers while applying Html2rss defaults.
+        #
+        # @param headers [Hash, nil] caller provided headers
+        # @param channel_language [String, nil] language defined on the channel
+        # @param url [String] request URL used to infer the Host header
+        # @return [Hash<String, String>] normalized HTTP headers
+        def normalize(headers, channel_language:, url:)
+          new(headers || {}, channel_language:, url:).to_h
+        end
+      end
+
+      def initialize(headers, channel_language:, url:)
+        @headers = headers
+        @channel_language = channel_language
+        @url = url
+      end
+
+      ##
+      # @return [Hash<String, String>] normalized HTTP headers
+      def to_h
+        defaults = DEFAULT_HEADERS.dup
+        normalized = normalize_custom_headers(headers)
+
+        accept_override = normalized.delete('Accept')
+        defaults.merge!(normalized)
+
+        defaults['Accept'] = normalize_accept(accept_override)
+        defaults['Accept-Language'] = build_accept_language
+        defaults['Host'] ||= request_host
+
+        defaults.compact
+      end
+
+      private
+
+      attr_reader :headers, :channel_language, :url
+
+      def normalize_custom_headers(custom)
+        custom.transform_keys { canonicalize(_1) }
+      end
+
+      def canonicalize(key)
+        key.to_s.split('-').map!(&:capitalize).join('-')
+      end
+
+      def normalize_accept(override)
+        return DEFAULT_ACCEPT if override.nil? || override.empty?
+
+        values = accept_values(DEFAULT_ACCEPT)
+
+        accept_values(override).reverse_each do |value|
+          next if values.include?(value)
+
+          values.unshift(value)
+        end
+
+        values.join(',')
+      end
+
+      def accept_values(header)
+        header.split(',').map!(&:strip).reject(&:empty?)
+      end
+
+      def build_accept_language
+        language = channel_language.to_s.strip
+        return 'en-US,en;q=0.9' if language.empty?
+
+        normalized = language.tr('_', '-')
+        primary, region = normalized.split('-', 2)
+        primary = primary.downcase
+        region = region&.upcase
+
+        return primary if region.nil?
+
+        "#{primary}-#{region},#{primary};q=0.9"
+      end
+
+      def request_host
+        return nil if url.nil? || url.empty?
+
+        Html2rss::Url.from_relative(url, url).host
+      end
+    end
+  end
+end

--- a/spec/exe/html2rss_spec.rb
+++ b/spec/exe/html2rss_spec.rb
@@ -26,10 +26,10 @@ RSpec.describe 'exe/html2rss', :slow do
         xmlns:dc="http://purl.org/dc/elements/1.1/"
         xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
         xmlns:trackback="http://madskills.com/public/xml/rss/module/trackback/">
-        <channel>
-          <title>Releases · nuxt/nuxt · GitHub</title>
     RSS
   end
+
+  let(:rss_title_pattern) { %r{<title>.+</title>} }
 
   context 'without any arguments' do
     it 'prints usage information' do
@@ -45,28 +45,37 @@ RSpec.describe 'exe/html2rss', :slow do
 
   context 'with feed config: nuxt-releases' do
     context 'with arguments: feed YAML_FILE' do
-      subject(:output) { `#{executable} feed spec/fixtures/single.test.yml` }
+      subject(:output) do
+        capture_cli_output('feed', 'spec/fixtures/single.test.yml', cassette: 'nuxt-releases')
+      end
 
       it 'generates the RSS', :aggregate_failures do
         expect(output).to start_with(doctype_xml)
         expect(output).not_to include(stylesheets_xml)
         expect(output).to include(rss_xml)
+        expect(output).to match(rss_title_pattern)
       end
     end
 
     context 'with arguments: feed YAML_FILE FEED_NAME' do
-      subject(:output) { `#{executable} feed spec/fixtures/feeds.test.yml nuxt-releases` }
+      subject(:output) do
+        capture_cli_output('feed', 'spec/fixtures/feeds.test.yml', 'nuxt-releases', cassette: 'nuxt-releases')
+      end
 
       it 'generates the RSS', :aggregate_failures do
         expect(output).to start_with(doctype_xml)
         expect(output).to include(stylesheets_xml)
         expect(output).to include(rss_xml)
+        expect(output).to match(rss_title_pattern)
       end
     end
   end
 
   context 'with feed config: withparams' do
-    subject(:output) { `#{executable} feed spec/fixtures/feeds.test.yml withparams --params sign:10 param:value` }
+    subject(:output) do
+      capture_cli_output('feed', 'spec/fixtures/feeds.test.yml', 'withparams', '--params', 'sign:10', 'param:value',
+                         cassette: 'notitle')
+    end
 
     it 'processes and escapes the params' do
       expect(output)

--- a/spec/fixtures/single.test.yml
+++ b/spec/fixtures/single.test.yml
@@ -11,7 +11,7 @@ selectors:
     selector: ".release-header .text-normal a"
     post_process:
       - name: "template"
-        string: "%<self>s (%<author>)"
+        string: "%<self>s (%<author>s)"
   author:
     selector: ".avatar"
     extractor: "attribute"

--- a/spec/lib/html2rss/auto_source/scraper/semantic_html_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper/semantic_html_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe Html2rss::AutoSource::Scraper::SemanticHtml do
     let(:parsed_body) { Nokogiri::HTML.parse(File.read('spec/fixtures/page_1.html')) }
 
     let(:grouped_expected_articles) do
-      # rubocop:disable Metrics/LineLength
+      # rubocop:disable Layout/LineLength
       [
         { title: 'Brittney Griner: What I Endured in Russia', url: 'https://page.com/6972085/brittney-griner-book-coming-home/', image: 'https://api.PAGE.com/wp-content/uploads/2024/04/brittney-griner-basketball-russia.jpg?quality=85&w=925&h=617&crop=1&resize=925,617', description: %(Chris Coduto—Getty Images Brittney Griner: What I Endured in Russia 17 MIN READ May 3, 2024 • 8:00 AM EDT "Prison is more than a place. It’s also a mindset," Brittney Griner writes in an excerpt from her book\n about surviving imprisonment in Russia.), id: '/6972085/brittney-griner-book-coming-home/' },
         { title: 'Driver Dies After Crashing Into White House Security Barrier', url: 'https://page.com/6974836/white-house-car-crash-driver-dies-security-barrier/', image: 'https://api.PAGE.com/wp-content/uploads/2024/05/AP24126237101577.jpg?quality=85&w=925&h=617&crop=1&resize=925,617', description: 'Driver Dies After Crashing Into White House Security Barrier 1 MIN READ May 5, 2024 • 7:46 AM EDT', id: '/6974836/white-house-car-crash-driver-dies-security-barrier/' }
       ].group_by { |article| article[:id] }
-      # rubocop:enable Metrics/LineLength
+      # rubocop:enable Layout/LineLength
     end
 
     it 'yields and includes all expected articles', :aggregate_failures, :slow do # rubocop:disable RSpec/ExampleLength

--- a/spec/lib/html2rss/config/request_headers_spec.rb
+++ b/spec/lib/html2rss/config/request_headers_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Html2rss::Config::RequestHeaders do
+  subject(:normalized) do
+    described_class.normalize(headers, channel_language:, url:)
+  end
+
+  let(:headers) { {} }
+  let(:channel_language) { 'de-DE' }
+  let(:url) { 'https://example.com/feed' }
+
+  describe '.browser_defaults' do
+    it 'returns a mutable copy of the default headers' do
+      expect { described_class.browser_defaults['User-Agent'] = 'Custom' }
+        .not_to(change { described_class.browser_defaults['User-Agent'] })
+    end
+  end
+
+  describe '#to_h' do
+    context 'when no overrides are provided' do
+      it 'adds Accept-Language from the channel language' do
+        expect(normalized).to include('Accept-Language' => 'de-DE,de;q=0.9')
+      end
+
+      it 'infers the Host header from the URL' do
+        expect(normalized).to include('Host' => 'example.com')
+      end
+    end
+
+    context 'when overrides are provided' do
+      let(:headers) do
+        { 'accept' => 'application/json', 'x-test-header' => 'abc' }
+      end
+
+      it 'capitalizes custom header keys' do
+        expect(normalized).to include('X-Test-Header' => 'abc')
+      end
+
+      it 'prepends custom Accept values while keeping defaults' do
+        expected = "application/json,#{described_class::DEFAULT_ACCEPT}"
+
+        expect(normalized).to include('Accept' => expected)
+      end
+    end
+
+    context 'when the channel language is blank' do
+      let(:channel_language) { '  ' }
+
+      it 'falls back to en-US' do
+        expect(normalized).to include('Accept-Language' => 'en-US,en;q=0.9')
+      end
+    end
+
+    context 'when the URL is blank' do
+      let(:url) { nil }
+
+      it 'does not add a Host header' do
+        expect(normalized).not_to include('Host')
+      end
+    end
+  end
+end

--- a/spec/lib/html2rss_spec.rb
+++ b/spec/lib/html2rss_spec.rb
@@ -41,7 +41,9 @@ RSpec.describe Html2rss do
 
       it 'returns a RSS::Rss instance & sets the request headers', :aggregate_failures do
         expect(feed_return).to be_a(RSS::Rss)
-        expect(Faraday).to have_received(:new).with(hash_including(headers: config[:headers]))
+        expect(Faraday).to have_received(:new).with(
+          hash_including(headers: hash_including(config[:headers].transform_keys(&:to_s)))
+        )
       end
 
       describe 'feed.channel' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,7 @@ if ENV['COVERAGE']
 end
 
 require_relative '../lib/html2rss'
+require_relative 'support/cli_helpers'
 
 Zeitwerk::Loader.eager_load_all # flush all potential loading issues
 
@@ -38,6 +39,8 @@ RSpec.configure do |config|
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
+
+  config.include CliHelpers
 
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/support/cli_helpers.rb
+++ b/spec/support/cli_helpers.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'stringio'
+
+module CliHelpers
+  # Capture CLI output while running inside a VCR cassette.
+  #
+  # @param args [Array<String>] CLI arguments to execute
+  # @param cassette [String] VCR cassette name
+  # @return [String] captured STDOUT output
+  def capture_cli_output(*args, cassette:)
+    stdout = StringIO.new
+    original_stdout = $stdout
+    $stdout = stdout
+    VCR.use_cassette(cassette) { Html2rss::CLI.start(args) }
+    stdout.string
+  ensure
+    $stdout = original_stdout
+  end
+end


### PR DESCRIPTION
This pull request introduces a major improvement to request header handling for outgoing HTTP requests in the `html2rss` codebase. It adds a new `RequestHeaders` class that ensures browser-like default headers and provides normalization for caller-provided overrides. The configuration logic is refactored to use this normalization, and new tests are added to verify header behavior. Additionally, CLI test helpers are introduced and existing specs are updated to use them for more robust output capture.

**Request header normalization and configuration improvements:**

* Added `RequestHeaders` class (`lib/html2rss/config/request_headers.rb`) to provide browser-like default headers and normalization logic for custom headers, including proper casing, Accept and Accept-Language handling, and Host inference.
* Refactored `Config` class (`lib/html2rss/config.rb`) to use `RequestHeaders.browser_defaults` for default config and to normalize headers using `RequestHeaders.normalize` during initialization. [[1]](diffhunk://#diff-ca55607f8388edb9b462b3f5a5318ca8b8c02c14f27d44f803c1014e129e5a86L66-R66) [[2]](diffhunk://#diff-ca55607f8388edb9b462b3f5a5318ca8b8c02c14f27d44f803c1014e129e5a86L79-R94)
* Extracted config preparation logic into a new `prepare_config` method for clarity and maintainability.

**Testing improvements:**

* Added comprehensive specs for `RequestHeaders` normalization, covering header overrides, Accept-Language fallback, and Host inference (`spec/lib/html2rss/config/request_headers_spec.rb`).
* Enhanced config specs to verify header normalization and defaulting behavior (`spec/lib/html2rss/config_spec.rb`).
* Updated integration specs to match normalized header keys and values (`spec/lib/html2rss_spec.rb`).

**CLI test infrastructure:**

* Introduced `CliHelpers` module for capturing CLI output within VCR cassettes (`spec/support/cli_helpers.rb`) and integrated it into spec configuration (`spec/spec_helper.rb`). [[1]](diffhunk://#diff-ad9190ca3838146446b47d296eb4998b03212b691838e8a435960247beb2aad9R1-R20) [[2]](diffhunk://#diff-89eebfcbc0f14b6d989517837ca1e94fce4e2ce9a03233641cd936f2b8d2ed94R32) [[3]](diffhunk://#diff-89eebfcbc0f14b6d989517837ca1e94fce4e2ce9a03233641cd936f2b8d2ed94R43-R44)
* Refactored CLI specs to use the new output capture helper for more reliable and isolated testing (`spec/exe/html2rss_spec.rb`). [[1]](diffhunk://#diff-55a58680b99d74d85bfa5f46531700d29154ec629dcf2f12d6ccce9074fc5005L29-R33) [[2]](diffhunk://#diff-55a58680b99d74d85bfa5f46531700d29154ec629dcf2f12d6ccce9074fc5005L48-R78)

Other minor changes include fixing a template string in a YAML fixture and updating a RuboCop directive in a spec file.