### PR TITLE
Hard-code fixture expectations in example specs

### DIFF
--- a/spec/examples/conditional_processing_spec.rb
+++ b/spec/examples/conditional_processing_spec.rb
@@ -1,100 +1,98 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'time'
 
 RSpec.describe 'Conditional Processing Configuration' do
   subject(:feed) do
-    # Mock the request service to return our HTML fixture
     mock_request_service_with_html_fixture('conditional_processing_site', 'https://example.com')
-
     Html2rss.feed(config)
   end
 
   let(:config_file) { File.join(%w[spec examples conditional_processing_site.yml]) }
   let(:html_file) { File.join(%w[spec examples conditional_processing_site.html]) }
   let(:config) { Html2rss.config_from_yaml_file(config_file) }
-
+  let(:channel_url) { config.dig(:channel, :url) }
   let(:items) { feed.items }
-  let(:titles) { items.map(&:title) }
 
-  it 'generates a valid RSS feed', :aggregate_failures do
-    expect(feed).to be_a(RSS::Rss)
+  let(:expected_titles) do
+    [
+      "Breaking News: ACME Corp's New Debugging Tool",
+      "Draft Article: ACME Corp's Green Coding Initiative",
+      "Archived Article: ACME Corp's Economic Analysis of Bug Fixes",
+      "ACME Corp's Developer Health and Wellness Guide",
+      "Pending Article: ACME Corp's Annual Code Golf Tournament",
+      "ACME Corp's Article Without Status (Status: Unknown)"
+    ]
+  end
+
+  let(:expected_links) do
+    [
+      'https://example.com/articles/technology-update',
+      'https://example.com/articles/environmental-research',
+      'https://example.com/articles/economic-analysis',
+      'https://example.com/articles/health-wellness',
+      'https://example.com/articles/sports-update',
+      'https://example.com/articles/no-status'
+    ]
+  end
+
+  let(:expected_descriptions) do
+    [
+      "[Status: Published] This is a published article about ACME Corp's latest debugging tool that can find bugs before they're even written. The content includes detailed information about recent developments in the tech industry. It's so advanced, it can predict when you'll need coffee. Additional content that provides more context and depth to the story. The tool also comes with a built-in rubber duck that actually quacks when you're stuck.",
+      "[Status: Draft] This is a draft article about ACME Corp's environmental research into carbon-neutral coding practices. It contains preliminary findings and is not yet ready for publication. They're trying to make infinite loops actually infinite without using infinite energy. More content that will be refined before the final publication. The research shows that using tabs instead of spaces can reduce your carbon footprint by 0.0001%.",
+      "[Status: Archived] This is an archived article about ACME Corp's economic analysis of bug fixes. It was previously published but is now archived for historical reference. The study found that 99% of bugs are caused by cosmic rays and the remaining 1% are caused by developers. Additional archived content that provides historical context. The research concluded that the most expensive bug in history was a missing semicolon that cost $1.2 billion.",
+      "[Status: Published] This is a comprehensive health and wellness guide for developers. It provides expert recommendations for maintaining good health while coding. Remember: coffee is not a food group, but it is a lifestyle choice. Additional health tips and recommendations for readers. Pro tip: Standing desks are great, but standing on your head while coding is not recommended.",
+      "[Status: Pending] This is a pending article about ACME Corp's annual code golf tournament. It's waiting for final approval before publication. The winner gets a lifetime supply of coffee and a rubber duck that never quacks. Content that will be reviewed and potentially modified before going live. The tournament features events like \"Write a sorting algorithm in one line\" and \"Debug this code blindfolded\".",
+      "[Status: ] This article doesn't have a status field, so it should use a fallback or empty value in the template. It's like a function that returns void but actually returns null. This tests how the template handles missing values. In programming terms, this is the equivalent of a null pointer exception waiting to happen."
+    ]
+  end
+
+  let(:expected_categories) do
+    [
+      ['Published'],
+      ['Draft'],
+      ['Archived'],
+      ['Published'],
+      ['Pending'],
+      []
+    ]
+  end
+
+  let(:expected_pubdates) do
+    [
+      'Mon, 15 Jan 2024 10:30:00 +0000',
+      'Sun, 14 Jan 2024 14:20:00 +0000',
+      'Sat, 13 Jan 2024 09:15:00 +0000',
+      'Fri, 12 Jan 2024 08:30:00 +0000',
+      'Thu, 11 Jan 2024 16:45:00 +0000',
+      'Wed, 10 Jan 2024 12:00:00 +0000'
+    ]
+  end
+
+  it 'publishes the configured channel metadata' do
     expect(feed.channel.title).to eq('ACME Conditional Processing Site News')
     expect(feed.channel.link).to eq('https://example.com')
   end
 
-  it 'extracts all 6 items from the HTML fixture', :aggregate_failures do
-    expect(feed.items).to be_an(Array)
-    expect(feed.items.size).to eq(6)
+  it 'renders templated descriptions that expose the item status', :aggregate_failures do
+    expect(items.map(&:description)).to eq(expected_descriptions)
+    expect(items.map { |item| item.categories.map(&:content) }).to eq(expected_categories)
   end
 
-  it 'extracts titles correctly', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    titles = items.map(&:title)
-    expect(titles).to all(be_a(String)).and all(satisfy { |title| !title.strip.empty? })
-    expect(titles).to include('Breaking News: ACME Corp\'s New Debugging Tool',
-                              'Draft Article: ACME Corp\'s Green Coding Initiative',
-                              'Archived Article: ACME Corp\'s Economic Analysis of Bug Fixes',
-                              'ACME Corp\'s Developer Health and Wellness Guide',
-                              'Pending Article: ACME Corp\'s Annual Code Golf Tournament',
-                              'ACME Corp\'s Article Without Status (Status: Unknown)')
+  it 'produces stable item identifiers and links for every article' do
+    expect(items.size).to eq(expected_titles.size)
+    expect(items.map(&:title)).to eq(expected_titles)
+    expect(items.map(&:link)).to eq(expected_links)
   end
 
-  it 'extracts URLs correctly', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    urls = items.map(&:link)
-    expect(urls).to all(be_a(String)).and all(satisfy { |url| !url.strip.empty? })
-    expect(urls).to include('https://example.com/articles/technology-update',
-                            'https://example.com/articles/environmental-research',
-                            'https://example.com/articles/economic-analysis',
-                            'https://example.com/articles/health-wellness',
-                            'https://example.com/articles/sports-update',
-                            'https://example.com/articles/no-status')
+  it 'parses ISO timestamps emitted by the editorial system' do
+    expect(items.map { |item| item.pubDate.rfc2822 }).to eq(expected_pubdates)
   end
 
-  it 'extracts published dates correctly', :aggregate_failures do
-    items_with_time = items.select(&:pubDate)
-    expect(items_with_time.size).to be > 0
-    expect(items_with_time).to all(have_attributes(pubDate: be_a(Time)))
-  end
-
-  it 'applies template post-processing with status interpolation', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    items = feed.items
-    descriptions = items.map(&:description)
-    expect(descriptions).to all(be_a(String)).and all(satisfy { |desc| !desc.strip.empty? })
-    expect(items.count { |item| item.description.include?('[Status: Published]') }).to be >= 2
-    expect(items.count { |item| item.description.include?('[Status: Draft]') }).to be >= 1
-    expect(items.count { |item| item.description.include?('[Status: Archived]') }).to be >= 1
-    expect(items.count { |item| item.description.include?('[Status: Pending]') }).to be >= 1
-  end
-
-  it 'handles missing status values in template gracefully', :aggregate_failures do
-    items = feed.items
-
-    # Find the item without status (should have empty status in template)
-    no_status_item = items.find { |item| item.title.include?('Without Status') }
-    expect(no_status_item).not_to be_nil
-
-    # The template should handle missing status gracefully
-    expect(no_status_item.description).to include('[Status: ]')
-  end
-
-  it 'extracts status information as categories', :aggregate_failures do
-    items_with_status = items.select { |item| item.categories.any? { |cat| cat.content.is_a?(String) } }
-    expect(items_with_status.size).to be >= 5
-    status_categories = items.flat_map(&:categories).filter_map(&:content)
-    expect(status_categories).to include('Published', 'Draft', 'Archived', 'Pending')
-  end
-
-  it 'validates that template post-processing preserves original content', :aggregate_failures do
-    items = feed.items
-    expect(items).to all(have_attributes(description: be_a(String).and(satisfy { |desc|
-      desc.length > 50
-    }).and(match(/\[Status: [^\]]*\]/))))
-  end
-
-  it 'handles different status values correctly in categories', :aggregate_failures do
-    expect(items.count { |item| item.categories.any? { |cat| cat.content == 'Published' } }).to be >= 2
-    expect(items.count { |item| item.categories.any? { |cat| cat.content == 'Draft' } }).to be >= 1
-    expect(items.count { |item| item.categories.any? { |cat| cat.content == 'Archived' } }).to be >= 1
-    expect(items.count { |item| item.categories.any? { |cat| cat.content == 'Pending' } }).to be >= 1
+  it 'gracefully handles missing statuses in both the template output and category list' do
+    empty_status_item = items.find { |item| item.title.include?('Without Status') }
+    expect(empty_status_item.description).to start_with('[Status: ]')
+    expect(empty_status_item.categories).to be_empty
   end
 end

