### PR TITLE
Streamline example spec helpers

### DIFF
--- a/spec/examples/conditional_processing_spec.rb
+++ b/spec/examples/conditional_processing_spec.rb
@@ -1,100 +1,101 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'time'
 
 RSpec.describe 'Conditional Processing Configuration' do
   subject(:feed) do
-    # Mock the request service to return our HTML fixture
     mock_request_service_with_html_fixture('conditional_processing_site', 'https://example.com')
-
     Html2rss.feed(config)
   end
 
   let(:config_file) { File.join(%w[spec examples conditional_processing_site.yml]) }
-  let(:html_file) { File.join(%w[spec examples conditional_processing_site.html]) }
   let(:config) { Html2rss.config_from_yaml_file(config_file) }
-
   let(:items) { feed.items }
-  let(:titles) { items.map(&:title) }
 
-  it 'generates a valid RSS feed', :aggregate_failures do
-    expect(feed).to be_a(RSS::Rss)
+  let(:expected_items) do
+    [
+      {
+        title: "Breaking News: ACME Corp's New Debugging Tool",
+        link: 'https://example.com/articles/technology-update',
+        description_starts_with: '[Status: Published]',
+        description_includes: [
+          "latest debugging tool",
+          'built-in rubber duck'
+        ],
+        categories: ['Published'],
+        pub_date: 'Mon, 15 Jan 2024 10:30:00 +0000'
+      },
+      {
+        title: "Draft Article: ACME Corp's Green Coding Initiative",
+        link: 'https://example.com/articles/environmental-research',
+        description_starts_with: '[Status: Draft]',
+        description_includes: [
+          'environmental research',
+          'tabs instead of spaces'
+        ],
+        categories: ['Draft'],
+        pub_date: 'Sun, 14 Jan 2024 14:20:00 +0000'
+      },
+      {
+        title: "Archived Article: ACME Corp's Economic Analysis of Bug Fixes",
+        link: 'https://example.com/articles/economic-analysis',
+        description_starts_with: '[Status: Archived]',
+        description_includes: [
+          '99% of bugs are caused by cosmic rays',
+          'missing semicolon that cost $1.2 billion'
+        ],
+        categories: ['Archived'],
+        pub_date: 'Sat, 13 Jan 2024 09:15:00 +0000'
+      },
+      {
+        title: "ACME Corp's Developer Health and Wellness Guide",
+        link: 'https://example.com/articles/health-wellness',
+        description_starts_with: '[Status: Published]',
+        description_includes: [
+          'coffee is not a food group',
+          'Standing desks are great'
+        ],
+        categories: ['Published'],
+        pub_date: 'Fri, 12 Jan 2024 08:30:00 +0000'
+      },
+      {
+        title: "Pending Article: ACME Corp's Annual Code Golf Tournament",
+        link: 'https://example.com/articles/sports-update',
+        description_starts_with: '[Status: Pending]',
+        description_includes: [
+          'lifetime supply of coffee',
+          'Debug this code blindfolded'
+        ],
+        categories: ['Pending'],
+        pub_date: 'Thu, 11 Jan 2024 16:45:00 +0000'
+      },
+      {
+        title: "ACME Corp's Article Without Status (Status: Unknown)",
+        link: 'https://example.com/articles/no-status',
+        description_starts_with: '[Status: ]',
+        description_includes: [
+          "doesn't have a status field",
+          'null pointer exception'
+        ],
+        categories: [],
+        pub_date: 'Wed, 10 Jan 2024 12:00:00 +0000'
+      }
+    ]
+  end
+
+  it 'publishes the configured channel metadata' do
     expect(feed.channel.title).to eq('ACME Conditional Processing Site News')
     expect(feed.channel.link).to eq('https://example.com')
   end
 
-  it 'extracts all 6 items from the HTML fixture', :aggregate_failures do
-    expect(feed.items).to be_an(Array)
-    expect(feed.items.size).to eq(6)
+  it 'renders templated descriptions that expose the item status' do
+    expect_feed_items(items, expected_items)
   end
 
-  it 'extracts titles correctly', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    titles = items.map(&:title)
-    expect(titles).to all(be_a(String)).and all(satisfy { |title| !title.strip.empty? })
-    expect(titles).to include('Breaking News: ACME Corp\'s New Debugging Tool',
-                              'Draft Article: ACME Corp\'s Green Coding Initiative',
-                              'Archived Article: ACME Corp\'s Economic Analysis of Bug Fixes',
-                              'ACME Corp\'s Developer Health and Wellness Guide',
-                              'Pending Article: ACME Corp\'s Annual Code Golf Tournament',
-                              'ACME Corp\'s Article Without Status (Status: Unknown)')
-  end
-
-  it 'extracts URLs correctly', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    urls = items.map(&:link)
-    expect(urls).to all(be_a(String)).and all(satisfy { |url| !url.strip.empty? })
-    expect(urls).to include('https://example.com/articles/technology-update',
-                            'https://example.com/articles/environmental-research',
-                            'https://example.com/articles/economic-analysis',
-                            'https://example.com/articles/health-wellness',
-                            'https://example.com/articles/sports-update',
-                            'https://example.com/articles/no-status')
-  end
-
-  it 'extracts published dates correctly', :aggregate_failures do
-    items_with_time = items.select(&:pubDate)
-    expect(items_with_time.size).to be > 0
-    expect(items_with_time).to all(have_attributes(pubDate: be_a(Time)))
-  end
-
-  it 'applies template post-processing with status interpolation', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    items = feed.items
-    descriptions = items.map(&:description)
-    expect(descriptions).to all(be_a(String)).and all(satisfy { |desc| !desc.strip.empty? })
-    expect(items.count { |item| item.description.include?('[Status: Published]') }).to be >= 2
-    expect(items.count { |item| item.description.include?('[Status: Draft]') }).to be >= 1
-    expect(items.count { |item| item.description.include?('[Status: Archived]') }).to be >= 1
-    expect(items.count { |item| item.description.include?('[Status: Pending]') }).to be >= 1
-  end
-
-  it 'handles missing status values in template gracefully', :aggregate_failures do
-    items = feed.items
-
-    # Find the item without status (should have empty status in template)
-    no_status_item = items.find { |item| item.title.include?('Without Status') }
-    expect(no_status_item).not_to be_nil
-
-    # The template should handle missing status gracefully
-    expect(no_status_item.description).to include('[Status: ]')
-  end
-
-  it 'extracts status information as categories', :aggregate_failures do
-    items_with_status = items.select { |item| item.categories.any? { |cat| cat.content.is_a?(String) } }
-    expect(items_with_status.size).to be >= 5
-    status_categories = items.flat_map(&:categories).filter_map(&:content)
-    expect(status_categories).to include('Published', 'Draft', 'Archived', 'Pending')
-  end
-
-  it 'validates that template post-processing preserves original content', :aggregate_failures do
-    items = feed.items
-    expect(items).to all(have_attributes(description: be_a(String).and(satisfy { |desc|
-      desc.length > 50
-    }).and(match(/\[Status: [^\]]*\]/))))
-  end
-
-  it 'handles different status values correctly in categories', :aggregate_failures do
-    expect(items.count { |item| item.categories.any? { |cat| cat.content == 'Published' } }).to be >= 2
-    expect(items.count { |item| item.categories.any? { |cat| cat.content == 'Draft' } }).to be >= 1
-    expect(items.count { |item| item.categories.any? { |cat| cat.content == 'Archived' } }).to be >= 1
-    expect(items.count { |item| item.categories.any? { |cat| cat.content == 'Pending' } }).to be >= 1
+  it 'gracefully handles missing statuses in both the template output and category list' do
+    empty_status_item = items.find { |item| item.title.include?('Without Status') }
+    expect(empty_status_item.description).to start_with('[Status: ]')
+    expect(empty_status_item.categories).to be_empty
   end
 end

