### PR TITLE
perf(media_renderer): reduce allocations for media table#299

### DIFF
--- a/lib/html2rss/rendering/media_table_renderer.rb
+++ b/lib/html2rss/rendering/media_table_renderer.rb
@@ -32,10 +32,13 @@ module Html2rss
         </table>
       HTML
 
-      TYPE_MAPPINGS = {
-        %r{^image/} => { icon: '🖼️', label: 'Image', action_text: 'View' },
-        %r{^video/} => { icon: '🎥', label: 'Video', action_text: 'Play' },
-        %r{^audio/} => { icon: '🎵', label: 'Audio', action_text: 'Play' },
+      PREFIX_TYPE_MAPPINGS = {
+        'image/' => { icon: '🖼️', label: 'Image', action_text: 'View' },
+        'video/' => { icon: '🎥', label: 'Video', action_text: 'Play' },
+        'audio/' => { icon: '🎵', label: 'Audio', action_text: 'Play' }
+      }.freeze
+
+      STRING_TYPE_MAPPINGS = {
         'application/pdf' => { icon: '📄', label: 'PDF Document', action_text: 'Open' }
       }.freeze
 
@@ -44,6 +47,8 @@ module Html2rss
       def initialize(enclosures:, image:)
         @enclosures = Array(enclosures)
         @image = image
+        @type_mapping_cache = {}
+        @has_image_enclosure = @enclosures.any? { |enclosure| enclosure.type&.start_with?('image/') }
       end
 
       # Generates the complete media table HTML.
@@ -67,82 +72,75 @@ module Html2rss
       end
 
       def table_rows
-        rows = []
-
-        # Add enclosure rows
-        rows.concat(@enclosures.map { |enclosure| enclosure_row(enclosure) })
-
-        # Add fallback image row if present and not already covered by enclosures
-        rows << image_row(@image) if @image && !image_enclosure?
-
+        rows = @enclosures.map { |enclosure| enclosure_row(enclosure) }
+        rows << image_row(@image) if @image && !@has_image_enclosure
         rows.join("\n")
       end
 
       def enclosure_row(enclosure)
-        type_icon = type_icon(enclosure.type)
-        type_label = type_label(enclosure.type)
-        escaped_url = escaped_url(enclosure.url)
+        mapping = type_mapping_for(enclosure.type)
+        escaped = escape_url(enclosure.url)
+        type_icon = mapping&.fetch(:icon, nil) || '📎'
+        type_label = mapping&.fetch(:label, nil) || 'File'
 
         <<~HTML.strip
           <tr>
             <td>#{type_icon} #{type_label}</td>
-            <td><a href="#{escaped_url}" target="_blank" rel="nofollow noopener noreferrer">#{escaped_url}</a></td>
-            <td>#{action_links(enclosure)}</td>
+            <td><a href="#{escaped}" target="_blank" rel="nofollow noopener noreferrer">#{escaped}</a></td>
+            <td>#{action_links_for(escaped, mapping)}</td>
           </tr>
         HTML
       end
 
       def image_row(url)
+        escaped = escape_url(url)
+
         <<~HTML.strip
           <tr>
             <td>🖼️ Image</td>
-            <td><a href="#{escaped_url(url)}" target="_blank" rel="nofollow noopener noreferrer">#{escaped_url(url)}</a></td>
-            <td>#{action_links_html(url, 'View')}</td>
+            <td><a href="#{escaped}" target="_blank" rel="nofollow noopener noreferrer">#{escaped}</a></td>
+            <td>#{action_links_html(escaped, 'View')}</td>
           </tr>
         HTML
       end
 
-      def type_icon(type)
-        mapping = find_type_mapping(type)
-        mapping&.dig(:icon) || '📎'
+      def action_links_for(escaped_url, mapping)
+        action_text = mapping&.fetch(:action_text, nil)
+        return download_link(escaped_url) unless action_text
+
+        action_links_html(escaped_url, action_text)
       end
 
-      def type_label(type)
-        mapping = find_type_mapping(type)
-        mapping&.dig(:label) || 'File'
+      def action_links_html(escaped_url, action_text)
+        <<~HTML.strip
+          <a href="#{escaped_url}" target="_blank" rel="nofollow noopener noreferrer">#{action_text}</a> |
+          #{download_link(escaped_url)}
+        HTML
       end
 
-      def action_links(enclosure)
-        mapping = find_type_mapping(enclosure.type)
-        if mapping
-          action_links_html(enclosure.url, mapping[:action_text])
-        else
-          download_link(enclosure.url)
+      def download_link(escaped_url)
+        <<~HTML.strip
+          <a href="#{escaped_url}" target="_blank" rel="nofollow noopener noreferrer" download="">Download</a>
+        HTML
+      end
+
+      def type_mapping_for(type)
+        return if type.nil?
+
+        return @type_mapping_cache[type] if @type_mapping_cache.key?(type)
+
+        @type_mapping_cache[type] = STRING_TYPE_MAPPINGS[type] || prefix_mapping_for(type)
+      end
+
+      def prefix_mapping_for(type)
+        PREFIX_TYPE_MAPPINGS.each do |prefix, mapping|
+          return mapping if type.start_with?(prefix)
         end
+
+        nil
       end
 
-      def find_type_mapping(type)
-        TYPE_MAPPINGS.find { |pattern, _| pattern.is_a?(Regexp) ? pattern =~ type : pattern == type }&.last
-      end
-
-      def action_links_html(url, action_text)
-        <<~HTML.strip
-          <a href="#{escaped_url(url)}" target="_blank" rel="nofollow noopener noreferrer">#{action_text}</a> |
-          #{download_link(url)}
-        HTML
-      end
-
-      def download_link(url)
-        <<~HTML.strip
-          <a href="#{escaped_url(url)}" target="_blank" rel="nofollow noopener noreferrer" download="">Download</a>
-        HTML
-      end
-
-      def image_enclosure?
-        @enclosures.any? { |enclosure| enclosure.type =~ %r{^image/} }
-      end
-
-      def escaped_url(url)
+      def escape_url(url)
         CGI.escapeHTML(url.to_s)
       end
     end


### PR DESCRIPTION

- cache MIME type lookups in the media table renderer and avoid repeated HTML escaping
- reuse prefix/string mappings to eliminate repeated regex scans and streamline row rendering