--- a/spec/examples/dynamic_content_site_spec.rb
+++ b/spec/examples/dynamic_content_site_spec.rb
@@ -4,107 +4,81 @@ require 'spec_helper'
 
 RSpec.describe 'Dynamic Content Site Configuration' do
   subject(:feed) do
-    # Mock the request service to return our HTML fixture
     mock_request_service_with_html_fixture('dynamic_content_site', 'https://example.com/news')
-
     Html2rss.feed(config)
   end
 
   let(:config_file) { File.join(%w[spec examples dynamic_content_site.yml]) }
-  let(:html_file) { File.join(%w[spec examples dynamic_content_site.html]) }
   let(:config) { Html2rss.config_from_yaml_file(config_file) }
-
+  let(:channel_url) { config.dig(:channel, :url) }
+  let(:time_zone) { config.dig(:channel, :time_zone) }
   let(:items) { feed.items }
+  let(:expected_titles) do
+    [
+      "ACME Corp's Revolutionary AI Breakthrough Changes Everything",
+      "ACME Corp's Green Coding Summit Reaches Historic Agreement",
+      "ACME Corp's Space Exploration Mission Discovers New Planet",
+      "ACME Corp's Medical Breakthrough Offers Hope for Bug Patients",
+      "ACME Corp's Renewable Energy Reaches New Milestone",
+      "ACME Corp's Cybersecurity Threats Reach All-Time High"
+    ]
+  end
 
-  it 'generates a valid RSS feed', :aggregate_failures do
-    expect(feed).to be_a(RSS::Rss)
+  let(:expected_links) do
+    [
+      'https://example.com/articles/ai-breakthrough-2024',
+      'https://example.com/articles/climate-summit-2024',
+      'https://example.com/articles/space-mission-discovery',
+      'https://example.com/articles/cancer-treatment-breakthrough',
+      'https://example.com/articles/renewable-energy-milestone',
+      'https://example.com/articles/cybersecurity-threats-2024'
+    ]
+  end
+
+  let(:expected_descriptions) do
+    [
+      "ACME Corp scientists have developed a new artificial intelligence system that can process natural language with unprecedented accuracy. This breakthrough promises to revolutionize how we interact with technology. It can finally understand \"it works on my machine\" and translate it to \"it's broken in production\". The system uses advanced neural networks and machine learning algorithms to understand context and nuance in human communication. It also knows when you're lying about your commit messages.",
+      "ACME Corp leaders have reached a groundbreaking agreement on green coding practices. The new accord includes ambitious targets for reducing infinite loops and adopting renewable energy for servers. This historic agreement represents a turning point in global coding policy and sets the stage for significant changes in how developers approach sustainability. They're banning tabs in favor of spaces to save trees.",
+      "ACME Corp's latest space exploration mission has discovered a potentially habitable planet in a nearby star system. The planet, designated ACME-442b, shows promising signs of having liquid water and a stable atmosphere. It also has excellent WiFi coverage. This discovery opens up new possibilities for future space exploration and the search for extraterrestrial life. The planet's inhabitants are reportedly very good at debugging code.",
+      "ACME Corp researchers have developed a new debugging treatment that shows remarkable success in treating previously untreatable forms of bugs. The treatment uses the developer's own immune system to target bug cells. Clinical trials have shown a 75% success rate in developers with advanced-stage bugs, offering new hope for millions of programmers worldwide. The treatment involves lots of coffee and rubber ducks.",
+      "ACME Corp's renewable energy sources now account for over 50% of global electricity generation for the first time in history. This milestone represents a major shift towards sustainable energy production. They're powering servers with coffee beans. Solar and wind power have led this transformation, with costs dropping dramatically over the past decade and efficiency continuing to improve. The wind turbines are powered by the hot air from marketing meetings.",
+      "ACME Corp cybersecurity experts report that cyber threats have reached unprecedented levels, with sophisticated attacks targeting critical infrastructure and government systems worldwide. The most dangerous threat is still developers using \"password123\". Organizations are being urged to implement stronger security measures and invest in advanced threat detection systems to protect against these evolving risks. ACME Corp recommends using \"password1234\" instead."
+    ]
+  end
+
+  let(:expected_pubdates) do
+    [
+      'Mon, 15 Jan 2024 14:30:00 -0500',
+      'Sun, 14 Jan 2024 09:15:00 -0500',
+      'Sat, 13 Jan 2024 16:45:00 -0500',
+      'Fri, 12 Jan 2024 11:20:00 -0500',
+      'Thu, 11 Jan 2024 15:10:00 -0500',
+      'Wed, 10 Jan 2024 08:30:00 -0500'
+    ]
+  end
+
+  it 'builds the channel with the configured metadata' do
     expect(feed.channel.title).to eq('ACME Dynamic Content Site News')
     expect(feed.channel.link).to eq('https://example.com/news')
+    expect(feed.channel.generator).to include('Selectors')
   end
 
-  it 'extracts all 6 articles from the dynamic content', :aggregate_failures do
-    expect(feed.items).to be_an(Array)
-    expect(feed.items.size).to eq(6)
+  it 'extracts every rendered article with sanitized descriptions and parsed timestamps', :aggregate_failures do
+    expect(items.size).to eq(expected_titles.size)
+    expect(items.map(&:title)).to eq(expected_titles)
+    expect(items.map(&:link)).to eq(expected_links)
+    expect(items.map(&:description)).to eq(expected_descriptions)
+    expect(items.map { |item| item.pubDate.rfc2822 }).to eq(expected_pubdates)
   end
 
-  it 'extracts titles correctly from dynamic content', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    titles = items.map(&:title)
-    expect(titles).to all(be_a(String)).and all(satisfy { |title| !title.strip.empty? })
-    expect(titles).to include('ACME Corp\'s Revolutionary AI Breakthrough Changes Everything',
-                              'ACME Corp\'s Green Coding Summit Reaches Historic Agreement',
-                              'ACME Corp\'s Space Exploration Mission Discovers New Planet',
-                              'ACME Corp\'s Medical Breakthrough Offers Hope for Bug Patients',
-                              'ACME Corp\'s Renewable Energy Reaches New Milestone',
-                              'ACME Corp\'s Cybersecurity Threats Reach All-Time High')
-  end
-
-  it 'extracts URLs correctly from dynamic content', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    urls = items.map(&:link)
-    expect(urls).to all(be_a(String)).and all(satisfy { |url| !url.strip.empty? })
-    expect(urls).to include('https://example.com/articles/ai-breakthrough-2024',
-                            'https://example.com/articles/climate-summit-2024',
-                            'https://example.com/articles/space-mission-discovery',
-                            'https://example.com/articles/cancer-treatment-breakthrough',
-                            'https://example.com/articles/renewable-energy-milestone',
-                            'https://example.com/articles/cybersecurity-threats-2024')
-  end
-
-  it 'extracts descriptions correctly with HTML sanitization', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    descriptions = items.map(&:description)
-    expect(descriptions).to all(be_a(String)).and all(satisfy { |desc| !desc.strip.empty? }).and all(satisfy { |desc|
-      !desc.match(/<[^>]+>/)
-    })
+  it 'captures the long-form excerpts exactly as rendered on the site' do
     ai_article = items.find { |item| item.title.include?('AI Breakthrough') }
-    expect(ai_article.description).to include('ACME Corp scientists have developed', 'artificial intelligence system')
+    expect(ai_article.description).to include('It also knows when you\'re lying about your commit messages.')
+    expect(ai_article.description).to include('translate it to "it\'s broken in production".')
   end
 