--- a/spec/examples/media_enclosures_spec.rb
+++ b/spec/examples/media_enclosures_spec.rb
@@ -1,114 +1,92 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'time'
 
-# This spec demonstrates the media enclosures configuration,
-# which handles podcast and video content with media enclosures,
-# duration extraction, and HTML to Markdown conversion.
 RSpec.describe 'Media Enclosures Configuration', type: :example do
-  # RSS feed generation tests
-  # These tests validate that the configuration successfully generates
-  # a valid RSS feed with proper media content extraction
   subject(:feed) { generate_feed_from_config(config, config_name, :html) }
 
   let(:config_name) { 'media_enclosures_site' }
   let(:config) { load_example_configuration(config_name) }
+  let(:items) { feed.items }
 
-  it 'generates a valid RSS feed' do
-    expect(feed).to be_a_valid_rss_feed
+  let(:expected_items) do
+    [
+      {
+        title: 'Episode 42: The Future of AI in Web Development',
+        link: 'https://example.com/episodes/episode-42-ai-web-dev',
+        description_includes: [
+          '<audio controls',
+          'AI-assisted coding'
+        ],
+        categories: ['3240'],
+        pub_date: 'Mon, 15 Jan 2024 10:00:00 +0000',
+        enclosure: { url: 'https://example.com/episodes/episode-42-ai-web-dev.mp3', type: 'audio/mpeg', length: 0 }
+      },
+      {
+        title: 'Episode 41: Building Scalable React Applications',
+        link: 'https://example.com/episodes/episode-41-scalable-react',
+        description_includes: [
+          '<audio controls',
+          'performance optimization'
+        ],
+        categories: ['2880'],
+        pub_date: 'Mon, 08 Jan 2024 10:00:00 +0000',
+        enclosure: { url: 'https://example.com/episodes/episode-41-scalable-react.mp3', type: 'audio/mpeg', length: 0 }
+      },
+      {
+        title: 'Episode 40: Special - Interview with Tech Industry Leaders',
+        link: 'https://example.com/episodes/episode-40-special-interview',
+        description_includes: [
+          '<audio controls',
+          'tech industry leaders'
+        ],
+        categories: ['4500'],
+        pub_date: 'Mon, 01 Jan 2024 10:00:00 +0000',
+        enclosure: { url: 'https://example.com/episodes/episode-40-special-interview.mp3', type: 'audio/mpeg', length: 0 }
+      },
+      {
+        title: 'Episode 39: Quick Tips for CSS Grid',
+        link: 'https://example.com/episodes/episode-39-css-grid-tips',
+        description_includes: [
+          '<audio controls',
+          'essential CSS Grid tips'
+        ],
+        categories: ['1800'],
+        pub_date: 'Mon, 25 Dec 2023 10:00:00 +0000',
+        enclosure: { url: 'https://example.com/episodes/episode-39-css-grid-tips.mp3', type: 'audio/mpeg', length: 0 }
+      },
+      {
+        title: 'Episode 38: Live Coding Session - Building a Todo App',
+        link: 'https://example.com/episodes/episode-38-live-coding',
+        description_includes: [
+          'live coding session',
+          'Implementing core functionality'
+        ],
+        categories: ['5400'],
+        pub_date: 'Mon, 18 Dec 2023 10:00:00 +0000',
+        enclosure: nil
+      },
+      {
+        title: 'Episode 37: Text-Only Episode - Reading List',
+        link: 'https://example.com/episodes/episode-37-reading-list',
+        description_includes: [
+          'text-only episode',
+          "This month's recommendations include books on software architecture"
+        ],
+        categories: ['0'],
+        pub_date: 'Mon, 11 Dec 2023 10:00:00 +0000',
+        enclosure: nil
+      }
+    ]
   end
 
-  it 'extracts the correct number of episodes' do
-    expect(feed).to have_valid_items
+  it 'translates every episode into an RSS item with markdown summaries' do
+    expect_feed_items(items, expected_items)
   end
 
