### PR TITLE
feat(auto_source): add JsonState to scrape SPA state

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,6 +41,10 @@ Keep logic anchored to the correct stage. For example, default headers or strate
 
 - Use RSpec with clear `describe` and `context` blocks.
 - Express setup with `let`.
+- Do not define methods within RSpec blocks. If unavoidable, consider creating a shared example.
+- Never use `send(:method_name)`
+- Use of [rspec-matchers](https://rspec.info/features/3-13/rspec-expectations/built-in-matchers/) properly.
+- Multiple Examples shall be tagged with `:aggregate_failures`.
 - Prefer `expect(...).to eq(...)` and `expect(...).to have_received(...)` expectations.
 - Stub with `allow(...).to receive(...).and_return(...)`.
 - Share examples for common extractor or post-processor behaviours.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,7 +44,7 @@ Keep logic anchored to the correct stage. For example, default headers or strate
 - Do not define methods within RSpec blocks. If unavoidable, consider creating a shared example.
 - Never use `send(:method_name)`
 - Use of [rspec-matchers](https://rspec.info/features/3-13/rspec-expectations/built-in-matchers/) properly.
-- Multiple Examples shall be tagged with `:aggregate_failures`.
+- Fix Rubocop offense `RSpec/MultipleExpectations` by taging example with `:aggregate_failures`.
 - Prefer `expect(...).to eq(...)` and `expect(...).to have_received(...)` expectations.
 - Stub with `allow(...).to receive(...).and_return(...)`.
 - Share examples for common extractor or post-processor behaviours.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This gem is the core of the [html2rss-web](https://github.com/html2rss/html2rss-
 ## ✨ Features
 
 - 🎯 **CSS Selector Support** - Extract content using familiar CSS selectors
-- 🤖 **Auto-Detection** - Automatically detect content using Schema.org and semantic HTML
+- 🤖 **Auto-Detection** - Automatically detect content using Schema.org, JSON state, and semantic HTML
 - 🔄 **Multiple Request Strategies** - Faraday for static sites, Browserless for JS-heavy sites
 - 🛠️ **Post-Processing** - Template rendering, HTML sanitization, time parsing, and more
 - 🧪 **Comprehensive Testing** - 95%+ test coverage with RSpec
@@ -58,7 +58,7 @@ Please see the [contributing guide](https://html2rss.github.io/get-involved/cont
 1. **Config** - Loads and validates configuration (YAML/hash)
 2. **RequestService** - Fetches pages using Faraday or Browserless
 3. **Selectors** - Extracts content via CSS selectors with extractors/post-processors
-4. **AutoSource** - Auto-detects content using Schema.org, semantic HTML, and structural patterns
+4. **AutoSource** - Auto-detects content using Schema.org, JSON state blobs, semantic HTML, and structural patterns
 5. **RssBuilder** - Assembles Article objects and renders RSS 2.0
 
 ### Data Flow
@@ -66,6 +66,26 @@ Please see the [contributing guide](https://html2rss.github.io/get-involved/cont
 ```text
 Config -> Request -> Extraction -> Processing -> Building -> Output
 ```
+
+### JSON-state scraper (AutoSource)
+
+Single-page applications often stash pre-rendered article data in `<script type="application/json">` tags or global variables
+such as `window.__NEXT_DATA__`, `window.__NUXT__`, or `window.STATE`. The JSON-state scraper walks those blobs, finds arrays with
+`title`/`url` pairs, and converts them into the same hashes produced by `HtmlExtractor`.
+
+```yaml
+auto_source:
+  scraper:
+    json_state:
+      enabled: true
+```
+
+The scraper is enabled by default when `auto_source` is configured. Explicitly enabling it is helpful when you rely only on the
+JSON output from frameworks like Next.js or Nuxt without any semantic HTML to fall back on. Disable it when a site exposes large
+non-article state payloads that could overwhelm the heuristics, or when it accidentally surfaces draft/private entries.
+
+**Limitations:** the scraper requires discoverable arrays of hashes containing clear `title` and `url` fields. Minified or
+obfuscated state objects, heavily encoded values, or blobs that require executing embedded functions are ignored.
 
 ## 🧪 Testing
 

--- a/README.md
+++ b/README.md
@@ -67,26 +67,6 @@ Please see the [contributing guide](https://html2rss.github.io/get-involved/cont
 Config -> Request -> Extraction -> Processing -> Building -> Output
 ```
 
-### JSON-state scraper (AutoSource)
-
-Single-page applications often stash pre-rendered article data in `<script type="application/json">` tags or global variables
-such as `window.__NEXT_DATA__`, `window.__NUXT__`, or `window.STATE`. The JSON-state scraper walks those blobs, finds arrays with
-`title`/`url` pairs, and converts them into the same hashes produced by `HtmlExtractor`.
-
-```yaml
-auto_source:
-  scraper:
-    json_state:
-      enabled: true
-```
-
-The scraper is enabled by default when `auto_source` is configured. Explicitly enabling it is helpful when you rely only on the
-JSON output from frameworks like Next.js or Nuxt without any semantic HTML to fall back on. Disable it when a site exposes large
-non-article state payloads that could overwhelm the heuristics, or when it accidentally surfaces draft/private entries.
-
-**Limitations:** the scraper requires discoverable arrays of hashes containing clear `title` and `url` fields. Minified or
-obfuscated state objects, heavily encoded values, or blobs that require executing embedded functions are ignored.
-
 ## 🧪 Testing
 
 - **RSpec** for comprehensive testing

--- a/lib/html2rss/auto_source.rb
+++ b/lib/html2rss/auto_source.rb
@@ -22,6 +22,9 @@ module Html2rss
         schema: {
           enabled: true
         },
+        json_state: {
+          enabled: true
+        },
         semantic_html: {
           enabled: true
         },
@@ -40,6 +43,9 @@ module Html2rss
     Config = Dry::Schema.Params do
       optional(:scraper).hash do
         optional(:schema).hash do
+          optional(:enabled).filled(:bool)
+        end
+        optional(:json_state).hash do
           optional(:enabled).filled(:bool)
         end
         optional(:semantic_html).hash do

--- a/lib/html2rss/auto_source/scraper.rb
+++ b/lib/html2rss/auto_source/scraper.rb
@@ -10,9 +10,10 @@ module Html2rss
     #
     module Scraper
       SCRAPERS = [
-        Html,
         Schema,
+        JsonState,
         SemanticHtml,
+        Html,
         RssFeedDetector
       ].freeze
 

--- a/lib/html2rss/auto_source/scraper/json_state.rb
+++ b/lib/html2rss/auto_source/scraper/json_state.rb
@@ -1,0 +1,318 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Html2rss
+  class AutoSource
+    module Scraper
+      #
+      # Scrapes JSON state blobs embedded in script tags such as Next.js, Nuxt,
+      # or custom window globals. The scraper searches `<script type="application/json">`
+      # tags and well-known JavaScript globals for arrays of article-like hashes
+      # and normalises them to a structure compatible with HtmlExtractor.
+      class JsonState
+        include Enumerable
+
+        JSON_SCRIPT_SELECTOR = 'script[type="application/json"]'
+        GLOBAL_ASSIGNMENT_PATTERNS = [
+          /(?:window|self|globalThis)\.__NEXT_DATA__\s*=\s*/m,
+          /(?:window|self|globalThis)\.__NUXT__\s*=\s*/m,
+          /(?:window|self|globalThis)\.STATE\s*=\s*/m
+        ].freeze
+
+        TITLE_KEYS = %w[title headline name text].freeze
+        URL_KEYS = %w[url link href permalink slug path canonicalUrl shortUrl].freeze
+        DESCRIPTION_KEYS = %w[description summary excerpt dek subheading].freeze
+        IMAGE_KEYS = %w[image imageUrl thumbnailUrl thumbnail src featuredImage coverImage heroImage].freeze
+        PUBLISHED_AT_KEYS = %w[published_at publishedAt datePublished date publicationDate pubDate updatedAt updated_at createdAt created_at].freeze
+        CATEGORY_KEYS = %w[categories tags section sections topic topics channel].freeze
+        ID_KEYS = %w[id guid uuid slug key].freeze
+
+        module DocumentScanner
+          module_function
+
+          def json_documents(parsed_body)
+            script_documents(parsed_body) + assignment_documents(parsed_body)
+          end
+
+          def script_documents(parsed_body)
+            parsed_body.css(JSON_SCRIPT_SELECTOR).filter_map { parse_json(_1.text) }
+          end
+
+          def assignment_documents(parsed_body)
+            parsed_body.css('script').filter_map { parse_assignment(_1.text) }
+          end
+
+          def parse_assignment(text)
+            payload = assignment_payload(text)
+            parse_json(payload) if payload
+          end
+
+          def assignment_payload(text)
+            trimmed = text.to_s.strip
+            return if trimmed.empty?
+
+            GLOBAL_ASSIGNMENT_PATTERNS.each do |pattern|
+              next unless trimmed.match?(pattern)
+
+              payload = trimmed.sub(pattern, '')
+              return extract_assignment_payload(payload)
+            end
+
+            nil
+          end
+
+          def extract_assignment_payload(text)
+            extract_json_block(text) || text
+          end
+
+          def extract_json_block(text)
+            start_index = text.index(/[\[{]/)
+            return unless start_index
+
+            stop_index = scan_for_json_end(text, start_index)
+            text[start_index..stop_index] if stop_index
+          end
+
+          def scan_for_json_end(text, start_index)
+            stack = []
+            in_string = false
+            escape = false
+
+            text.each_char.with_index do |char, index|
+              next if index < start_index
+
+              if in_string
+                if escape
+                  escape = false
+                elsif char == '\\'
+                  escape = true
+                elsif char == '"'
+                  in_string = false
+                end
+                next
+              end
+
+              case char
+              when '"'
+                in_string = true
+              when '{'
+                stack << '}'
+              when '['
+                stack << ']'
+              when '}', ']'
+                expected = stack.pop
+                return index if expected == char && stack.empty?
+              end
+            end
+
+            nil
+          end
+
+          def parse_json(payload)
+            return unless payload
+
+            JSON.parse(payload, symbolize_names: true)
+          rescue JSON::ParserError => error
+            Log.debug('JsonState: Failed to parse JSON payload', error: error.message)
+            nil
+          end
+        end
+        private_constant :DocumentScanner
+
+        module ValueFinder
+          module_function
+
+          def fetch(object, keys)
+            case object
+            when Hash then fetch_from_hash(object, keys)
+            when Array then fetch_from_array(object, keys)
+            end
+          end
+
+          def fetch_from_hash(hash, keys)
+            keys.each do |key|
+              string_key = key.to_s
+              return hash[string_key] if hash.key?(string_key)
+
+              symbol_key = string_key.to_sym
+              return hash[symbol_key] if hash.key?(symbol_key)
+            end
+
+            fetch_nested(hash[:attributes] || hash['attributes'], keys) ||
+              fetch_nested(hash[:data] || hash['data'], keys)
+          end
+
+          def fetch_from_array(array, keys)
+            array.each do |entry|
+              result = fetch(entry, keys)
+              return result if result
+            end
+
+            nil
+          end
+
+          def fetch_nested(value, keys)
+            fetch(value, keys) if value
+          end
+        end
+        private_constant :ValueFinder
+
+        module CandidateDetector
+          module_function
+
+          def candidate_array?(document)
+            case document
+            when Array then array_of_articles?(document)
+            when Hash then document.each_value.any? { candidate_array?(_1) }
+            else false
+            end
+          end
+
+          def array_of_articles?(array)
+            array.any? do |element|
+              next unless element.is_a?(Hash)
+
+              title_from(element) && url_from(element)
+            end
+          end
+
+          def title_from(object)
+            ValueFinder.fetch(object, TITLE_KEYS)
+          end
+
+          def url_from(object)
+            ValueFinder.fetch(object, URL_KEYS)
+          end
+        end
+        private_constant :CandidateDetector
+
+        module ArticleNormalizer
+          module_function
+
+          def normalise(entry, base_url:)
+            return unless entry.is_a?(Hash)
+
+            title = string(ValueFinder.fetch(entry, TITLE_KEYS))
+            description = string(ValueFinder.fetch(entry, DESCRIPTION_KEYS))
+            article_url = resolve_link(entry, keys: URL_KEYS, base_url: base_url, log_key: 'JsonState: invalid URL encountered')
+            return unless article_url
+            return if title.nil? && description.nil?
+
+            {
+              title: title,
+              description: description,
+              url: article_url,
+              image: resolve_link(entry, keys: IMAGE_KEYS, base_url: base_url, log_key: 'JsonState: invalid image URL encountered'),
+              published_at: string(ValueFinder.fetch(entry, PUBLISHED_AT_KEYS)),
+              categories: categories(entry),
+              id: identifier(entry, article_url)
+            }.compact
+          end
+
+          def string(value)
+            trimmed = value.to_s.strip
+            trimmed unless trimmed.empty?
+          end
+
+          def resolve_link(entry, keys:, base_url:, log_key:)
+            value = ValueFinder.fetch(entry, keys)
+            value = ValueFinder.fetch(value, keys) if value.is_a?(Hash)
+            string = string(value)
+            return unless string
+
+            Url.from_relative(string, base_url)
+          rescue ArgumentError
+            Log.debug(log_key, url: string)
+            nil
+          end
+
+          def categories(entry)
+            raw = ValueFinder.fetch(entry, CATEGORY_KEYS)
+            names = case raw
+                    when Array then raw
+                    when Hash then raw.values
+                    when String then [raw]
+                    else []
+                    end
+
+            result = names.flat_map do |value|
+              case value
+              when Hash
+                string(ValueFinder.fetch(value, %w[name title label]))
+              else
+                string(value)
+              end
+            end.compact
+
+            result.uniq!
+            result unless result.empty?
+          end
+
+          def identifier(entry, article_url)
+            value = ValueFinder.fetch(entry, ID_KEYS)
+            value = ValueFinder.fetch(value, ID_KEYS) if value.is_a?(Hash)
+            string(value) || article_url.to_s
+          end
+        end
+        private_constant :ArticleNormalizer
+
+        def self.options_key = :json_state
+
+        class << self
+          def articles?(parsed_body)
+            return false unless parsed_body
+
+            DocumentScanner.json_documents(parsed_body).any? { CandidateDetector.candidate_array?(_1) }
+          end
+
+          def json_documents(parsed_body)
+            DocumentScanner.json_documents(parsed_body)
+          end
+        end
+
+        def initialize(parsed_body, url:, **_opts)
+          @parsed_body = parsed_body
+          @url = url
+        end
+
+        attr_reader :parsed_body
+
+        def each
+          return enum_for(:each) unless block_given?
+
+          DocumentScanner.json_documents(parsed_body).each do |document|
+            discover_articles(document) do |article|
+              yield article if article
+            end
+          end
+        end
+
+        private
+
+        attr_reader :url
+
+        def discover_articles(document, &block)
+          case document
+          when Array then handle_array(document, &block)
+          when Hash then document.each_value { discover_articles(_1, &block) if traversable?(_1) }
+          end
+        end
+
+        def handle_array(array, &block)
+          if CandidateDetector.array_of_articles?(array)
+            array.each do |entry|
+              block.call(ArticleNormalizer.normalise(entry, base_url: url))
+            end
+          else
+            array.each { discover_articles(_1, &block) if traversable?(_1) }
+          end
+        end
+
+        def traversable?(value)
+          value.is_a?(Array) || value.is_a?(Hash)
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/auto_source/scraper/json_state.rb
+++ b/lib/html2rss/auto_source/scraper/json_state.rb
@@ -169,8 +169,18 @@ module Html2rss
 
           def candidate_array?(document)
             case document
-            when Array then array_of_articles?(document)
+            when Array
+              return true if array_of_articles?(document)
+
+              document.any? { traversable_candidate?(_1) }
             when Hash then document.each_value.any? { candidate_array?(_1) }
+            else false
+            end
+          end
+
+          def traversable_candidate?(value)
+            case value
+            when Array, Hash then candidate_array?(value)
             else false
             end
           end

--- a/spec/fixtures/auto_source/json_state/nested_array.html
+++ b/spec/fixtures/auto_source/json_state/nested_array.html
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    <script type="application/json">
+      [{ "posts": [{ "title": "Nested article", "url": "/nested/article" }] }]
+    </script>
+  </body>
+</html>

--- a/spec/fixtures/auto_source/json_state/next.html
+++ b/spec/fixtures/auto_source/json_state/next.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+  <head>
+    <script id="__NEXT_DATA__" type="application/json">
+      {
+        "props": {
+          "pageProps": {
+            "articles": [
+              {
+                "id": "next-article-1",
+                "title": "Next.js powers the latest headlines",
+                "description": "A summary sourced from Next.js JSON state.",
+                "url": "/next/headline",
+                "image": "https://cdn.example.com/images/next/headline.jpg",
+                "datePublished": "2024-04-01T12:00:00Z",
+                "tags": ["nextjs", "spa"]
+              }
+            ]
+          }
+        }
+      }
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/spec/fixtures/auto_source/json_state/nuxt.html
+++ b/spec/fixtures/auto_source/json_state/nuxt.html
@@ -3,23 +3,20 @@
   <body>
     <script>
       window.__NUXT__ = {
-        "state": {
-          "feed": {
-            "items": [
+        state: {
+          feed: {
+            items: [
               {
-                "headline": "Nuxt article arrives",
-                "path": "/nuxt/article",
-                "excerpt": "Nuxt.js embeds article data into a global.",
-                "thumbnailUrl": "/images/nuxt/article.jpg",
-                "publishedAt": "2024-04-02T10:00:00Z",
-                "categories": [
-                  { "name": "nuxt" },
-                  { "name": "spa" }
-                ]
-              }
-            ]
-          }
-        }
+                headline: "Nuxt article arrives",
+                path: "/nuxt/article",
+                excerpt: "Nuxt.js embeds article data into a global.",
+                thumbnailUrl: "/images/nuxt/article.jpg",
+                publishedAt: "2024-04-02T10:00:00Z",
+                categories: [{ name: "nuxt" }, { name: "spa" }],
+              },
+            ],
+          },
+        },
       };
     </script>
   </body>

--- a/spec/fixtures/auto_source/json_state/nuxt.html
+++ b/spec/fixtures/auto_source/json_state/nuxt.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+  <body>
+    <script>
+      window.__NUXT__ = {
+        "state": {
+          "feed": {
+            "items": [
+              {
+                "headline": "Nuxt article arrives",
+                "path": "/nuxt/article",
+                "excerpt": "Nuxt.js embeds article data into a global.",
+                "thumbnailUrl": "/images/nuxt/article.jpg",
+                "publishedAt": "2024-04-02T10:00:00Z",
+                "categories": [
+                  { "name": "nuxt" },
+                  { "name": "spa" }
+                ]
+              }
+            ]
+          }
+        }
+      };
+    </script>
+  </body>
+</html>

--- a/spec/fixtures/auto_source/json_state/state.html
+++ b/spec/fixtures/auto_source/json_state/state.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+  <body>
+    <script>
+      window.STATE = {
+        "posts": [
+          {
+            "name": "Window state update",
+            "permalink": "/state/update",
+            "summary": "Content embedded in a custom window.STATE blob.",
+            "imageUrl": "/images/state/update.png",
+            "id": "state-post-42",
+            "published_at": "2024-04-03T08:30:00Z",
+            "tags": ["updates", "custom"]
+          }
+        ]
+      };
+    </script>
+  </body>
+</html>

--- a/spec/fixtures/auto_source/json_state/state.html
+++ b/spec/fixtures/auto_source/json_state/state.html
@@ -3,17 +3,17 @@
   <body>
     <script>
       window.STATE = {
-        "posts": [
+        posts: [
           {
-            "name": "Window state update",
-            "permalink": "/state/update",
-            "summary": "Content embedded in a custom window.STATE blob.",
-            "imageUrl": "/images/state/update.png",
-            "id": "state-post-42",
-            "published_at": "2024-04-03T08:30:00Z",
-            "tags": ["updates", "custom"]
-          }
-        ]
+            name: "Window state update",
+            permalink: "/state/update",
+            summary: "Content embedded in a custom window.STATE blob.",
+            imageUrl: "/images/state/update.png",
+            id: "state-post-42",
+            published_at: "2024-04-03T08:30:00Z",
+            tags: ["updates", "custom"],
+          },
+        ],
       };
     </script>
   </body>

--- a/spec/lib/html2rss/auto_source/scraper/json_state_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper/json_state_spec.rb
@@ -101,10 +101,11 @@ RSpec.describe Html2rss::AutoSource::Scraper::JsonState do
       let(:parsed_body) { Nokogiri::HTML(load_fixture('nested_array.html')) }
 
       it 'finds articles nested inside array entries' do
-        expect(articles).to contain_exactly(a_hash_including(title: 'Nested article',
-                                                             url: Html2rss::Url.from_relative(
-                                                               '/nested/article', base_url
-                                                             )))
+        expect(articles).to contain_exactly(a_hash_including(
+                                              title: 'Nested article',
+                                              url: Html2rss::Url.from_relative('/nested/article',
+                                                                               base_url)
+                                            ))
       end
     end
   end

--- a/spec/lib/html2rss/auto_source/scraper/json_state_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper/json_state_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+RSpec.describe Html2rss::AutoSource::Scraper::JsonState do
+  let(:base_url) { Html2rss::Url.from_relative('https://example.com', 'https://example.com') }
+
+  def load_fixture(name)
+    file = File.join(__dir__, '../../../..', 'fixtures/auto_source/json_state', name)
+    File.read(file)
+  end
+
+  describe '.articles?' do
+    it 'detects Next.js JSON state' do
+      parsed_body = Nokogiri::HTML(load_fixture('next.html'))
+
+      expect(described_class.articles?(parsed_body)).to be(true)
+    end
+
+    it 'detects Nuxt JSON state' do
+      parsed_body = Nokogiri::HTML(load_fixture('nuxt.html'))
+
+      expect(described_class.articles?(parsed_body)).to be(true)
+    end
+
+    it 'detects custom window state blobs' do
+      parsed_body = Nokogiri::HTML(load_fixture('state.html'))
+
+      expect(described_class.articles?(parsed_body)).to be(true)
+    end
+
+    it 'returns false when no JSON state is present' do
+      parsed_body = Nokogiri::HTML('<html><body><script>console.log("hello")</script></body></html>')
+
+      expect(described_class.articles?(parsed_body)).to be(false)
+    end
+  end
+
+  describe '#each' do
+    subject(:articles) { described_class.new(parsed_body, url: base_url).each.to_a }
+
+    context 'with Next.js data' do
+      let(:parsed_body) { Nokogiri::HTML(load_fixture('next.html')) }
+
+      it 'normalises the article data' do
+        expect(articles.size).to eq(1)
+
+        article = articles.first
+        expect(article[:title]).to eq('Next.js powers the latest headlines')
+        expect(article[:description]).to eq('A summary sourced from Next.js JSON state.')
+        expect(article[:url]).to eq(Html2rss::Url.from_relative('/next/headline', base_url))
+        expect(article[:image]).to eq(Html2rss::Url.from_relative('https://cdn.example.com/images/next/headline.jpg', base_url))
+        expect(article[:published_at]).to eq('2024-04-01T12:00:00Z')
+        expect(article[:categories]).to eq(%w[nextjs spa])
+        expect(article[:id]).to eq('next-article-1')
+      end
+    end
+
+    context 'with Nuxt data' do
+      let(:parsed_body) { Nokogiri::HTML(load_fixture('nuxt.html')) }
+
+      it 'extracts relative URLs and nested categories' do
+        expect(articles.size).to eq(1)
+
+        article = articles.first
+        expect(article[:title]).to eq('Nuxt article arrives')
+        expect(article[:description]).to eq('Nuxt.js embeds article data into a global.')
+        expect(article[:url]).to eq(Html2rss::Url.from_relative('/nuxt/article', base_url))
+        expect(article[:image]).to eq(Html2rss::Url.from_relative('/images/nuxt/article.jpg', base_url))
+        expect(article[:published_at]).to eq('2024-04-02T10:00:00Z')
+        expect(article[:categories]).to eq(%w[nuxt spa])
+        expect(article[:id]).to eq('https://example.com/nuxt/article')
+      end
+    end
+
+    context 'with custom window state' do
+      let(:parsed_body) { Nokogiri::HTML(load_fixture('state.html')) }
+
+      it 'handles bespoke globals' do
+        expect(articles.size).to eq(1)
+
+        article = articles.first
+        expect(article[:title]).to eq('Window state update')
+        expect(article[:description]).to eq('Content embedded in a custom window.STATE blob.')
+        expect(article[:url]).to eq(Html2rss::Url.from_relative('/state/update', base_url))
+        expect(article[:image]).to eq(Html2rss::Url.from_relative('/images/state/update.png', base_url))
+        expect(article[:published_at]).to eq('2024-04-03T08:30:00Z')
+        expect(article[:categories]).to eq(%w[updates custom])
+        expect(article[:id]).to eq('state-post-42')
+      end
+    end
+  end
+end

--- a/spec/lib/html2rss/auto_source/scraper/json_state_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper/json_state_spec.rb
@@ -12,25 +12,25 @@ RSpec.describe Html2rss::AutoSource::Scraper::JsonState do
     it 'detects Next.js JSON state' do
       parsed_body = Nokogiri::HTML(load_fixture('next.html'))
 
-      expect(described_class.articles?(parsed_body)).to be(true)
+      expect(described_class).to be_articles(parsed_body)
     end
 
     it 'detects Nuxt JSON state' do
       parsed_body = Nokogiri::HTML(load_fixture('nuxt.html'))
 
-      expect(described_class.articles?(parsed_body)).to be(true)
+      expect(described_class).to be_articles(parsed_body)
     end
 
     it 'detects custom window state blobs' do
       parsed_body = Nokogiri::HTML(load_fixture('state.html'))
 
-      expect(described_class.articles?(parsed_body)).to be(true)
+      expect(described_class).to be_articles(parsed_body)
     end
 
     it 'returns false when no JSON state is present' do
       parsed_body = Nokogiri::HTML('<html><body><script>console.log("hello")</script></body></html>')
 
-      expect(described_class.articles?(parsed_body)).to be(false)
+      expect(described_class).not_to be_articles(parsed_body)
     end
   end
 
@@ -40,51 +40,54 @@ RSpec.describe Html2rss::AutoSource::Scraper::JsonState do
     context 'with Next.js data' do
       let(:parsed_body) { Nokogiri::HTML(load_fixture('next.html')) }
 
-      it 'normalises the article data' do
-        expect(articles.size).to eq(1)
-
-        article = articles.first
-        expect(article[:title]).to eq('Next.js powers the latest headlines')
-        expect(article[:description]).to eq('A summary sourced from Next.js JSON state.')
-        expect(article[:url]).to eq(Html2rss::Url.from_relative('/next/headline', base_url))
-        expect(article[:image]).to eq(Html2rss::Url.from_relative('https://cdn.example.com/images/next/headline.jpg', base_url))
-        expect(article[:published_at]).to eq('2024-04-01T12:00:00Z')
-        expect(article[:categories]).to eq(%w[nextjs spa])
-        expect(article[:id]).to eq('next-article-1')
+      it 'normalises the article data' do # rubocop:disable RSpec/ExampleLength
+        expect(articles).to contain_exactly(
+          a_hash_including(
+            title: 'Next.js powers the latest headlines',
+            description: 'A summary sourced from Next.js JSON state.',
+            url: Html2rss::Url.from_relative('/next/headline', base_url),
+            image: Html2rss::Url.from_relative('https://cdn.example.com/images/next/headline.jpg', base_url),
+            published_at: '2024-04-01T12:00:00Z',
+            categories: %w[nextjs spa],
+            id: 'next-article-1'
+          )
+        )
       end
     end
 
     context 'with Nuxt data' do
       let(:parsed_body) { Nokogiri::HTML(load_fixture('nuxt.html')) }
 
-      it 'extracts relative URLs and nested categories' do
-        expect(articles.size).to eq(1)
-
-        article = articles.first
-        expect(article[:title]).to eq('Nuxt article arrives')
-        expect(article[:description]).to eq('Nuxt.js embeds article data into a global.')
-        expect(article[:url]).to eq(Html2rss::Url.from_relative('/nuxt/article', base_url))
-        expect(article[:image]).to eq(Html2rss::Url.from_relative('/images/nuxt/article.jpg', base_url))
-        expect(article[:published_at]).to eq('2024-04-02T10:00:00Z')
-        expect(article[:categories]).to eq(%w[nuxt spa])
-        expect(article[:id]).to eq('https://example.com/nuxt/article')
+      it 'extracts relative URLs and nested categories' do # rubocop:disable RSpec/ExampleLength
+        expect(articles).to contain_exactly(
+          a_hash_including(
+            title: 'Nuxt article arrives',
+            description: 'Nuxt.js embeds article data into a global.',
+            url: Html2rss::Url.from_relative('/nuxt/article', base_url),
+            image: Html2rss::Url.from_relative('/images/nuxt/article.jpg', base_url),
+            published_at: '2024-04-02T10:00:00Z',
+            categories: %w[nuxt spa],
+            id: 'https://example.com/nuxt/article'
+          )
+        )
       end
     end
 
     context 'with custom window state' do
       let(:parsed_body) { Nokogiri::HTML(load_fixture('state.html')) }
 
-      it 'handles bespoke globals' do
-        expect(articles.size).to eq(1)
-
-        article = articles.first
-        expect(article[:title]).to eq('Window state update')
-        expect(article[:description]).to eq('Content embedded in a custom window.STATE blob.')
-        expect(article[:url]).to eq(Html2rss::Url.from_relative('/state/update', base_url))
-        expect(article[:image]).to eq(Html2rss::Url.from_relative('/images/state/update.png', base_url))
-        expect(article[:published_at]).to eq('2024-04-03T08:30:00Z')
-        expect(article[:categories]).to eq(%w[updates custom])
-        expect(article[:id]).to eq('state-post-42')
+      it 'handles bespoke globals' do # rubocop:disable RSpec/ExampleLength
+        expect(articles).to contain_exactly(
+          a_hash_including(
+            title: 'Window state update',
+            description: 'Content embedded in a custom window.STATE blob.',
+            url: Html2rss::Url.from_relative('/state/update', base_url),
+            image: Html2rss::Url.from_relative('/images/state/update.png', base_url),
+            published_at: '2024-04-03T08:30:00Z',
+            categories: %w[updates custom],
+            id: 'state-post-42'
+          )
+        )
       end
     end
   end

--- a/spec/lib/html2rss/auto_source/scraper/json_state_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper/json_state_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe Html2rss::AutoSource::Scraper::JsonState do
       expect(described_class).to be_articles(parsed_body)
     end
 
+    it 'detects arrays containing nested article arrays' do
+      parsed_body = Nokogiri::HTML(load_fixture('nested_array.html'))
+
+      expect(described_class).to be_articles(parsed_body)
+    end
+
     it 'returns false when no JSON state is present' do
       parsed_body = Nokogiri::HTML('<html><body><script>console.log("hello")</script></body></html>')
 
@@ -88,6 +94,17 @@ RSpec.describe Html2rss::AutoSource::Scraper::JsonState do
             id: 'state-post-42'
           )
         )
+      end
+    end
+
+    context 'with nested array data' do
+      let(:parsed_body) { Nokogiri::HTML(load_fixture('nested_array.html')) }
+
+      it 'finds articles nested inside array entries' do
+        expect(articles).to contain_exactly(a_hash_including(title: 'Nested article',
+                                                             url: Html2rss::Url.from_relative(
+                                                               '/nested/article', base_url
+                                                             )))
       end
     end
   end

--- a/spec/lib/html2rss/auto_source_spec.rb
+++ b/spec/lib/html2rss/auto_source_spec.rb
@@ -55,6 +55,14 @@ RSpec.describe Html2rss::AutoSource do
       expect(described_class::Config.call(described_class::DEFAULT_CONFIG)).to be_success
     end
 
+    it 'allows toggling the json_state scraper' do
+      config = described_class::DEFAULT_CONFIG.merge(
+        scraper: described_class::DEFAULT_CONFIG[:scraper].merge(json_state: { enabled: false })
+      )
+
+      expect(described_class::Config.call(config)).to be_success
+    end
+
     describe 'optional(:cleanup)' do
       let(:config) do
         config = described_class::DEFAULT_CONFIG.dup

--- a/spec/lib/html2rss/config_spec.rb
+++ b/spec/lib/html2rss/config_spec.rb
@@ -159,6 +159,7 @@ RSpec.describe Html2rss::Config do
               minimum_selector_frequency: 3,  # was explicitly set -> overrides default
               use_top_selectors: 5            # wasn't explicitly set -> default
             },
+            json_state: { enabled: true },    # wasn't explicitly set -> default
             rss_feed_detector: { enabled: true } # wasn't explicitly set -> default
           },
           cleanup: {


### PR DESCRIPTION
Completing #103 - scrape SPA application state.

---

This pull request introduces a new "JSON state" scraping capability to the core AutoSource feature, enabling automatic extraction of article data from modern single-page applications (SPAs) like Next.js, Nuxt, or custom global state blobs. It updates documentation, configuration, and test coverage to support and validate this new functionality.

#### AutoSource JSON State Scraper Feature

* Added a new `JsonState` scraper to `AutoSource` that detects and extracts article data from embedded JSON blobs in `<script type="application/json">` tags and well-known global variables (`window.__NEXT_DATA__`, `window.__NUXT__`, `window.STATE`). This enables robust support for SPAs that don't use semantic HTML for article content. (`lib/html2rss/auto_source/scraper/json_state.rb`)
* Updated the configuration and validation logic to allow enabling/disabling the `json_state` scraper, with sensible defaults and schema validation. (`lib/html2rss/auto_source.rb`) [[1]](diffhunk://#diff-58f175b10b42f06d3fffce32fccf4f66f0b044fbb69e46ed8c8d1756b0d056c0R25-R27) [[2]](diffhunk://#diff-58f175b10b42f06d3fffce32fccf4f66f0b044fbb69e46ed8c8d1756b0d056c0R48-R50)
* Improved documentation in `README.md` to describe the new auto-detection method and its limitations, including usage examples and configuration options. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R28) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L61-R61) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R70-R89)

#### Testing and Fixtures

* Added comprehensive RSpec tests for the new `JsonState` scraper, covering Next.js, Nuxt, custom state blobs, and nested arrays. (`spec/lib/html2rss/auto_source/scraper/json_state_spec.rb`)
* Included new HTML fixtures representing typical JSON state patterns found in SPAs for use in tests. (`spec/fixtures/auto_source/json_state/next.html`, `spec/fixtures/auto_source/json_state/nuxt.html`, `spec/fixtures/auto_source/json_state/state.html`) [[1]](diffhunk://#diff-c00cac17e01317a397772d3e5ac2bdc1529d954adc8dcd31ac8b4a534b2bb3a4R1-R25) [[2]](diffhunk://#diff-e9098be7a0d674fbbfabf9247351157d083543efb6c6db376648b213ced047faR1-R26) [[3]](diffhunk://#diff-d77101c7e3cfe8b8299807d3c674663c32e08863f4e36990cf0d856aff93de15R1-R20)

#### Configuration and Spec Updates

* Ensured configuration specs allow toggling the `json_state` scraper and reflect its default-enabled status. (`spec/lib/html2rss/auto_source_spec.rb`, `spec/lib/html2rss/config_spec.rb`) [[1]](diffhunk://#diff-7809e65605d7e586a2c9e501a8e221121c2e77ea9affaf268b3bbf3a394d57d3R58-R65) [[2]](diffhunk://#diff-95feb92e5a3a462e7eeb5e419ac22e6e17dc74fae506386c8e542441bfcb923eR162)

#### Dev Workflow Documentation

* Updated `.github/copilot-instructions.md` with additional RSpec best practices, including how to handle multiple expectations and avoid method definitions inside spec blocks.