-  it 'extracts published dates correctly from timestamps', :aggregate_failures do
-    items_with_time = items.select(&:pubDate)
-    expect(items_with_time.size).to eq(6)
-    expect(items_with_time).to all(have_attributes(pubDate: be_a(Time).and(have_attributes(year: 2024))))
-  end
-
-  it 'handles dynamic content loading with browserless strategy', :aggregate_failures do
-    expect(config[:strategy]).to eq('browserless')
-    expect(items.size).to eq(6)
-    expect(items).to all(have_attributes(title: be_a(String)))
-    expect(items).to all(have_attributes(description: be_a(String)))
-    expect(items).to all(have_attributes(pubDate: be_a(Time)))
-  end
-
-  it 'validates that .article-card selector works correctly', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    doc = Nokogiri::HTML(File.read(html_file))
-    article_cards = doc.css('.article-card')
-    expect(article_cards.size).to eq(6)
-    card_titles = article_cards.filter_map { |card| card.at('h2')&.text }
-    expect(card_titles).to include('ACME Corp\'s Revolutionary AI Breakthrough Changes Everything',
-                                   'ACME Corp\'s Green Coding Summit Reaches Historic Agreement',
-                                   'ACME Corp\'s Space Exploration Mission Discovers New Planet')
-  end
-
-  it 'handles content that would normally be hidden by JavaScript', :aggregate_failures do
-    expect(items).to all(have_attributes(title: be_a(String), description: be_a(String), link: be_a(String)))
-    expect(items.size).to eq(6)
-  end
-
-  it 'validates that excerpt content is properly extracted and sanitized', :aggregate_failures do
-    items.each do |item|
-      # Excerpt should be extracted from .excerpt class
-      expect(item.description).to be_a(String)
-      expect(item.description.length).to be > 50
-
-      # Should contain ACME Corp references
-      expect(item.description).to include('ACME Corp')
-    end
-  end
-
-  it 'handles timestamp parsing from various formats', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    items_with_time = items.select(&:pubDate)
-    expect(items_with_time.size).to eq(6)
-    expect(items_with_time).to all(have_attributes(pubDate: be_a(Time).and(have_attributes(
-                                                                             year: 2024,
-                                                                             month: be_between(1, 12),
-                                                                             day: be_between(1, 31)
-                                                                           ))))
+  it 'preserves temporal ordering using the configured time zone' do
+    expect(items.map(&:pubDate)).to eq(items.map(&:pubDate).sort.reverse)
+    expect(items.first.pubDate.utc_offset).to eq(-18_000)
   end
 end

--- a/spec/examples/json_api_site_spec.rb
+++ b/spec/examples/json_api_site_spec.rb
@@ -1,115 +1,251 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'json'
+require 'time'
 
 RSpec.describe 'JSON API Site Configuration' do
   subject(:feed) do
-    # Mock the request service to return our JSON fixture
     mock_request_service_with_json_fixture('json_api_site', 'https://example.com/posts')
-
     Html2rss.feed(config)
   end
 
   let(:config_file) { File.join(%w[spec examples json_api_site.yml]) }
-  let(:json_file) { File.join(%w[spec examples json_api_site.json]) }
   let(:config) { Html2rss.config_from_yaml_file(config_file) }
-
+  let(:channel_url) { config.dig(:channel, :url) }
+  let(:time_zone) { config.dig(:channel, :time_zone) }
   let(:items) { feed.items }
+  let(:expected_titles) do
+    [
+      "ACME Corp's Revolutionary AI Breakthrough Changes Everything",
+      'Climate Change Summit Reaches Historic Agreement',
+      'Space Exploration Mission Discovers New Planet',
+      'Medical Breakthrough Offers Hope for Cancer Patients',
+      'Renewable Energy Reaches New Milestone',
+      'Cybersecurity Threats Reach All-Time High'
+    ]
+  end
 