-  context 'with basic item content validation' do
-    it 'extracts titles correctly' do
-      expect(feed).to have_valid_titles
-    end
-
-    it 'extracts URLs correctly' do
-      expect(feed).to have_valid_links
-    end
-
-    it 'extracts descriptions correctly' do
-      expect(feed).to have_valid_descriptions
-    end
-
-    it 'extracts published dates correctly' do
-      expect(feed).to have_valid_published_dates
-    end
-  end
-
-  context 'with media-specific content validation' do
-    it 'extracts duration information as categories' do
-      expect(feed).to have_categories
-    end
-
-    it 'handles media enclosures' do
-      expect(feed).to have_enclosures
-    end
-
-    it 'handles episodes without media enclosures' do
-      # This test ensures the configuration gracefully handles
-      # items that don't have media enclosures
-      items = feed.items
-      expect(items).to be_an(Array)
-    end
-  end
-
-  context 'with duration processing' do
-    it 'extracts duration from data-duration attribute' do
-      all_categories = extract_all_categories(feed)
-      duration_categories = all_categories.grep(/^\d+$/)
-      expect(duration_categories).not_to be_empty
-    end
-
-    it 'validates duration values are non-negative' do
-      all_categories = extract_all_categories(feed)
-      duration_categories = all_categories.grep(/^\d+$/)
-
-      duration_categories.each do |duration|
-        expect(duration.to_i).to be >= 0
-      end
-    end
-  end
-
-  context 'with enclosure validation' do
-    it 'validates enclosure URLs are absolute' do
-      items = feed.items
-      items_with_enclosures = items.select(&:enclosure)
-
-      items_with_enclosures.each do |item|
-        expect(item.enclosure.url).to be_a(String)
-      end
-    end
-
-    it 'validates enclosure URLs are not empty' do
-      items = feed.items
-      items_with_enclosures = items.select(&:enclosure)
-
-      items_with_enclosures.each do |item|
-        expect(item.enclosure.url).not_to be_empty
-      end
-    end
-
-    it 'validates enclosure types are specified' do
-      items = feed.items
-      items_with_enclosures = items.select(&:enclosure)
-
-      items_with_enclosures.each do |item|
-        expect(item.enclosure.type).to be_a(String)
-      end
-    end
-
-    it 'validates enclosure types are not empty' do
-      items = feed.items
-      items_with_enclosures = items.select(&:enclosure)
-
-      items_with_enclosures.each do |item|
-        expect(item.enclosure.type).not_to be_empty
-      end
-    end
+  it 'emits absolute URLs for episode pages and media assets' do
+    urls = items.map(&:link)
+    expect(urls).to all(start_with('https://example.com/episodes/'))
   end
 end

--- a/spec/examples/multilang_site_spec.rb
+++ b/spec/examples/multilang_site_spec.rb
@@ -4,131 +4,103 @@ require 'spec_helper'
 
 RSpec.describe 'Multi-Language Site Configuration' do
   subject(:feed) do
-    # Mock the request service to return our HTML fixture
     mock_request_service_with_html_fixture('multilang_site', 'https://example.com')
-
     Html2rss.feed(config)
   end
 
   let(:config_file) { File.join(%w[spec examples multilang_site.yml]) }
-  let(:html_file) { File.join(%w[spec examples multilang_site.html]) }
   let(:config) { Html2rss.config_from_yaml_file(config_file) }
+  let(:items) { feed.items }
 
-  it 'generates a valid RSS feed', :aggregate_failures do
-    expect(feed).to be_a(RSS::Rss)
+  let(:expected_items) do
+    [
+      {
+        title: "[en] Breaking News: ACME Corp's Technology Update",
+        description_includes: [
+          'quantum computing algorithm that promises to revolutionize data processing',
+          "It's so fast, it can compile Hello World before you finish typing it."
+        ],
+        categories: ['en', 'Technology']
+      },
+      {
+        title: '[es] Noticias: Actualización Tecnológica de ACME Corp',
+        description_includes: [
+          'gran innovación tecnológica',
+          'También viene con una taza de café integrada.'
+        ],
+        categories: ['es', 'Tecnología']
+      },
+      {
+        title: "[fr] Actualités: Mise à jour technologique d'ACME Corp",
+        description_includes: [
+          'percée technologique majeure',
+          "Il est si rapide qu'il peut compiler \"Bonjour le monde\""
+        ],
+        categories: ['fr', 'Technologie']
+      },
+      {
+        title: '[de] Nachrichten: ACME Corp Technologie-Update',
+        description_includes: [
+          'wichtiger technologischer Durchbruch',
+          'Es ist so schnell, dass es "Hallo Welt" kompilieren kann'
+        ],
+        categories: ['de', 'Technologie']
+      },
+      {
+        title: '[en] Environmental Research Update',
+        description_includes: [
+          'climate change is accelerating faster than previously predicted',
+          'Immediate action is required'
+        ],
+        categories: ['en', 'Environment']
+      },
+      {
+        title: '[es] Investigación Ambiental Actualizada',
+        description_includes: [
+          'El estudio, realizado por un equipo internacional de científicos',
+          'Se requiere acción inmediata'
+        ],
+        categories: ['es', 'Medio Ambiente']
+      },
+      {
+        title: '[en] Health and Wellness Guide',
+        description_includes: [
+          'Maintaining good health requires a balanced approach',
+          'Experts recommend at least 30 minutes of moderate exercise daily'
+        ],
+        categories: ['en', 'Health']
+      },
+      {
+        title: '[fr] Guide Santé et Bien-être',
+        description_includes: [
+          "Maintenir une bonne santé nécessite une approche équilibrée",
+          'Les experts recommandent au moins 30 minutes d\'exercice modéré quotidien'
+        ],
+        categories: ['fr', 'Santé']
+      }
+    ]
+  end
+
+  it 'applies the configured channel metadata' do
     expect(feed.channel.title).to eq('ACME Multi-Language Site News')
     expect(feed.channel.link).to eq('https://example.com')
     expect(feed.channel.language).to eq('en')
   end
 
-  it 'extracts all 8 items from the multi-language HTML', :aggregate_failures do
-    expect(feed.items).to be_an(Array)
-    expect(feed.items.size).to eq(8)
+  it 'renders every post with language-prefixed titles and sanitised body copy' do
+    expect_feed_items(items, expected_items)
   end
 
