### PR TITLE
feat: deduplicate articles before building feeds

### DIFF
--- a/lib/html2rss.rb
+++ b/lib/html2rss.rb
@@ -64,10 +64,13 @@ module Html2rss
       articles.concat AutoSource.new(response, auto_source).articles
     end
 
-    # Step 4: Build the RSS feed
+    # Step 4: Deduplicate aggregated articles
+    unique_articles = Html2rss::ArticlePipeline::Processors::Deduplicator.new(articles).call
+
+    # Step 5: Build the RSS feed
     channel = RssBuilder::Channel.new(response, overrides: config.channel)
 
-    RssBuilder.new(channel:, articles:, stylesheets: config.stylesheets).call
+    RssBuilder.new(channel:, articles: unique_articles, stylesheets: config.stylesheets).call
   end
 
   ##

--- a/lib/html2rss/article_pipeline/processors/deduplicator.rb
+++ b/lib/html2rss/article_pipeline/processors/deduplicator.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'set'
+
+module Html2rss
+  module ArticlePipeline
+    module Processors
+      ##
+      # Deduplicates a list of articles while preserving their original order.
+      #
+      # The processor uses each article's guid when available to determine
+      # uniqueness and falls back to a composite of id and URL. When neither is
+      # present, it defaults to the article's hash so the original object is
+      # retained.
+      class Deduplicator
+        ##
+        # @param articles [Array<Html2rss::RssBuilder::Article>]
+        def initialize(articles)
+          @articles = Array(articles)
+        end
+
+        ##
+        # Returns the list of unique articles, preserving the order of the
+        # original collection and keeping the first occurrence of a duplicate.
+        #
+        # @return [Array<Html2rss::RssBuilder::Article>]
+        def call
+          seen = Set.new
+
+          articles.each_with_object([]) do |article, deduplicated|
+            fingerprint = fingerprint_for(article)
+            next if seen.include?(fingerprint)
+
+            seen.add(fingerprint)
+            deduplicated << article
+          end
+        end
+
+        private
+
+        attr_reader :articles
+
+        def fingerprint_for(article)
+          return article.guid if article.respond_to?(:guid) && article.guid
+
+          parts = []
+          parts << article.id if article.respond_to?(:id) && article.id
+          parts << article.url.to_s if article.respond_to?(:url) && article.url
+
+          return parts.join('#!/') unless parts.empty?
+
+          article.hash
+        end
+      end
+    end
+  end
+end

--- a/spec/html2rss/article_pipeline/processors/deduplicator_spec.rb
+++ b/spec/html2rss/article_pipeline/processors/deduplicator_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Html2rss::ArticlePipeline::Processors::Deduplicator do
+  subject(:deduplicated) { described_class.new(articles).call }
+
+  let(:scraper) { Class.new }
+
+  describe '#call' do
+    context 'when multiple sources provide overlapping articles' do
+      let(:articles) do
+        [article_a, article_b, duplicate_article_a, article_c, duplicate_article_b]
+      end
+
+      let(:article_a) { build_article(id: 'a', url: 'https://example.com/a', title: 'Alpha') }
+      let(:article_b) { build_article(id: 'b', url: 'https://example.com/b', title: 'Beta') }
+      let(:article_c) { build_article(id: 'c', url: 'https://example.com/c', title: 'Gamma') }
+      let(:duplicate_article_a) { build_article(id: 'a', url: 'https://example.com/a', title: 'Alpha (selectors)') }
+      let(:duplicate_article_b) { build_article(id: 'b', url: 'https://example.com/b', title: 'Beta (auto)') }
+
+      it 'removes duplicates while preserving order of first occurrences' do
+        expect(deduplicated).to eq([article_a, article_b, article_c])
+      end
+
+      it 'keeps articles in their original relative order' do
+        expect(deduplicated.map(&:id)).to eq(%w[a b c])
+      end
+    end
+
+    context 'when articles do not expose a guid' do
+      let(:url) { instance_double(Html2rss::Url, to_s: 'https://example.com/shared') }
+      let(:articles) do
+        [article_without_guid, duplicate_without_guid, unique_article]
+      end
+      let(:article_without_guid) do
+        instance_double('Html2rss::RssBuilder::Article', guid: nil, id: 'shared', url:, scraper:)
+      end
+      let(:duplicate_without_guid) do
+        instance_double('Html2rss::RssBuilder::Article', guid: nil, id: 'shared', url:, scraper:)
+      end
+      let(:unique_article) do
+        instance_double('Html2rss::RssBuilder::Article', guid: nil, id: 'unique', url: instance_double(Html2rss::Url, to_s: 'https://example.com/unique'), scraper:)
+      end
+
+      it 'falls back to the combination of id and URL to deduplicate' do
+        expect(deduplicated).to eq([article_without_guid, unique_article])
+      end
+    end
+  end
+
+  def build_article(id:, url:, title:, description: 'Description')
+    Html2rss::RssBuilder::Article.new(id:, url:, title:, description:, scraper:)
+  end
+end


### PR DESCRIPTION
## Summary
- call the article deduplicator directly from `Html2rss.feed` so feeds only use unique items
- add a dedicated deduplicator processor that keys off GUIDs with sensible fallbacks
- cover the deduplicator entry point with specs to ensure ordering and fallback behaviour

## Testing
- bundle exec rspec spec/html2rss/article_pipeline/processors/deduplicator_spec.rb spec/examples/combined_scraper_sources_spec.rb

------
https://chatgpt.com/codex/tasks/task_e_68e565bd7b50832dabc7d3526af5bb6d