-  it 'generates a valid RSS feed', :aggregate_failures do
-    expect(feed).to be_a(RSS::Rss)
+  let(:expected_descriptions) do
+    [
+      <<~HTML.chomp,
+        <img src="https://example.com/images/ai-breakthrough.jpg" alt="ACME Corp&#39;s Revolutionary AI Breakthrough Changes Everything" title="ACME Corp&#39;s Revolutionary AI Breakthrough Changes Everything" loading="lazy" referrerpolicy="no-referrer" decoding="async" crossorigin="anonymous">
+
+        ACME Corp scientists have developed a new artificial intelligence system that can process natural language with unprecedented accuracy. This breakthrough promises to revolutionize how we interact with technology. It can finally understand 'it works on my machine' and translate it to 'it's broken in production'. The system uses advanced neural networks and machine learning algorithms to understand context and nuance in human communication. It also knows when you're lying about your commit messages.
+
+        <details>
+          <summary>Available resources</summary>
+          <table>
+          <thead>
+            <tr>
+              <th>Type</th>
+              <th>URL</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+          <td>🖼️ Image</td>
+          <td><a href="https://example.com/images/ai-breakthrough.jpg" target="_blank" rel="nofollow noopener noreferrer">https://example.com/images/ai-breakthrough.jpg</a></td>
+          <td><a href="https://example.com/images/ai-breakthrough.jpg" target="_blank" rel="nofollow noopener noreferrer">View</a> |
+        <a href="https://example.com/images/ai-breakthrough.jpg" target="_blank" rel="nofollow noopener noreferrer" download="">Download</a></td>
+        </tr>
+          </tbody>
+        </table>
+        </details>
+      HTML
+      <<~HTML.chomp,
+        <img src="https://example.com/images/climate-summit.jpg" alt="Climate Change Summit Reaches Historic Agreement" title="Climate Change Summit Reaches Historic Agreement" loading="lazy" referrerpolicy="no-referrer" decoding="async" crossorigin="anonymous">
+
+        World leaders have reached a groundbreaking agreement on climate change mitigation strategies. The new accord includes ambitious targets for carbon reduction and renewable energy adoption. This historic agreement represents a turning point in global environmental policy and sets the stage for significant changes in how nations approach sustainability.
+
+        <details>
+          <summary>Available resources</summary>
+          <table>
+          <thead>
+            <tr>
+              <th>Type</th>
+              <th>URL</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+          <td>🖼️ Image</td>
+          <td><a href="https://example.com/images/climate-summit.jpg" target="_blank" rel="nofollow noopener noreferrer">https://example.com/images/climate-summit.jpg</a></td>
+          <td><a href="https://example.com/images/climate-summit.jpg" target="_blank" rel="nofollow noopener noreferrer">View</a> |
+        <a href="https://example.com/images/climate-summit.jpg" target="_blank" rel="nofollow noopener noreferrer" download="">Download</a></td>
+        </tr>
+          </tbody>
+        </table>
+        </details>
+      HTML
+      <<~HTML.chomp,
+        <img src="https://example.com/images/space-discovery.jpg" alt="Space Exploration Mission Discovers New Planet" title="Space Exploration Mission Discovers New Planet" loading="lazy" referrerpolicy="no-referrer" decoding="async" crossorigin="anonymous">
+
+        NASA's latest space exploration mission has discovered a potentially habitable planet in a nearby star system. The planet, designated Kepler-442b, shows promising signs of having liquid water and a stable atmosphere. This discovery opens up new possibilities for future space exploration and the search for extraterrestrial life.
+
+        <details>
+          <summary>Available resources</summary>
+          <table>
+          <thead>
+            <tr>
+              <th>Type</th>
+              <th>URL</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+          <td>🖼️ Image</td>
+          <td><a href="https://example.com/images/space-discovery.jpg" target="_blank" rel="nofollow noopener noreferrer">https://example.com/images/space-discovery.jpg</a></td>
+          <td><a href="https://example.com/images/space-discovery.jpg" target="_blank" rel="nofollow noopener noreferrer">View</a> |
+        <a href="https://example.com/images/space-discovery.jpg" target="_blank" rel="nofollow noopener noreferrer" download="">Download</a></td>
+        </tr>
+          </tbody>
+        </table>
+        </details>
+      HTML
+      <<~HTML.chomp,
+        <img src="https://example.com/images/cancer-research.jpg" alt="Medical Breakthrough Offers Hope for Cancer Patients" title="Medical Breakthrough Offers Hope for Cancer Patients" loading="lazy" referrerpolicy="no-referrer" decoding="async" crossorigin="anonymous">
+
+        Researchers have developed a new immunotherapy treatment that shows remarkable success in treating previously untreatable forms of cancer. The treatment uses the patient's own immune system to target cancer cells. Clinical trials have shown a 75% success rate in patients with advanced-stage cancer, offering new hope for millions of patients worldwide.
+
+        <details>
+          <summary>Available resources</summary>
+          <table>
+          <thead>
+            <tr>
+              <th>Type</th>
+              <th>URL</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+          <td>🖼️ Image</td>
+          <td><a href="https://example.com/images/cancer-research.jpg" target="_blank" rel="nofollow noopener noreferrer">https://example.com/images/cancer-research.jpg</a></td>
+          <td><a href="https://example.com/images/cancer-research.jpg" target="_blank" rel="nofollow noopener noreferrer">View</a> |
+        <a href="https://example.com/images/cancer-research.jpg" target="_blank" rel="nofollow noopener noreferrer" download="">Download</a></td>
+        </tr>
+          </tbody>
+        </table>
+        </details>
+      HTML
+      <<~HTML.chomp,
+        <img src="https://example.com/images/renewable-energy.jpg" alt="Renewable Energy Reaches New Milestone" title="Renewable Energy Reaches New Milestone" loading="lazy" referrerpolicy="no-referrer" decoding="async" crossorigin="anonymous">
+
+        Renewable energy sources now account for over 50% of global electricity generation for the first time in history. This milestone represents a major shift towards sustainable energy production. Solar and wind power have led this transformation, with costs dropping dramatically over the past decade and efficiency continuing to improve.
+
+        <details>
+          <summary>Available resources</summary>
+          <table>
+          <thead>
+            <tr>
+              <th>Type</th>
+              <th>URL</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+          <td>🖼️ Image</td>
+          <td><a href="https://example.com/images/renewable-energy.jpg" target="_blank" rel="nofollow noopener noreferrer">https://example.com/images/renewable-energy.jpg</a></td>
+          <td><a href="https://example.com/images/renewable-energy.jpg" target="_blank" rel="nofollow noopener noreferrer">View</a> |
+        <a href="https://example.com/images/renewable-energy.jpg" target="_blank" rel="nofollow noopener noreferrer" download="">Download</a></td>
+        </tr>
+          </tbody>
+        </table>
+        </details>
+      HTML
+      <<~HTML.chomp,
+        <img src="https://example.com/images/cybersecurity.jpg" alt="Cybersecurity Threats Reach All-Time High" title="Cybersecurity Threats Reach All-Time High" loading="lazy" referrerpolicy="no-referrer" decoding="async" crossorigin="anonymous">
+
+        Cybersecurity experts report that cyber threats have reached unprecedented levels, with sophisticated attacks targeting critical infrastructure and government systems worldwide. Organizations are being urged to implement stronger security measures and invest in advanced threat detection systems to protect against these evolving risks.
+
+        <details>
+          <summary>Available resources</summary>
+          <table>
+          <thead>
+            <tr>
+              <th>Type</th>
+              <th>URL</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+          <td>🖼️ Image</td>
+          <td><a href="https://example.com/images/cybersecurity.jpg" target="_blank" rel="nofollow noopener noreferrer">https://example.com/images/cybersecurity.jpg</a></td>
+          <td><a href="https://example.com/images/cybersecurity.jpg" target="_blank" rel="nofollow noopener noreferrer">View</a> |
+        <a href="https://example.com/images/cybersecurity.jpg" target="_blank" rel="nofollow noopener noreferrer" download="">Download</a></td>
+        </tr>
+          </tbody>
+        </table>
+        </details>
+      HTML
+    ]
+  end
+
+  let(:expected_categories) do
+    [
+      ['Technology', 'Artificial Intelligence', 'Machine Learning', 'Innovation'],
+      ['Environment', 'Climate Change', 'Sustainability', 'Policy'],
+      ['Science', 'Space Exploration', 'Astronomy', 'Discovery'],
+      ['Health', 'Cancer Research', 'Immunotherapy', 'Medical Breakthrough'],
+      ['Energy', 'Renewable Energy', 'Solar Power', 'Wind Power'],
+      ['Security', 'Cybersecurity', 'Threat Detection', 'Infrastructure Security']
+    ]
+  end
+
+  let(:expected_pubdates) do
+    [
+      'Mon, 15 Jan 2024 14:30:00 +0000',
+      'Sun, 14 Jan 2024 09:15:00 +0000',
+      'Sat, 13 Jan 2024 16:45:00 +0000',
+      'Fri, 12 Jan 2024 11:20:00 +0000',
+      'Thu, 11 Jan 2024 15:10:00 +0000',
+      'Wed, 10 Jan 2024 08:30:00 +0000'
+    ]
+  end
+
+  let(:expected_enclosures) do
+    [
+      ['https://example.com/images/ai-breakthrough.jpg', 'image/jpeg', 0],
+      ['https://example.com/images/climate-summit.jpg', 'image/jpeg', 0],
+      ['https://example.com/images/space-discovery.jpg', 'image/jpeg', 0],
+      ['https://example.com/images/cancer-research.jpg', 'image/jpeg', 0],
+      ['https://example.com/images/renewable-energy.jpg', 'image/jpeg', 0],
+      ['https://example.com/images/cybersecurity.jpg', 'image/jpeg', 0]
+    ]
+  end
+
+  it 'loads channel metadata from the configuration file' do
     expect(feed.channel.title).to eq('ACME JSON API Site News')
     expect(feed.channel.link).to eq('https://example.com/posts')
   end
 
-  it 'extracts all 6 items from the JSON API response', :aggregate_failures do
-    expect(feed.items).to be_an(Array)
-    expect(feed.items.size).to eq(6)
+  it 'materialises feed items directly from the API payload', :aggregate_failures do
+    expect(items.size).to eq(expected_titles.size)
+    expect(items.map(&:title)).to eq(expected_titles)
+    expect(items.map(&:description)).to eq(expected_descriptions)
+    expect(items.map { |item| item.pubDate.rfc2822 }).to eq(expected_pubdates)
   end
 
-  it 'extracts titles correctly from JSON data', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    titles = items.map(&:title)
-    expect(titles).to all(be_a(String)).and all(satisfy { |title| !title.strip.empty? })
-    expect(titles).to include('ACME Corp\'s Revolutionary AI Breakthrough Changes Everything',
-                              'Climate Change Summit Reaches Historic Agreement',
-                              'Space Exploration Mission Discovers New Planet',
-                              'Medical Breakthrough Offers Hope for Cancer Patients',
-                              'Renewable Energy Reaches New Milestone',
-                              'Cybersecurity Threats Reach All-Time High')
+  it 'exposes category and tag metadata as discrete RSS category entries' do
+    expect(items.map { |item| item.categories.map(&:content) })
+      .to eq(expected_categories)
   end
 
-  it 'extracts descriptions correctly with HTML to Markdown conversion', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    descriptions = items.map(&:description)
-    expect(descriptions).to all(be_a(String)).and all(satisfy { |desc| !desc.strip.empty? }).and all(satisfy { |desc|
-      desc.length > 50
-    })
-    ai_article = items.find { |item| item.title.include?('AI Breakthrough') }
-    expect(ai_article.description).to include('ACME Corp scientists have developed', 'artificial intelligence system')
+  it 'omits item links when no selector is configured' do
+    expect(items.map(&:link)).to all(be_nil)
   end
 
-  it 'handles URLs correctly (no URL selector configured)', :aggregate_failures do
-    urls = items.map(&:link)
-    # Since no URL selector is configured in the JSON API config, all URLs should be nil
-    expect(urls).to all(be_nil)
-  end
-
-  it 'extracts published dates correctly from ISO 8601 timestamps', :aggregate_failures do
-    items_with_time = items.select(&:pubDate)
-    expect(items_with_time.size).to eq(6)
-    expect(items_with_time).to all(have_attributes(pubDate: be_a(Time).and(have_attributes(year: 2024))))
-  end
-
-  it 'extracts author information correctly', :aggregate_failures do
-    items.each do |item|
-      # Author information should be available in the description or as a separate field
-      # Since the config doesn't specify author extraction, we test that items are valid
-      expect(item.title).to be_a(String)
-      expect(item.description).to be_a(String)
+  it 'attaches a media enclosure to every entry' do
+    actual_enclosures = items.map do |item|
+      enclosure = item.enclosure
+      [enclosure&.url, enclosure&.type, enclosure&.length]
     end