-  it 'extracts titles correctly with language template processing', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    items = feed.items
-    titles = items.map(&:title)
-    expect(titles).to all(be_a(String)).and all(satisfy { |title| !title.strip.empty? }).and all(match(/^\[[a-z]{2}\]/))
-    expect(titles).to include('[en] Breaking News: ACME Corp\'s Technology Update',
-                              '[es] Noticias: Actualización Tecnológica de ACME Corp',
-                              '[fr] Actualités: Mise à jour technologique d\'ACME Corp',
-                              '[de] Nachrichten: ACME Corp Technologie-Update',
-                              '[en] Environmental Research Update',
-                              '[es] Investigación Ambiental Actualizada',
-                              '[en] Health and Wellness Guide',
-                              '[fr] Guide Santé et Bien-être')
+  it 'keeps multilingual content grouped correctly' do
+    groups = items.group_by { |item| item.categories.first.content }
+    expect(groups.transform_values(&:count)).to eq('en' => 3, 'es' => 2, 'fr' => 2, 'de' => 1)
   end
 
-  it 'extracts language information correctly from data-lang attributes', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    items = feed.items
-    language_categories = items.flat_map(&:categories).select { |cat| cat.content.match?(/^[a-z]{2}$/) }
-    expect(language_categories.size).to eq(8)
-    language_codes = language_categories.map(&:content)
-    expect(language_codes).to include('en', 'es', 'fr', 'de')
-    expect(language_codes.count('en')).to eq(3)
-    expect(language_codes.count('es')).to eq(2)
-    expect(language_codes.count('fr')).to eq(2)
-    expect(language_codes.count('de')).to eq(1)
-  end
+  it 'retains the source language copy within descriptions' do
+    spanish_item = items.find { |item| item.title.start_with?('[es]') }
+    french_item = items.find { |item| item.title.start_with?('[fr]') }
 
-  it 'extracts topic information correctly as categories', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    items = feed.items
-    topic_categories = items.flat_map(&:categories).select do |cat|
-      cat.content.match?(/^[A-Za-z\s]+$/) && !cat.content.match?(/^[a-z]{2}$/)
-    end
-    expect(topic_categories.size).to eq(6)
-    topic_names = topic_categories.map(&:content)
-    expect(topic_names).to include('Technology', 'Technologie', 'Environment', 'Medio Ambiente', 'Health')
-  end
-
-  it 'extracts descriptions correctly with HTML sanitization', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    items = feed.items
-    descriptions = items.map(&:description)
-    expect(descriptions).to all(be_a(String)).and all(satisfy { |desc| !desc.strip.empty? }).and all(satisfy { |desc|
-      !desc.match(/<[^>]+>/)
-    })
-    en_article = items.find { |item| item.title.include?('[en] Breaking News') }
-    expect(en_article.description).to include('ACME Corp scientists have developed', 'quantum computing algorithm')
-    es_article = items.find { |item| item.title.include?('[es] Noticias') }
-    expect(es_article.description).to include('Los científicos de ACME Corp han desarrollado',
-                                              'algoritmo de computación cuántica')
-  end
-
-  it 'validates that template processing works with language interpolation', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    items = feed.items
-    items.each do |item|
-      expect(item.title).to match(/^\[[a-z]{2}\]/)
-      language_code = item.title.match(/^\[([a-z]{2})\]/)[1]
-      language_category = item.categories.find do |cat|
-        cat.content == language_code
-      end
-      expect(language_category).not_to be_nil
-    end
-  end
-
-  it 'handles multiple languages correctly in the same feed', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    items_by_language = feed.items.group_by do |item|
-      language_category = item.categories.find { |cat| cat.content.match?(/^[a-z]{2}$/) }
-      language_category ? language_category.content : 'unknown'
-    end
-
-    expect(items_by_language.keys).to contain_exactly('de', 'en', 'es', 'fr')
-    expect(items_by_language.fetch('en').size).to eq(3)
-    expect(items_by_language.fetch('es').size).to eq(2)
-    expect(items_by_language.fetch('fr').size).to eq(2)
-    expect(items_by_language.fetch('de').size).to eq(1)
-  end
-
-  it 'validates that attribute extraction works for data-lang', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    items = feed.items
-    items.each do |item|
-      language_category = item.categories.find do |cat|
-        cat.content.match?(/^[a-z]{2}$/)
-      end
-      expect(language_category).not_to be_nil
-      expect(language_category.content).to match(/^[a-z]{2}$/)
-    end
-  end
-
-  it 'preserves original content structure in template processing', :aggregate_failures do
-    items = feed.items
-    expect(items).to all(have_attributes(title: be_a(String).and(satisfy { |title|
-      title.length > 10
-    }).and(match(/^\[[a-z]{2}\] .+/))))
-  end
-
-  it 'handles different topic categories correctly', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    items = feed.items
-    technology_items = items.select { |item| item.categories.any? { |cat| cat.content.match?(/^[Tt]echnolog/) } }
-    expect(technology_items.size).to eq(3)
-    environment_items = items.select do |item|
-      item.categories.any? do |cat|
-        cat.content.match?(/^[Ee]nvironment|^[Mm]edio [Aa]mbiente/)
-      end
-    end
-    expect(environment_items.size).to eq(2)
-    health_items = items.select { |item| item.categories.any? { |cat| cat.content.match?(/^[Hh]ealth|^[Ss]anté/) } }
-    expect(health_items.size).to eq(2)
+    expect(spanish_item.description).to include('Los científicos de ACME Corp han desarrollado')
+    expect(french_item.description).to include("Les scientifiques d'ACME Corp ont développé")
   end
 end

--- a/spec/examples/performance_optimized_spec.rb
+++ b/spec/examples/performance_optimized_spec.rb
@@ -1,117 +1,69 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'time'
 
 RSpec.describe 'Performance-Optimized Configuration' do
   subject(:feed) do
-    # Mock the request service to return our HTML fixture
     mock_request_service_with_html_fixture('performance_optimized_site', 'https://example.com')
-
     Html2rss.feed(config)
   end
 
   let(:config_file) { File.join(%w[spec examples performance_optimized_site.yml]) }
