### PR TITLE
Add fixture strategy to stabilize CLI specs

### DIFF
--- a/lib/html2rss.rb
+++ b/lib/html2rss.rb
@@ -61,8 +61,14 @@ module Html2rss
   private_class_method :build_config
 
   def self.fetch_response(config)
-    RequestService.execute(RequestService::Context.new(url: config.url, headers: config.headers),
-                           strategy: config.strategy)
+    RequestService.execute(
+      RequestService::Context.new(
+        url: config.url,
+        headers: config.headers,
+        options: config.request_options
+      ),
+      strategy: config.strategy
+    )
   end
   private_class_method :fetch_response
 

--- a/lib/html2rss/article_pipeline/processors/deduplicator.rb
+++ b/lib/html2rss/article_pipeline/processors/deduplicator.rb
@@ -25,11 +25,22 @@ module Html2rss
         private
 
         def deduplication_key(article)
-          [article.url&.to_s, article.id, article.title].find do |candidate|
-            next if candidate.nil?
+          id = normalize(article.id)
+          return id if id
 
-            candidate.respond_to?(:empty?) ? !candidate.empty? : true
-          end
+          url = normalize(article.url&.to_s)
+          return url if url
+
+          normalize(article.title)
+        end
+
+        def normalize(value)
+          return if value.nil?
+
+          string = value.respond_to?(:strip) ? value.strip : value.to_s
+          return if string.empty?
+
+          string
         end
       end
     end

--- a/lib/html2rss/config.rb
+++ b/lib/html2rss/config.rb
@@ -50,6 +50,7 @@ module Html2rss
         if params
           DynamicParams.call(config[:headers], params)
           DynamicParams.call(config[:channel], params)
+          DynamicParams.call(config[:request], params)
         end
 
         new(config)
@@ -64,6 +65,7 @@ module Html2rss
           strategy: RequestService.default_strategy_name,
           channel: { time_zone: 'UTC' },
           headers: {},
+          request: {},
           stylesheets: []
         }
       end
@@ -95,6 +97,7 @@ module Html2rss
     def stylesheets = config[:stylesheets]
 
     def headers = config[:headers]
+    def request_options = config[:request]
 
     def channel = config[:channel]
     def url = config.dig(:channel, :url)

--- a/lib/html2rss/config/validator.rb
+++ b/lib/html2rss/config/validator.rb
@@ -26,10 +26,16 @@ module Html2rss
         optional(:media).maybe(:string)
       end
 
+      RequestConfig = Dry::Schema.Params do
+        optional(:fixture).filled(:string)
+        optional(:content_type).maybe(:string)
+      end
+
       params do
         required(:strategy).filled(:symbol)
         required(:channel).hash(ChannelConfig)
         optional(:headers).hash
+        optional(:request).hash(RequestConfig)
         optional(:stylesheets).array(StylesheetConfig)
         optional(:auto_source).hash(AutoSource::Config)
         optional(:selectors).hash

--- a/lib/html2rss/request_service.rb
+++ b/lib/html2rss/request_service.rb
@@ -32,7 +32,8 @@ module Html2rss
     def initialize
       @strategies = {
         faraday: FaradayStrategy,
-        browserless: BrowserlessStrategy
+        browserless: BrowserlessStrategy,
+        fixture: FixtureStrategy
       }
       @default_strategy_name = :faraday
     end

--- a/lib/html2rss/request_service/context.rb
+++ b/lib/html2rss/request_service/context.rb
@@ -9,10 +9,12 @@ module Html2rss
       ##
       # @param url [String, Html2rss::Url] the URL to request
       # @param headers [Hash] HTTP request headers
-      def initialize(url:, headers: {})
+      # @param options [Hash] additional options for the request strategy
+      def initialize(url:, headers: {}, options: {})
         @url = Html2rss::Url.from_relative(url, url)
 
         @headers = headers
+        @options = options || {}
       end
 
       # @return [Html2rss::Url] the parsed and normalized URL
@@ -20,6 +22,9 @@ module Html2rss
 
       # @return [Hash] the HTTP request headers
       attr_reader :headers
+
+      # @return [Hash] strategy-specific options
+      attr_reader :options
     end
   end
 end

--- a/lib/html2rss/request_service/fixture_strategy.rb
+++ b/lib/html2rss/request_service/fixture_strategy.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'pathname'
+
+module Html2rss
+  class RequestService
+    # Strategy that returns fixture content for offline or deterministic testing.
+    class FixtureStrategy < Strategy
+      DEFAULT_CONTENT_TYPE = 'text/html'
+
+      # @return [Response]
+      def execute
+        path = resolve_fixture_path
+        body = path.read
+        content_type = ctx.options.fetch(:content_type, DEFAULT_CONTENT_TYPE)
+
+        Response.new(
+          body:,
+          headers: { 'content-type' => content_type },
+          url: ctx.url
+        )
+      end
+
+      private
+
+      def resolve_fixture_path
+        raw_path = ctx.options[:fixture]
+        raise ArgumentError, 'Fixture strategy requires :fixture option' unless raw_path
+
+        path = Pathname.new(raw_path)
+        path = Pathname.new(Dir.pwd).join(path) unless path.absolute?
+
+        return path if path.file?
+
+        raise ArgumentError, "Fixture file not found: #{path}"
+      end
+    end
+  end
+end

--- a/spec/examples/multilang_site.yml
+++ b/spec/examples/multilang_site.yml
@@ -13,6 +13,13 @@ selectors:
     post_process:
       - name: "template"
         string: "[%<language>s] %<self>s"
+  id:
+    selector: ".lang"
+    extractor: "attribute"
+    attribute: "data-lang"
+    post_process:
+      - name: "template"
+        string: "%<self>s-%<title>s"
   language:
     selector: ".lang"
     extractor: "attribute"

--- a/spec/examples/withparams.html
+++ b/spec/examples/withparams.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Daily Horoscope</title>
+  </head>
+  <body>
+    <main>
+      <div class="main-horoscope">
+        <p>The cosmos align perfectly. Your lucky number is 10 and the param is value.</p>
+        <a id="src-horo-today" href="https://www.horoscope.com/us/horoscopes/general/horoscope-general-daily-today.aspx?sign=10">
+          Read more
+        </a>
+      </div>
+    </main>
+  </body>
+</html>

--- a/spec/fixtures/feeds.test.yml
+++ b/spec/fixtures/feeds.test.yml
@@ -115,6 +115,10 @@ feeds:
         selector: "#src-horo-today"
         extractor: "href"
   withparams:
+    strategy: fixture
+    request:
+      fixture: spec/examples/withparams.html
+      content_type: text/html
     channel:
       url: https://www.horoscope.com/us/horoscopes/general/horoscope-general-daily-today.aspx?sign=%<sign>s
       description: "The value of param is: %<param>s"


### PR DESCRIPTION
## Summary
- add a fixture-backed request strategy so CLI specs can run offline and extend config defaults/validation for request options
- normalize deduplication keys while preferring article IDs to preserve multi-language feeds and add deterministic IDs to the example config
- provide a local HTML fixture and update the demo feed to use the new fixture strategy in CLI coverage

## Testing
- bundle exec rspec
- bundle exec rubocop
- bundle exec reek

------
https://chatgpt.com/codex/tasks/task_e_68e57227e638832da597fae1afda4f2e