-  end
-
-  it 'keeps category and tag values as discrete RSS category entries', :aggregate_failures do
-    ai_article = items.find { |item| item.title.include?('AI Breakthrough') }
-    expect(ai_article).not_to be_nil
-
-    expect(ai_article.categories.map(&:content)).to contain_exactly('Technology', 'Artificial Intelligence',
-                                                                    'Machine Learning', 'Innovation')
-  end
-
-  it 'handles complex JSON structure with nested objects and arrays', :aggregate_failures do
-    expect(items.size).to eq(6)
-    expect(items).to all(have_attributes(title: be_a(String), description: be_a(String), pubDate: be_a(Time),
-                                         categories: be_an(Array)))
-  end
-
-  it 'handles enclosures correctly', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    expect(items).to all(have_attributes(title: be_a(String), description: be_a(String), pubDate: be_a(Time)))
-    items_with_enclosures = items.select(&:enclosure)
-    if items_with_enclosures.any?
-      expect(items_with_enclosures).to all(have_attributes(enclosure: have_attributes(url: be_a(String),
-                                                                                      type: be_a(String))))
-    end
-  end
-
-  it 'validates that JSON path selectors work correctly', :aggregate_failures do
-    # Test that the JSON path selectors are working
-    # data > array > object should select the items array
-    # title should select the title field
-    # content should select the content field
-    items.each do |item|
-      expect(item.title).to be_a(String)
-      expect(item.description).to be_a(String)
-      expect(item.pubDate).to be_a(Time)
-    end
-  end
-
-  it 'validates that HTML to Markdown conversion preserves content structure', :aggregate_failures do
-    items.each do |item|
-      # Content should be processed and have substantial content
-      expect(item.description.length).to be > 50
-
-      # Should contain some meaningful content (not all items mention ACME Corp)
-      expect(item.description).to be_a(String)
-    end
+    expect(actual_enclosures).to eq(expected_enclosures)
   end
 end

--- a/spec/examples/media_enclosures_spec.rb
+++ b/spec/examples/media_enclosures_spec.rb
@@ -1,114 +1,214 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'time'
 
-# This spec demonstrates the media enclosures configuration,
-# which handles podcast and video content with media enclosures,
-# duration extraction, and HTML to Markdown conversion.
 RSpec.describe 'Media Enclosures Configuration', type: :example do
-  # RSS feed generation tests
-  # These tests validate that the configuration successfully generates
-  # a valid RSS feed with proper media content extraction
   subject(:feed) { generate_feed_from_config(config, config_name, :html) }
 
   let(:config_name) { 'media_enclosures_site' }
   let(:config) { load_example_configuration(config_name) }
-
-  it 'generates a valid RSS feed' do
-    expect(feed).to be_a_valid_rss_feed
+  let(:items) { feed.items }
+  let(:expected_titles) do
+    [
+      'Episode 42: The Future of AI in Web Development',
+      'Episode 41: Building Scalable React Applications',
+      'Episode 40: Special - Interview with Tech Industry Leaders',
+      'Episode 39: Quick Tips for CSS Grid',
+      'Episode 38: Live Coding Session - Building a Todo App',
+      'Episode 37: Text-Only Episode - Reading List'
+    ]
   end
 
-  it 'extracts the correct number of episodes' do
-    expect(feed).to have_valid_items
+  let(:expected_links) do
+    [
+      'https://example.com/episodes/episode-42-ai-web-dev',
+      'https://example.com/episodes/episode-41-scalable-react',
+      'https://example.com/episodes/episode-40-special-interview',
+      'https://example.com/episodes/episode-39-css-grid-tips',
+      'https://example.com/episodes/episode-38-live-coding',
+      'https://example.com/episodes/episode-37-reading-list'
+    ]
   end
 
-  context 'with basic item content validation' do
-    it 'extracts titles correctly' do
-      expect(feed).to have_valid_titles
-    end
+  let(:expected_descriptions) do
+    [
+      <<~HTML.chomp,
+        <audio controls preload="none" referrerpolicy="no-referrer" crossorigin="anonymous">
+                    <source src="https://example.com/episodes/episode-42-ai-web-dev.mp3" type="audio/mpeg">
+                  </audio>
 
-    it 'extracts URLs correctly' do
-      expect(feed).to have_valid_links
-    end
+        In this episode, we explore how artificial intelligence is revolutionizing web development. We discuss the latest tools, frameworks, and methodologies that are changing the way developers build applications. Our guest speaker, Dr. Sarah Johnson, shares insights from her research on AI-assisted coding and the potential impact on the industry. Introduction to AI in web development Current tools and frameworks Future predictions and trends
 
-    it 'extracts descriptions correctly' do
-      expect(feed).to have_valid_descriptions
-    end
+        <details>
+          <summary>Available resources</summary>
+          <table>
+          <thead>
+            <tr>
+              <th>Type</th>
+              <th>URL</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+          <td>🎵 Audio</td>
+          <td><a href="https://example.com/episodes/episode-42-ai-web-dev.mp3" target="_blank" rel="nofollow noopener noreferrer">https://example.com/episodes/episode-42-ai-web-dev.mp3</a></td>
+          <td><a href="https://example.com/episodes/episode-42-ai-web-dev.mp3" target="_blank" rel="nofollow noopener noreferrer">Play</a> |
+        <a href="https://example.com/episodes/episode-42-ai-web-dev.mp3" target="_blank" rel="nofollow noopener noreferrer" download="">Download</a></td>
+        </tr>
+          </tbody>
+        </table>
+        </details>
+      HTML
+      <<~HTML.chomp,
+        <audio controls preload="none" referrerpolicy="no-referrer" crossorigin="anonymous">
+                    <source src="https://example.com/episodes/episode-41-scalable-react.mp3" type="audio/mpeg">
+                  </audio>
 
-    it 'extracts published dates correctly' do
-      expect(feed).to have_valid_published_dates
-    end
+        This episode covers best practices for building scalable React applications. We dive deep into performance optimization, state management, and architectural patterns. Topics include: Component optimization techniques State management strategies Code splitting and lazy loading Testing strategies for large applications
+
+        <details>
+          <summary>Available resources</summary>
+          <table>
+          <thead>
+            <tr>
+              <th>Type</th>
+              <th>URL</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+          <td>🎵 Audio</td>
+          <td><a href="https://example.com/episodes/episode-41-scalable-react.mp3" target="_blank" rel="nofollow noopener noreferrer">https://example.com/episodes/episode-41-scalable-react.mp3</a></td>
+          <td><a href="https://example.com/episodes/episode-41-scalable-react.mp3" target="_blank" rel="nofollow noopener noreferrer">Play</a> |
+        <a href="https://example.com/episodes/episode-41-scalable-react.mp3" target="_blank" rel="nofollow noopener noreferrer" download="">Download</a></td>
+        </tr>
+          </tbody>
+        </table>
+        </details>
+      HTML
+      <<~HTML.chomp,
+        <audio controls preload="none" referrerpolicy="no-referrer" crossorigin="anonymous">
+                    <source src="https://example.com/episodes/episode-40-special-interview.mp3" type="audio/mpeg">
+                  </audio>
+
+        In this special episode, we interview three tech industry leaders about the current state of technology and where they see the industry heading in the next five years. Our guests include: John Smith, CTO of TechCorp Maria Garcia, VP of Engineering at StartupXYZ David Chen, Principal Architect at BigTech Inc This is a longer episode with in-depth discussions about technology trends, career advice, and industry insights.
+
+        <details>
+          <summary>Available resources</summary>
+          <table>
+          <thead>
+            <tr>
+              <th>Type</th>
+              <th>URL</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+          <td>🎵 Audio</td>
+          <td><a href="https://example.com/episodes/episode-40-special-interview.mp3" target="_blank" rel="nofollow noopener noreferrer">https://example.com/episodes/episode-40-special-interview.mp3</a></td>
+          <td><a href="https://example.com/episodes/episode-40-special-interview.mp3" target="_blank" rel="nofollow noopener noreferrer">Play</a> |
+        <a href="https://example.com/episodes/episode-40-special-interview.mp3" target="_blank" rel="nofollow noopener noreferrer" download="">Download</a></td>
+        </tr>
+          </tbody>
+        </table>
+        </details>
+      HTML
+      <<~HTML.chomp,
+        <audio controls preload="none" referrerpolicy="no-referrer" crossorigin="anonymous">
+                    <source src="https://example.com/episodes/episode-39-css-grid-tips.mp3" type="audio/mpeg">
+                  </audio>
+
+        A quick episode covering essential CSS Grid tips and tricks. Perfect for developers who want to improve their layout skills. We cover: Basic grid concepts Common use cases Browser support considerations
+
+        <details>
+          <summary>Available resources</summary>
+          <table>
+          <thead>
+            <tr>
+              <th>Type</th>
+              <th>URL</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+          <td>🎵 Audio</td>
+          <td><a href="https://example.com/episodes/episode-39-css-grid-tips.mp3" target="_blank" rel="nofollow noopener noreferrer">https://example.com/episodes/episode-39-css-grid-tips.mp3</a></td>
+          <td><a href="https://example.com/episodes/episode-39-css-grid-tips.mp3" target="_blank" rel="nofollow noopener noreferrer">Play</a> |
+        <a href="https://example.com/episodes/episode-39-css-grid-tips.mp3" target="_blank" rel="nofollow noopener noreferrer" download="">Download</a></td>
+        </tr>
+          </tbody>
+        </table>
+        </details>
+      HTML
+      "In this episode, we do a live coding session building a todo application from scratch. Watch as we implement features step by step. This episode includes: Project setup and planning Implementing core functionality Adding advanced features Testing and deployment",
+      "This is a text-only episode featuring our monthly reading list. We share the best articles, books, and resources we've discovered. This month's recommendations include books on software architecture, design patterns, and career development."
+    ]
   end
 