-  let(:html_file) { File.join(%w[spec examples performance_optimized_site.html]) }
   let(:config) { Html2rss.config_from_yaml_file(config_file) }
-
   let(:items) { feed.items }
 
-  it 'generates a valid RSS feed', :aggregate_failures do
-    expect(feed).to be_a(RSS::Rss)
-    expect(feed.channel.title).to eq('ACME Performance-Optimized Site News')
-    expect(feed.channel.link).to eq('https://example.com')
+  let(:expected_items) do
+    [
+      {
+        title: "Breaking News: ACME Corp's Technology Breakthrough",
+        link: 'https://example.com/articles/technology-breakthrough',
+        description_includes: [
+          'major breakthrough in quantum computing technology',
+          'They also discovered that coffee makes quantum computers work better.'
+        ],
+        pub_date: 'Mon, 15 Jan 2024 10:30:00 +0000'
+      },
+      {
+        title: "ACME Corp's Environmental Research Update",
+        link: 'https://example.com/articles/environmental-research',
+        description_includes: [
+          'climate change is affecting different regions around the world',
+          'The study found that using tabs instead of spaces can reduce your carbon footprint'
+        ],
+        pub_date: 'Sun, 14 Jan 2024 14:20:00 +0000'
+      },
+      {
+        title: "ACME Corp's Economic Analysis Report",
+        link: 'https://example.com/articles/economic-analysis',
+        description_includes: [
+          'quarterly economic analysis shows positive trends',
+          'the demand for rubber ducks will increase by 42%'
+        ],
+        pub_date: 'Sat, 13 Jan 2024 09:15:00 +0000'
+      },
+      {
+        title: "ACME Corp's Developer Health and Wellness Tips",
+        link: 'https://example.com/articles/health-tips',
+        description_includes: [
+          'ACME Corp expert recommendations for maintaining good health during the winter months.',
+          'Also, remember to take breaks from your computer every 2 hours'
+        ],
+        pub_date: 'Fri, 12 Jan 2024 08:30:00 +0000'
+      }
+    ]
   end
 
-  it 'extracts only the 4 main content items (excludes ads and sidebar)', :aggregate_failures do
-    expect(feed.items).to be_an(Array)
-    expect(feed.items.size).to eq(4) # Should exclude advertisement and sidebar content
-  end
-
-  it 'extracts titles correctly', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    titles = items.map(&:title)
-    expect(titles).to all(be_a(String)).and all(satisfy { |title| !title.strip.empty? })
-    expect(titles).to include('Breaking News: ACME Corp\'s Technology Breakthrough',
-                              'ACME Corp\'s Environmental Research Update',
-                              'ACME Corp\'s Economic Analysis Report',
-                              'ACME Corp\'s Developer Health and Wellness Tips')
-    expect(titles).not_to include('Sponsored Content: Buy ACME Corp\'s Product', 'Sidebar Content', 'Sidebar Article')
-  end
-
-  it 'extracts URLs correctly', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    urls = items.map(&:link)
-    expect(urls).to all(be_a(String)).and all(satisfy { |url| !url.strip.empty? })
-    expect(urls).to include('https://example.com/articles/technology-breakthrough',
-                            'https://example.com/articles/environmental-research',
-                            'https://example.com/articles/economic-analysis',
-                            'https://example.com/articles/health-tips')
-    expect(urls).not_to include('https://example.com/ads/product-promotion',
-                                'https://example.com/sidebar/article',
-                                'https://example.com/sidebar/sidebar-article')
-  end
-
-  it 'extracts published dates correctly from time elements', :aggregate_failures do
-    items_with_time = items.select(&:pubDate)
-    expect(items_with_time.size).to eq(4)
-    expect(items_with_time).to all(have_attributes(pubDate: be_a(Time)))
-  end
-
-  it 'excludes advertisements using :not(.advertisement) selector', :aggregate_failures do
-    items = feed.items
-    titles = items.map(&:title)
-
-    # Ensure no advertisement content is included
-    expect(titles).not_to include('Sponsored Content: Buy ACME Corp\'s Product')
-
-    # Verify we still have the expected number of items
+  it 'applies the high-signal CSS selector and ignores adverts' do
     expect(items.size).to eq(4)
+    expect(items.map(&:title)).to all(include("ACME Corp"))
   end
 
-  it 'excludes sidebar content by limiting to .main-content', :aggregate_failures do
-    items = feed.items
-    titles = items.map(&:title)
-
-    # Ensure no sidebar content is included
-    expect(titles).not_to include('Sidebar Content')
-    expect(titles).not_to include('Sidebar Article')
-
-    # Verify we still have the expected number of items
-    expect(items.size).to eq(4)
+  it 'converts relative article links to absolute URLs and preserves editorial tone' do
+    expect_feed_items(items, expected_items)
   end
 
-  it 'validates that the CSS selector works as expected', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    doc = Nokogiri::HTML(File.read(html_file))
-    matching_posts = doc.css('.main-content .post:not(.advertisement)')
-    expect(matching_posts.size).to eq(4)
-    matching_titles = matching_posts.filter_map { |post| post.at('h2')&.text }
-    expect(matching_titles).to include('Breaking News: ACME Corp\'s Technology Breakthrough',
-                                       'ACME Corp\'s Environmental Research Update',
-                                       'ACME Corp\'s Economic Analysis Report',
-                                       'ACME Corp\'s Developer Health and Wellness Tips')
-    expect(matching_titles).not_to include('Sponsored Content: Buy ACME Corp\'s Product')
-  end
-
-  it 'parses ISO 8601 datetime format correctly from time elements', :aggregate_failures do
-    items_with_time = items.select(&:pubDate)
-    expect(items_with_time.size).to eq(4)
-    expect(items_with_time).to all(have_attributes(pubDate: be_a(Time).and(have_attributes(year: 2024))))
-  end
-
-  it 'validates that attribute extraction works for datetime', :aggregate_failures do
-    items = feed.items
-
-    # All items should have published dates extracted from time[datetime] attributes
-    items.each do |item|
-      expect(item.pubDate).to be_a(Time)
-      expect(item.pubDate.year).to eq(2024)
-    end
-  end
-
-  it 'ensures performance optimization by using specific selectors', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    doc = Nokogiri::HTML(File.read(html_file))
-    all_posts = doc.css('.post')
-    optimized_posts = doc.css('.main-content .post:not(.advertisement)')
-    expect(all_posts.size).to eq(7)
-    expect(optimized_posts.size).to eq(4)
-    expect(optimized_posts.size).to be < all_posts.size
+  it 'parses datetime attributes directly from the markup' do
+    expect(items.map { |item| item.pubDate.rfc2822 }).to eq(expected_items.map { |expected| expected[:pub_date] })
   end
 end

--- a/spec/examples/unreliable_site_spec.rb
+++ b/spec/examples/unreliable_site_spec.rb
@@ -4,110 +4,72 @@ require 'spec_helper'
 
 RSpec.describe 'Unreliable Site Configuration' do
   subject(:feed) do
-    # Mock the request service to return our HTML fixture
     mock_request_service_with_html_fixture('unreliable_site', 'https://example.com')
-
     Html2rss.feed(config)
   end
 
   let(:config_file) { File.join(%w[spec examples unreliable_site.yml]) }
-  let(:html_file) { File.join(%w[spec examples unreliable_site.html]) }
   let(:config) { Html2rss.config_from_yaml_file(config_file) }
+  let(:items) { feed.items }
 
-  it 'generates a valid RSS feed', :aggregate_failures do
-    expect(feed).to be_a(RSS::Rss)
-    expect(feed.channel.title).to be_a(String)
-    expect(feed.channel.link).to be_a(String)
+  let(:expected_items) do
+    [
+      {
+        title: "Breaking News: ACME Corp's Technology Advances",
+        link: 'https://example.com/articles/breaking-news-technology-advances',
+        description_includes: [
+          "latest technology advances",
+          'Warning: May contain traces of bugs.'
+        ]
+      },
+      {
+        title: 'ACME Corp Science Discovery: New Findings',
+        link: 'https://example.com/articles/science-discovery-new-findings',
+        description_includes: [
+          'groundbreaking discoveries in the field of quantum physics',
+          'They discovered that quantum computers work better with coffee.'
+        ]
+      },
+      {
+        title: 'ACME Corp Environmental Impact Report',
+        link: 'https://example.com/articles/environmental-impact-report',
+        description_includes: [
+          'environmental changes and their impact on global ecosystems',
+          'ACME Corp is trying to make infinite loops carbon-neutral.'
+        ]
+      },
+      {
+        title: 'ACME Corp Economic Analysis: Market Trends',
+        link: 'https://example.com/articles/economic-analysis-market-trends',
+        description_includes: [
+          'current market trends and their implications',
+          'coffee stocks are up 42%'
+        ]
+      },
+      {
+        title: 'ACME Corp Developer Health and Wellness Update',
+        link: 'https://example.com/articles/health-wellness-update',
+        description_includes: [
+          'health and wellness trends that are gaining popularity among developers',
+          'standing desks are great'
+        ]
+      }
+    ]
+  end
+
+  it 'emits channel metadata suitable for flaky upstream sources' do
     expect(feed.channel.ttl).to eq(60)
   end
 
-  it 'extracts all 5 items from the HTML fixture', :aggregate_failures do
-    expect(feed.items).to be_an(Array)
-    expect(feed.items.size).to eq(5)
+  it 'extracts resilient titles across heterogeneous markup' do
+    expect_feed_items(items, expected_items)
   end
 
-  it 'extracts titles using fallback selectors (h1, h2, .title)', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    items = feed.items
-    titles = items.map(&:title)
-    expect(titles).to all(be_a(String)).and all(satisfy { |title| !title.strip.empty? })
-    expect(titles).to include('Breaking News: ACME Corp\'s Technology Advances',
-                              'ACME Corp Science Discovery: New Findings',
-                              'ACME Corp Environmental Impact Report',
-                              'ACME Corp Economic Analysis: Market Trends',
-                              'ACME Corp Developer Health and Wellness Update')
+  it 'sanitises and truncates body content to keep feeds lightweight' do
+    expect(items.map { |item| item.description.length }).to all(be <= 500)
   end
 