-  context 'with media-specific content validation' do
-    it 'extracts duration information as categories' do
-      expect(feed).to have_categories
-    end
-
-    it 'handles media enclosures' do
-      expect(feed).to have_enclosures
-    end
-
-    it 'handles episodes without media enclosures' do
-      # This test ensures the configuration gracefully handles
-      # items that don't have media enclosures
-      items = feed.items
-      expect(items).to be_an(Array)
-    end
+  let(:expected_categories) do
+    [
+      ['3240'],
+      ['2880'],
+      ['4500'],
+      ['1800'],
+      ['5400'],
+      ['0']
+    ]
   end
 
-  context 'with duration processing' do
-    it 'extracts duration from data-duration attribute' do
-      all_categories = extract_all_categories(feed)
-      duration_categories = all_categories.grep(/^\d+$/)
-      expect(duration_categories).not_to be_empty
-    end
-
-    it 'validates duration values are non-negative' do
-      all_categories = extract_all_categories(feed)
-      duration_categories = all_categories.grep(/^\d+$/)
-
-      duration_categories.each do |duration|
-        expect(duration.to_i).to be >= 0
-      end
-    end
+  let(:expected_pubdates) do
+    [
+      'Mon, 15 Jan 2024 10:00:00 +0000',
+      'Mon, 08 Jan 2024 10:00:00 +0000',
+      'Mon, 01 Jan 2024 10:00:00 +0000',
+      'Mon, 25 Dec 2023 10:00:00 +0000',
+      'Mon, 18 Dec 2023 10:00:00 +0000',
+      'Mon, 11 Dec 2023 10:00:00 +0000'
+    ]
   end
 
-  context 'with enclosure validation' do
-    it 'validates enclosure URLs are absolute' do
-      items = feed.items
-      items_with_enclosures = items.select(&:enclosure)
+  let(:expected_enclosures) do
+    [
+      ['https://example.com/episodes/episode-42-ai-web-dev.mp3', 'audio/mpeg', 0],
+      ['https://example.com/episodes/episode-41-scalable-react.mp3', 'audio/mpeg', 0],
+      ['https://example.com/episodes/episode-40-special-interview.mp3', 'audio/mpeg', 0],
+      ['https://example.com/episodes/episode-39-css-grid-tips.mp3', 'audio/mpeg', 0],
+      [nil, nil, nil],
+      [nil, nil, nil]
+    ]
+  end
 
-      items_with_enclosures.each do |item|
-        expect(item.enclosure.url).to be_a(String)
-      end
-    end
+  it 'translates every episode into an RSS item with markdown summaries', :aggregate_failures do
+    expect(items.size).to eq(expected_titles.size)
+    expect(items.map(&:title)).to eq(expected_titles)
+    expect(items.map(&:description)).to eq(expected_descriptions)
+    expect(items.map { |item| item.pubDate.rfc2822 }).to eq(expected_pubdates)
+  end
 
-    it 'validates enclosure URLs are not empty' do
-      items = feed.items
-      items_with_enclosures = items.select(&:enclosure)
+  it 'emits absolute URLs for episode pages and media assets', :aggregate_failures do
+    expect(items.map(&:link)).to eq(expected_links)
+    expect(items.map do |item|
+             enclosure = item.enclosure
+             [enclosure&.url, enclosure&.type, enclosure&.length]
+           end).to eq(expected_enclosures)
+  end
 
-      items_with_enclosures.each do |item|
-        expect(item.enclosure.url).not_to be_empty
-      end
-    end
+  it 'records playback duration as a numeric category' do
+    expect(items.map { |item| item.categories.map(&:content) })
+      .to eq(expected_categories)
+  end
 
-    it 'validates enclosure types are specified' do
-      items = feed.items
-      items_with_enclosures = items.select(&:enclosure)
+  it 'leaves purely textual episodes without an enclosure' do
+    video_episode = items.find { |item| item.title.include?('Live Coding Session') }
+    trailing_episode = items.last
 
-      items_with_enclosures.each do |item|
-        expect(item.enclosure.type).to be_a(String)
-      end
-    end
-
-    it 'validates enclosure types are not empty' do
-      items = feed.items
-      items_with_enclosures = items.select(&:enclosure)
-
-      items_with_enclosures.each do |item|
-        expect(item.enclosure.type).not_to be_empty
-      end
-    end
+    expect(video_episode.enclosure).to be_nil
+    expect(trailing_episode.title).to eq('Episode 37: Text-Only Episode - Reading List')
+    expect(trailing_episode.enclosure).to be_nil
   end
 end

--- a/spec/examples/multilang_site_spec.rb
+++ b/spec/examples/multilang_site_spec.rb
@@ -4,131 +4,80 @@ require 'spec_helper'
 
 RSpec.describe 'Multi-Language Site Configuration' do
   subject(:feed) do
-    # Mock the request service to return our HTML fixture
     mock_request_service_with_html_fixture('multilang_site', 'https://example.com')
-
     Html2rss.feed(config)
   end
 
   let(:config_file) { File.join(%w[spec examples multilang_site.yml]) }
-  let(:html_file) { File.join(%w[spec examples multilang_site.html]) }
   let(:config) { Html2rss.config_from_yaml_file(config_file) }
+  let(:channel_url) { config.dig(:channel, :url) }
+  let(:items) { feed.items }
+  let(:expected_titles) do
+    [
+      "[en] Breaking News: ACME Corp's Technology Update",
+      '[es] Noticias: Actualización Tecnológica de ACME Corp',
+      "[fr] Actualités: Mise à jour technologique d'ACME Corp",
+      '[de] Nachrichten: ACME Corp Technologie-Update',
+      '[en] Environmental Research Update',
+      '[es] Investigación Ambiental Actualizada',
+      '[en] Health and Wellness Guide',
+      '[fr] Guide Santé et Bien-être'
+    ]
+  end
 