-  it 'extracts URLs correctly with parse_uri post-processing', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    items = feed.items
-    urls = items.map(&:link)
-    expect(urls).to all(be_a(String)).and all(satisfy { |url| !url.strip.empty? })
-    expect(urls).to include('https://example.com/articles/breaking-news-technology-advances',
-                            'https://example.com/articles/science-discovery-new-findings',
-                            'https://example.com/articles/environmental-impact-report',
-                            'https://example.com/articles/economic-analysis-market-trends',
-                            'https://example.com/articles/health-wellness-update')
-  end
-
-  it 'applies sanitize_html post-processing to descriptions', :aggregate_failures do
-    items = feed.items
-    descriptions = items.map(&:description)
-    expect(descriptions).to all(be_a(String)).and all(satisfy { |desc| !desc.strip.empty? }).and all(satisfy { |desc|
-      !desc.match(/<[^>]+>/)
-    })
-  end
-
-  it 'applies substring post-processing with 500 character limit', :aggregate_failures do
-    items = feed.items
-    descriptions = items.map(&:description)
-    expect(descriptions).to all(satisfy { |desc| desc.length <= 500 })
-    long_descriptions = descriptions.select { |desc| desc.length >= 400 }
-    expect(long_descriptions.size).to be > 0
-  end
-
-  it 'handles multiple selector fallbacks for items (.post, .article)', :aggregate_failures do
-    items = feed.items
-    expect(items.size).to eq(5)
-
-    # Verify we got items from both .post and .article selectors
-    # This tests that the fallback selector mechanism works
-    expect(items.size).to be > 0
-  end
-
-  it 'handles different content structures (.content, .excerpt, p)', :aggregate_failures do
-    items = feed.items
-    descriptions = items.map(&:description)
-
-    # All items should have descriptions regardless of source structure
-    expect(descriptions).to all(be_a(String))
-    expect(descriptions).to all(satisfy { |desc| !desc.strip.empty? })
-
-    # Test that we can extract from different content structures
-    # Some items use .content, some use .excerpt, some use direct p tags
-    expect(descriptions.size).to eq(5)
-  end
-
-  it 'validates that parse_uri post-processing creates valid URLs', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    items = feed.items
-    urls = items.map(&:link)
-    expect(urls).to all(match(%r{^https://example\.com/articles/})
-    .and(satisfy { |url| !url.include?(' ') })
-    .and(satisfy { |url| !url.include?('<') })
-    .and(satisfy { |url| !url.include?('>') }))
-  end
-
-  it 'sets the correct TTL value for unreliable sites' do
-    expect(feed.channel.ttl).to eq(60)
-  end
-
-  it 'extracts content from items with different title structures', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    items = feed.items
-    h2_titles = items.select do |item|
-      item.title.include?('Technology Advances') || item.title.include?('Environmental Impact')
-    end
-    h1_titles = items.select { |item| item.title.include?('Science Discovery') }
-    dot_title = items.select { |item| item.title.include?('Environmental Impact Report') }
-    expect(h2_titles.size).to be >= 2
-    expect(h1_titles.size).to be >= 1
-    expect(dot_title.size).to be >= 1
+  it 'normalises every hyperlink via parse_uri post-processing' do
+    expect(items.map(&:link)).to eq(expected_items.map { |item| item[:link] })
   end
 end

--- a/spec/support/helpers/example_helpers.rb
+++ b/spec/support/helpers/example_helpers.rb
@@ -1,67 +1,24 @@
 # frozen_string_literal: true
 
 # Helper methods for HTML2RSS example specs
-# These methods provide common setup and validation patterns
-# to make tests more readable and maintainable.
+# These helpers keep the specs focused on intent while staying close to the
+# production pipeline so the assertions remain trustworthy.
 
 require_relative 'configuration_helpers'
 
 module ExampleHelpers
   include ConfigurationHelpers
 
-  # Loads an example HTML fixture from the spec/examples directory
-  # @param fixture_name [String] The name of the HTML fixture file (without .html extension)
-  # @return [String] The HTML content as a string
-  # @example
-  #   html_content = load_html_fixture('combined_scraper_sources')
-  def load_html_fixture(fixture_name)
-    html_file = File.join(%w[spec examples], "#{fixture_name}.html")
-    File.read(html_file)
+  FIXTURE_ROOT = File.join('spec', 'examples').freeze
+
+  def mock_request_service_with_html_fixture(fixture_name, url, content_type: 'text/html')
+    stub_request_service(fixture_path(fixture_name, 'html'), url, content_type)
   end
 
-  # Loads an example JSON fixture from the spec/examples directory
-  # @param fixture_name [String] The name of the JSON fixture file (without .json extension)
-  # @return [String] The JSON content as a string
-  # @example
-  #   json_content = load_json_fixture('json_api_site')
-  def load_json_fixture(fixture_name)
-    json_file = File.join(%w[spec examples], "#{fixture_name}.json")
-    File.read(json_file)
+  def mock_request_service_with_json_fixture(fixture_name, url, content_type: 'application/json')
+    stub_request_service(fixture_path(fixture_name, 'json'), url, content_type)
   end
 
-  # Mocks the request service to return HTML content from a fixture
-  # @param fixture_name [String] The name of the HTML fixture file
-  # @param url [String] The URL to use for the mock response (default: 'https://example.com')
-  # @param content_type [String] The content type header (default: 'text/html')
-  # @example
-  #   mock_request_service_with_html_fixture('combined_scraper_sources', 'https://example.com')
-  def mock_request_service_with_html_fixture(fixture_name, url = 'https://example.com', content_type = 'text/html')
-    html_content = load_html_fixture(fixture_name)
-    url_object = create_url_object(url)
-    mock_request_service(html_content, url_object, content_type)
-  end
-
-  # Mocks the request service to return JSON content from a fixture
-  # @param fixture_name [String] The name of the JSON fixture file
-  # @param url [String] The URL to use for the mock response (default: 'https://example.com/api')
-  # @param content_type [String] The content type header (default: 'application/json')
-  # @example
-  #   mock_request_service_with_json_fixture('json_api_site', 'https://api.example.com/posts')
-  def mock_request_service_with_json_fixture(fixture_name, url = 'https://example.com/api',
-                                             content_type = 'application/json')
-    json_content = load_json_fixture(fixture_name)
-    url_object = create_url_object(url)
-    mock_request_service(json_content, url_object, content_type)
-  end
-
-  # Generates an RSS feed from a configuration with mocked request service
-  # @param config [Hash] The HTML2RSS configuration hash
-  # @param fixture_name [String] The name of the fixture file to use
-  # @param fixture_type [Symbol] The type of fixture (:html or :json)
-  # @param url [String] The URL to use for the mock response
-  # @return [RSS::Rss] The generated RSS feed
-  # @example
-  #   feed = generate_feed_from_config(config, 'combined_scraper_sources', :html)
   def generate_feed_from_config(config, fixture_name, fixture_type = :html, url = 'https://example.com')
     case fixture_type
     when :html
@@ -72,115 +29,70 @@ module ExampleHelpers
       raise ArgumentError, "Invalid fixture_type: #{fixture_type}. Must be :html or :json"
     end
 
-    # Update the config with the URL for proper URL handling
-    config_with_url = config.merge(channel: config[:channel].merge(url:))
-    Html2rss.feed(config_with_url)
+    channel_config = config.fetch(:channel).merge(url:)
+    Html2rss.feed(config.merge(channel: channel_config))
   end
 
-  # Extracts all item titles from an RSS feed
-  # @param feed [RSS::Rss] The RSS feed
-  # @return [Array<String>] Array of item titles
-  # @example
-  #   titles = extract_item_titles(feed)
-  def extract_item_titles(feed)
-    return [] unless feed.is_a?(RSS::Rss) && feed.items.is_a?(Array)
+  def expect_feed_items(items, expected_items)
+    expect(items.size).to eq(expected_items.size)
 
-    feed.items.filter_map(&:title)
-  end
+    items.zip(expected_items).each_with_index do |(item, expected), index|
+      aggregate_failures("item ##{index + 1}") do
+        expect(item.title).to eq(expected[:title]) if expected.key?(:title)
 
-  # Extracts all item descriptions from an RSS feed
-  # @param feed [RSS::Rss] The RSS feed
-  # @return [Array<String>] Array of item descriptions
-  # @example
-  #   descriptions = extract_item_descriptions(feed)
-  def extract_item_descriptions(feed)
-    return [] unless feed.is_a?(RSS::Rss) && feed.items.is_a?(Array)
+        if expected.key?(:link)
+          expected_link = expected[:link]
+          expected_link.nil? ? expect(item.link).to(be_nil) : expect(item.link).to(eq(expected_link))
+        end
 
-    feed.items.filter_map(&:description)
-  end
+        Array(expected[:description_includes]).each do |snippet|
+          expect(item.description).to include(snippet)
+        end
 
-  # Extracts all item links from an RSS feed
-  # @param feed [RSS::Rss] The RSS feed
-  # @return [Array<String>] Array of item links
-  # @example
-  #   links = extract_item_links(feed)
-  def extract_item_links(feed)
-    return [] unless feed.is_a?(RSS::Rss) && feed.items.is_a?(Array)
+        if expected.key?(:description_starts_with)
+          expect(item.description).to start_with(expected[:description_starts_with])
+        end
 
-    feed.items.filter_map(&:link)
-  end
+        if expected.key?(:categories)
+          expect(item.categories.map(&:content)).to eq(expected[:categories])
+        end
 
-  # Extracts all item published dates from an RSS feed
-  # @param feed [RSS::Rss] The RSS feed
-  # @return [Array<Time>] Array of item published dates (excluding nil values)
-  # @example
-  #   dates = extract_item_published_dates(feed)
-  def extract_item_published_dates(feed)
-    return [] unless feed.is_a?(RSS::Rss) && feed.items.is_a?(Array)
+        if expected.key?(:pub_date)
+          actual_pub_date = item.pubDate&.rfc2822
+          expected[:pub_date].nil? ? expect(actual_pub_date).to(be_nil) : expect(actual_pub_date).to(eq(expected[:pub_date]))
+        end
 
-    feed.items.filter_map(&:pubDate)
-  end
+        next unless expected.key?(:enclosure)
 
-  # Extracts all categories from RSS feed items
-  # @param feed [RSS::Rss] The RSS feed
-  # @return [Array<String>] Array of all category contents
-  # @example
-  #   categories = extract_all_categories(feed)
-  def extract_all_categories(feed)
-    return [] unless feed.is_a?(RSS::Rss) && feed.items.is_a?(Array)
-
-    feed.items.flat_map { |item| item.categories.map(&:content) }.compact.uniq
-  end
-
-  # Validates that all strings in an array are non-empty
-  # @param strings [Array<String>] Array of strings to validate
-  # @return [Boolean] True if all strings are non-empty
-  # @example
-  #   expect(all_strings_non_empty?(titles)).to be true
-  def all_strings_non_empty?(strings)
-    strings.is_a?(Array) && strings.all? { |str| str.is_a?(String) && !str.strip.empty? }
-  end
-
-  # Validates that all times in an array are valid Time objects
-  # @param times [Array] Array of objects to validate as times
-  # @return [Boolean] True if all objects are valid Time objects
-  # @example
-  #   expect(all_valid_times?(published_dates)).to be true
-  def all_valid_times?(times)
-    times.is_a?(Array) && times.all?(Time)
-  end
-
-  # Creates a descriptive test name for configuration validation
-  # @param config_name [String] The name of the configuration
-  # @param validation_type [String] The type of validation being performed
-  # @return [String] A descriptive test name
-  # @example
-  #   test_name = config_validation_test_name('combined_scraper_sources', 'basic structure')
-  def config_validation_test_name(config_name, validation_type)
-    "#{config_name} configuration #{validation_type}"
-  end
-
-  # Creates a descriptive test name for RSS feed validation
-  # @param validation_type [String] The type of validation being performed
-  # @return [String] A descriptive test name
-  # @example
-  #   test_name = rss_validation_test_name('generates valid feed')
-  def rss_validation_test_name(validation_type)
-    "RSS feed #{validation_type}"
+        if expected[:enclosure].nil?
+          expect(item.enclosure).to be_nil
+        else
+          expect(item.enclosure).not_to be_nil
+          enclosure = item.enclosure
+          expect(enclosure.url).to eq(expected[:enclosure][:url]) if expected[:enclosure].key?(:url)
+          expect(enclosure.type).to eq(expected[:enclosure][:type]) if expected[:enclosure].key?(:type)
+          if expected[:enclosure].key?(:length)
+            expect(enclosure.length).to eq(expected[:enclosure][:length])
+          end
+        end
+      end
+    end
   end
 
   private
 
-  def create_url_object(url)
-    url.is_a?(String) ? Html2rss::Url.from_relative(url, url) : url
+  def fixture_path(fixture_name, extension)
+    File.join(FIXTURE_ROOT, "#{fixture_name}.#{extension}")
   end
 
-  def mock_request_service(content, url_object, content_type)
-    # Mock the execute method on the RequestService class (which delegates to instance)
+  def stub_request_service(fixture_path, url, content_type)
+    body = File.read(fixture_path)
+    response_url = Html2rss::Url.from_relative(url, url)
+
     allow(Html2rss::RequestService).to receive(:execute).and_return(
       Html2rss::RequestService::Response.new(
-        body: content,
-        url: url_object,
+        body: body,
+        url: response_url,
         headers: { 'content-type': content_type }
       )
     )


### PR DESCRIPTION
## Summary
- remove unused helper utilities from the example specs to keep the helper focused on fixture stubbing and item assertions
- simplify `expect_feed_items` so it only covers the exercised attributes with clearer aggregate failure scopes
- centralise HTML/JSON fixture loading through lightweight request stubs for readability

## Testing
- bundle exec rspec spec/examples

------
https://chatgpt.com/codex/tasks/task_e_68e5890d717c832d928fb03710f5dff2