-  it 'generates a valid RSS feed', :aggregate_failures do
-    expect(feed).to be_a(RSS::Rss)
+  let(:expected_descriptions) do
+    [
+      "This is a major technology breakthrough that will change everything. ACME Corp scientists have developed a new quantum computing algorithm that promises to revolutionize data processing. It can finally solve the halting problem... or can it? The new system can process complex calculations in seconds that would take traditional computers years to complete. It's so fast, it can compile Hello World before you finish typing it.",
+      "Esta es una gran innovación tecnológica que cambiará todo. Los científicos de ACME Corp han desarrollado un nuevo algoritmo de computación cuántica que promete revolucionar el procesamiento de datos. Es tan avanzado que puede debuggear código antes de que se escriba. El nuevo sistema puede procesar cálculos complejos en segundos que tomarían años a las computadoras tradicionales. También viene con una taza de café integrada.",
+      "Il s'agit d'une percée technologique majeure qui va tout changer. Les scientifiques d'ACME Corp ont développé un nouvel algorithme de calcul quantique qui promet de révolutionner le traitement des données. Il peut même comprendre le code français. Le nouveau système peut traiter des calculs complexes en quelques secondes qui prendraient des années aux ordinateurs traditionnels. Il est si rapide qu'il peut compiler \"Bonjour le monde\" avant que vous ne finissiez de le taper.",
+      "Dies ist ein wichtiger technologischer Durchbruch, der alles verändern wird. Wissenschaftler von ACME Corp haben einen neuen Quantencomputing-Algorithmus entwickelt, der die Datenverarbeitung revolutionieren soll. Er kann sogar deutsche Kommentare verstehen. Das neue System kann komplexe Berechnungen in Sekunden verarbeiten, für die herkömmliche Computer Jahre benötigen würden. Es ist so schnell, dass es \"Hallo Welt\" kompilieren kann, bevor Sie es fertig getippt haben.",
+      'New research shows that climate change is accelerating faster than previously predicted. The study, conducted by an international team of scientists, reveals alarming trends in global temperature rise. Immediate action is required to prevent catastrophic environmental damage within the next decade.',
+      'Nueva investigación muestra que el cambio climático se está acelerando más rápido de lo previsto. El estudio, realizado por un equipo internacional de científicos, revela tendencias alarmantes en el aumento de la temperatura global. Se requiere acción inmediata para prevenir daños ambientales catastróficos en la próxima década.',
+      'Maintaining good health requires a balanced approach to diet, exercise, and mental well-being. Recent studies have shown the importance of regular physical activity and proper nutrition. Experts recommend at least 30 minutes of moderate exercise daily, combined with a diet rich in fruits, vegetables, and whole grains.',
+      "Maintenir une bonne santé nécessite une approche équilibrée de l'alimentation, de l'exercice et du bien-être mental. Des études récentes ont montré l'importance de l'activité physique régulière et d'une nutrition appropriée. Les experts recommandent au moins 30 minutes d'exercice modéré quotidien, combiné avec un régime riche en fruits, légumes et céréales complètes."
+    ]
+  end
+
+  let(:expected_categories) do
+    [
+      ['en', 'Technology'],
+      ['es', 'Tecnología'],
+      ['fr', 'Technologie'],
+      ['de', 'Technologie'],
+      ['en', 'Environment'],
+      ['es', 'Medio Ambiente'],
+      ['en', 'Health'],
+      ['fr', 'Santé']
+    ]
+  end
+
+  it 'applies the configured channel metadata' do
     expect(feed.channel.title).to eq('ACME Multi-Language Site News')
     expect(feed.channel.link).to eq('https://example.com')
     expect(feed.channel.language).to eq('en')
   end
 
-  it 'extracts all 8 items from the multi-language HTML', :aggregate_failures do
-    expect(feed.items).to be_an(Array)
-    expect(feed.items.size).to eq(8)
+  it 'renders every post with language-prefixed titles and sanitised body copy', :aggregate_failures do
+    expect(items.size).to eq(expected_titles.size)
+    expect(items.map(&:title)).to eq(expected_titles)
+    expect(items.map(&:description)).to eq(expected_descriptions)
   end
 
-  it 'extracts titles correctly with language template processing', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    items = feed.items
-    titles = items.map(&:title)
-    expect(titles).to all(be_a(String)).and all(satisfy { |title| !title.strip.empty? }).and all(match(/^\[[a-z]{2}\]/))
-    expect(titles).to include('[en] Breaking News: ACME Corp\'s Technology Update',
-                              '[es] Noticias: Actualización Tecnológica de ACME Corp',
-                              '[fr] Actualités: Mise à jour technologique d\'ACME Corp',
-                              '[de] Nachrichten: ACME Corp Technologie-Update',
-                              '[en] Environmental Research Update',
-                              '[es] Investigación Ambiental Actualizada',
-                              '[en] Health and Wellness Guide',
-                              '[fr] Guide Santé et Bien-être')
+  it 'exposes language codes and translated topics as individual categories' do
+    expect(items.map { |item| item.categories.map(&:content) })
+      .to eq(expected_categories)
   end
 
-  it 'extracts language information correctly from data-lang attributes', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    items = feed.items
-    language_categories = items.flat_map(&:categories).select { |cat| cat.content.match?(/^[a-z]{2}$/) }
-    expect(language_categories.size).to eq(8)
-    language_codes = language_categories.map(&:content)
-    expect(language_codes).to include('en', 'es', 'fr', 'de')
-    expect(language_codes.count('en')).to eq(3)
-    expect(language_codes.count('es')).to eq(2)
-    expect(language_codes.count('fr')).to eq(2)
-    expect(language_codes.count('de')).to eq(1)
+  it 'keeps multilingual content grouped correctly' do
+    groups = items.group_by { |item| item.categories.first.content }
+    expect(groups.transform_values(&:count)).to eq('en' => 3, 'es' => 2, 'fr' => 2, 'de' => 1)
   end
 
-  it 'extracts topic information correctly as categories', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    items = feed.items
-    topic_categories = items.flat_map(&:categories).select do |cat|
-      cat.content.match?(/^[A-Za-z\s]+$/) && !cat.content.match?(/^[a-z]{2}$/)
-    end
-    expect(topic_categories.size).to eq(6)
-    topic_names = topic_categories.map(&:content)
-    expect(topic_names).to include('Technology', 'Technologie', 'Environment', 'Medio Ambiente', 'Health')
-  end
+  it 'retains the source language copy within descriptions' do
+    spanish_item = items.find { |item| item.title.start_with?('[es]') }
+    french_item = items.find { |item| item.title.start_with?('[fr]') }
 
-  it 'extracts descriptions correctly with HTML sanitization', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    items = feed.items
-    descriptions = items.map(&:description)
-    expect(descriptions).to all(be_a(String)).and all(satisfy { |desc| !desc.strip.empty? }).and all(satisfy { |desc|
-      !desc.match(/<[^>]+>/)
-    })
-    en_article = items.find { |item| item.title.include?('[en] Breaking News') }
-    expect(en_article.description).to include('ACME Corp scientists have developed', 'quantum computing algorithm')
-    es_article = items.find { |item| item.title.include?('[es] Noticias') }
-    expect(es_article.description).to include('Los científicos de ACME Corp han desarrollado',
-                                              'algoritmo de computación cuántica')
-  end
-
-  it 'validates that template processing works with language interpolation', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    items = feed.items
-    items.each do |item|
-      expect(item.title).to match(/^\[[a-z]{2}\]/)
-      language_code = item.title.match(/^\[([a-z]{2})\]/)[1]
-      language_category = item.categories.find do |cat|
-        cat.content == language_code
-      end
-      expect(language_category).not_to be_nil
-    end
-  end
-
-  it 'handles multiple languages correctly in the same feed', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    items_by_language = feed.items.group_by do |item|
-      language_category = item.categories.find { |cat| cat.content.match?(/^[a-z]{2}$/) }
-      language_category ? language_category.content : 'unknown'
-    end
-
-    expect(items_by_language.keys).to contain_exactly('de', 'en', 'es', 'fr')
-    expect(items_by_language.fetch('en').size).to eq(3)
-    expect(items_by_language.fetch('es').size).to eq(2)
-    expect(items_by_language.fetch('fr').size).to eq(2)
-    expect(items_by_language.fetch('de').size).to eq(1)
-  end
-
-  it 'validates that attribute extraction works for data-lang', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    items = feed.items
-    items.each do |item|
-      language_category = item.categories.find do |cat|
-        cat.content.match?(/^[a-z]{2}$/)
-      end
-      expect(language_category).not_to be_nil
-      expect(language_category.content).to match(/^[a-z]{2}$/)
-    end
-  end
-
-  it 'preserves original content structure in template processing', :aggregate_failures do
-    items = feed.items
-    expect(items).to all(have_attributes(title: be_a(String).and(satisfy { |title|
-      title.length > 10
-    }).and(match(/^\[[a-z]{2}\] .+/))))
-  end
-
-  it 'handles different topic categories correctly', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    items = feed.items
-    technology_items = items.select { |item| item.categories.any? { |cat| cat.content.match?(/^[Tt]echnolog/) } }
-    expect(technology_items.size).to eq(3)
-    environment_items = items.select do |item|
-      item.categories.any? do |cat|
-        cat.content.match?(/^[Ee]nvironment|^[Mm]edio [Aa]mbiente/)
-      end
-    end
-    expect(environment_items.size).to eq(2)
-    health_items = items.select { |item| item.categories.any? { |cat| cat.content.match?(/^[Hh]ealth|^[Ss]anté/) } }
-    expect(health_items.size).to eq(2)
+    expect(spanish_item.description).to include('Los científicos de ACME Corp han desarrollado')
+    expect(french_item.description).to include("Les scientifiques d'ACME Corp ont développé")
   end
 end

--- a/spec/examples/performance_optimized_spec.rb
+++ b/spec/examples/performance_optimized_spec.rb
@@ -1,117 +1,69 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'time'
 
 RSpec.describe 'Performance-Optimized Configuration' do
   subject(:feed) do
-    # Mock the request service to return our HTML fixture
     mock_request_service_with_html_fixture('performance_optimized_site', 'https://example.com')
-
     Html2rss.feed(config)
   end
 
   let(:config_file) { File.join(%w[spec examples performance_optimized_site.yml]) }
-  let(:html_file) { File.join(%w[spec examples performance_optimized_site.html]) }
   let(:config) { Html2rss.config_from_yaml_file(config_file) }
-
+  let(:channel_url) { config.dig(:channel, :url) }
   let(:items) { feed.items }
-
-  it 'generates a valid RSS feed', :aggregate_failures do
-    expect(feed).to be_a(RSS::Rss)
-    expect(feed.channel.title).to eq('ACME Performance-Optimized Site News')
-    expect(feed.channel.link).to eq('https://example.com')
+  let(:expected_titles) do
+    [
+      "Breaking News: ACME Corp's Technology Breakthrough",
+      "ACME Corp's Environmental Research Update",
+      "ACME Corp's Economic Analysis Report",
+      "ACME Corp's Developer Health and Wellness Tips"
+    ]
   end
 
-  it 'extracts only the 4 main content items (excludes ads and sidebar)', :aggregate_failures do
-    expect(feed.items).to be_an(Array)
-    expect(feed.items.size).to eq(4) # Should exclude advertisement and sidebar content
+  let(:expected_links) do
+    [
+      'https://example.com/articles/technology-breakthrough',
+      'https://example.com/articles/environmental-research',
+      'https://example.com/articles/economic-analysis',
+      'https://example.com/articles/health-tips'
+    ]
   end
 
-  it 'extracts titles correctly', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    titles = items.map(&:title)
-    expect(titles).to all(be_a(String)).and all(satisfy { |title| !title.strip.empty? })
-    expect(titles).to include('Breaking News: ACME Corp\'s Technology Breakthrough',
-                              'ACME Corp\'s Environmental Research Update',
-                              'ACME Corp\'s Economic Analysis Report',
-                              'ACME Corp\'s Developer Health and Wellness Tips')
-    expect(titles).not_to include('Sponsored Content: Buy ACME Corp\'s Product', 'Sidebar Content', 'Sidebar Article')
+  let(:expected_descriptions) do
+    [
+      "January 15, 2024 ACME Corp scientists have achieved a major breakthrough in quantum computing technology. This advancement could revolutionize how we process information and solve complex problems. It can finally solve the halting problem... or can it? The research team spent over three years developing this new approach to quantum error correction, which addresses one of the biggest challenges in quantum computing. They also discovered that coffee makes quantum computers work better. Read more",
+      "January 14, 2024 New ACME Corp research reveals significant changes in global climate patterns. The study provides important insights into how climate change is affecting different regions around the world. They're trying to make infinite loops carbon-neutral. Researchers analyzed data from over 100 weather stations across five continents to reach these conclusions. The study found that using tabs instead of spaces can reduce your carbon footprint by 0.0001%. Read full article",
+      "January 13, 2024 ACME Corp's quarterly economic analysis shows positive trends in several key sectors. The report indicates steady growth in technology and renewable energy industries. The most profitable sector is still selling coffee to developers. Market analysts predict continued expansion in these areas over the next fiscal year. They also predict that the demand for rubber ducks will increase by 42%. View report",
+      "January 12, 2024 ACME Corp expert recommendations for maintaining good health during the winter months. These tips can help boost your immune system and overall well-being. Remember: coffee is not a food group, but it is a lifestyle choice. Regular exercise, proper nutrition, and adequate sleep are the three pillars of good health. Also, remember to take breaks from your computer every 2 hours to prevent carpal tunnel syndrome. Read tips"
+    ]
   end
 
-  it 'extracts URLs correctly', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    urls = items.map(&:link)
-    expect(urls).to all(be_a(String)).and all(satisfy { |url| !url.strip.empty? })
-    expect(urls).to include('https://example.com/articles/technology-breakthrough',
-                            'https://example.com/articles/environmental-research',
-                            'https://example.com/articles/economic-analysis',
-                            'https://example.com/articles/health-tips')
-    expect(urls).not_to include('https://example.com/ads/product-promotion',
-                                'https://example.com/sidebar/article',
-                                'https://example.com/sidebar/sidebar-article')
+  let(:expected_pubdates) do
+    [
+      'Mon, 15 Jan 2024 10:30:00 +0000',
+      'Sun, 14 Jan 2024 14:20:00 +0000',
+      'Sat, 13 Jan 2024 09:15:00 +0000',
+      'Fri, 12 Jan 2024 08:30:00 +0000'
+    ]
   end
 
-  it 'extracts published dates correctly from time elements', :aggregate_failures do
-    items_with_time = items.select(&:pubDate)
-    expect(items_with_time.size).to eq(4)
-    expect(items_with_time).to all(have_attributes(pubDate: be_a(Time)))
-  end
-
-  it 'excludes advertisements using :not(.advertisement) selector', :aggregate_failures do
-    items = feed.items
-    titles = items.map(&:title)
-
-    # Ensure no advertisement content is included
-    expect(titles).not_to include('Sponsored Content: Buy ACME Corp\'s Product')
-
-    # Verify we still have the expected number of items
+  it 'applies the high-signal CSS selector and ignores adverts' do
     expect(items.size).to eq(4)
+    expect(items.map(&:title)).to eq(expected_titles)
   end
 
-  it 'excludes sidebar content by limiting to .main-content', :aggregate_failures do
-    items = feed.items
-    titles = items.map(&:title)
-
-    # Ensure no sidebar content is included
-    expect(titles).not_to include('Sidebar Content')
-    expect(titles).not_to include('Sidebar Article')
-
-    # Verify we still have the expected number of items
-    expect(items.size).to eq(4)
+  it 'converts relative article links to absolute URLs' do
+    expect(items.map(&:link)).to eq(expected_links)
   end
 
-  it 'validates that the CSS selector works as expected', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    doc = Nokogiri::HTML(File.read(html_file))
-    matching_posts = doc.css('.main-content .post:not(.advertisement)')
-    expect(matching_posts.size).to eq(4)
-    matching_titles = matching_posts.filter_map { |post| post.at('h2')&.text }
-    expect(matching_titles).to include('Breaking News: ACME Corp\'s Technology Breakthrough',
-                                       'ACME Corp\'s Environmental Research Update',
-                                       'ACME Corp\'s Economic Analysis Report',
-                                       'ACME Corp\'s Developer Health and Wellness Tips')
-    expect(matching_titles).not_to include('Sponsored Content: Buy ACME Corp\'s Product')
+  it 'sanitises body copy while keeping the editorial voice intact' do
+    expect(items.map(&:description)).to eq(expected_descriptions)
+    expect(items.first.description).to include('coffee makes quantum computers work better.')
   end
 
-  it 'parses ISO 8601 datetime format correctly from time elements', :aggregate_failures do
-    items_with_time = items.select(&:pubDate)
-    expect(items_with_time.size).to eq(4)
-    expect(items_with_time).to all(have_attributes(pubDate: be_a(Time).and(have_attributes(year: 2024))))
-  end
-
-  it 'validates that attribute extraction works for datetime', :aggregate_failures do
-    items = feed.items
-
-    # All items should have published dates extracted from time[datetime] attributes
-    items.each do |item|
-      expect(item.pubDate).to be_a(Time)
-      expect(item.pubDate.year).to eq(2024)
-    end
-  end
-
-  it 'ensures performance optimization by using specific selectors', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    doc = Nokogiri::HTML(File.read(html_file))
-    all_posts = doc.css('.post')
-    optimized_posts = doc.css('.main-content .post:not(.advertisement)')
-    expect(all_posts.size).to eq(7)
-    expect(optimized_posts.size).to eq(4)
-    expect(optimized_posts.size).to be < all_posts.size
+  it 'parses datetime attributes directly from the markup' do
+    expect(items.map { |item| item.pubDate.rfc2822 }).to eq(expected_pubdates)
   end
 end


### PR DESCRIPTION
## Summary
- replace dynamically derived expectations in example specs with explicit strings and metadata taken from the fixtures
- assert full descriptions, links, categories, and publication dates for HTML and JSON feeds to ensure tests exercise end-to-end processing

## Testing
- bundle exec rspec spec/examples

------
https://chatgpt.com/codex/tasks/task_e_68e5890d717c832d928fb03710f5dff2