### PR TITLE
Add HTML parser abstraction

### DIFF
--- a/lib/html2rss/auto_source/scraper.rb
+++ b/lib/html2rss/auto_source/scraper.rb
@@ -23,7 +23,7 @@ module Html2rss
 
       ##
       # Returns an array of scrapers that claim to find articles in the parsed body.
-      # @param parsed_body [Nokogiri::HTML::Document] The parsed HTML body.
+      # @param parsed_body [Object] The parsed HTML body.
       # @param opts [Hash] The options hash.
       # @return [Array<Class>] An array of scraper classes that can handle the parsed body.
       def self.from(parsed_body, opts = Html2rss::AutoSource::DEFAULT_CONFIG[:scraper])

--- a/lib/html2rss/auto_source/scraper/html.rb
+++ b/lib/html2rss/auto_source/scraper/html.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'nokogiri'
-
 module Html2rss
   class AutoSource
     module Scraper
@@ -28,7 +26,7 @@ module Html2rss
           xpath.gsub(/\[\d+\]/, '')
         end
 
-        # @param parsed_body [Nokogiri::HTML::Document] The parsed HTML document.
+        # @param parsed_body [Object] The parsed HTML document.
         # @param url [String] The base URL.
         # @param extractor [Class] The extractor class to handle article extraction.
         # @param opts [Hash] Additional options.

--- a/lib/html2rss/auto_source/scraper/rss_feed_detector.rb
+++ b/lib/html2rss/auto_source/scraper/rss_feed_detector.rb
@@ -39,7 +39,7 @@ module Html2rss
         ##
         # Check if the parsed_body contains RSS feed link tags.
         # This scraper should only be used as a fallback when other scrapers fail.
-        # @param parsed_body [Nokogiri::HTML::Document] The parsed HTML document
+        # @param parsed_body [Object] The parsed HTML document
         # @return [Boolean] True if RSS feeds are found, otherwise false.
         def self.articles?(parsed_body)
           return false unless parsed_body
@@ -47,7 +47,7 @@ module Html2rss
           parsed_body.css(FEED_LINK_SELECTOR).any?
         end
 
-        # @param parsed_body [Nokogiri::HTML::Document] The parsed HTML document.
+        # @param parsed_body [Object] The parsed HTML document.
         # @param url [String, Html2rss::Url] The base URL.
         # @param opts [Hash] Additional options (unused but kept for consistency).
         def initialize(parsed_body, url:, **opts)

--- a/lib/html2rss/auto_source/scraper/schema.rb
+++ b/lib/html2rss/auto_source/scraper/schema.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'json'
-require 'nokogiri'
 
 module Html2rss
   class AutoSource
@@ -36,12 +35,12 @@ module Html2rss
           # of all supported schema objects
           # by recursively traversing the given `object`.
           #
-          # @param object [Hash, Array, Nokogiri::XML::Element]
+          # @param object [Hash, Array, Object]
           # @return [Array<Hash>] the schema_objects, or an empty array
           # :reek:DuplicateMethodCall
           def from(object)
             case object
-            when Nokogiri::XML::Element
+            when HtmlParser.element_class
               from(parse_script_tag(object))
             when Hash
               supported_schema_object?(object) ? [object] : object.values.flat_map { |item| from(item) }

--- a/lib/html2rss/auto_source/scraper/semantic_html.rb
+++ b/lib/html2rss/auto_source/scraper/semantic_html.rb
@@ -27,7 +27,7 @@ module Html2rss
         def self.options_key = :semantic_html
 
         # Check if the parsed_body contains articles
-        # @param parsed_body [Nokogiri::HTML::Document] The parsed HTML document
+        # @param parsed_body [Object] The parsed HTML document
         # @return [Boolean] True if articles are found, otherwise false.
         def self.articles?(parsed_body)
           return false unless parsed_body
@@ -37,7 +37,7 @@ module Html2rss
           end
         end
 
-        # @param parsed_body [Nokogiri::HTML::Document] The parsed HTML document.
+        # @param parsed_body [Object] The parsed HTML document.
         # @param url [String] The base URL.
         # @param extractor [Class] The extractor class to handle article extraction.
         # @param opts [Hash] Additional options.
@@ -66,7 +66,7 @@ module Html2rss
 
         private
 
-        # @yield [Nokogiri::XML::Element] Gives each found article tag.
+        # @yield [Object] Gives each found article tag.
         def each_candidate
           ANCHOR_TAG_SELECTORS.each do |tag_name, selector|
             parsed_body.css(selector).each do |anchor|

--- a/lib/html2rss/category_extractor.rb
+++ b/lib/html2rss/category_extractor.rb
@@ -18,7 +18,7 @@ module Html2rss
     # Extracts categories from the given article tag by looking for elements
     # with class names containing common category-related terms.
     #
-    # @param article_tag [Nokogiri::XML::Element] The article element to extract categories from
+    # @param article_tag [Object] The article element to extract categories from
     # @return [Array<String>] Array of category strings, empty if none found
     def self.call(article_tag)
       return [] unless article_tag
@@ -32,7 +32,7 @@ module Html2rss
     ##
     # Optimized single DOM traversal that extracts all category types.
     #
-    # @param article_tag [Nokogiri::XML::Element] The article element
+    # @param article_tag [Object] The article element
     # @return [Set<String>] Set of category strings
     def self.extract_all_categories(article_tag)
       Set.new.tap do |categories|
@@ -49,7 +49,7 @@ module Html2rss
     ##
     # Extracts categories from data attributes of a single element.
     #
-    # @param element [Nokogiri::XML::Element] The element to process
+    # @param element [Object] The element to process
     # @return [Set<String>] Set of category strings
     def self.extract_element_data_categories(element)
       Set.new.tap do |categories|
@@ -65,7 +65,7 @@ module Html2rss
     ##
     # Extracts text-based categories from elements, splitting content into discrete values.
     #
-    # @param element [Nokogiri::XML::Element] The element to process
+    # @param element [Object] The element to process
     # @return [Set<String>] Set of category strings
     def self.extract_text_categories(element)
       anchor_values = element.css('a').filter_map do |node|

--- a/lib/html2rss/html_extractor.rb
+++ b/lib/html2rss/html_extractor.rb
@@ -21,7 +21,7 @@ module Html2rss
       ##
       # Extracts visible text from a given node and its children.
       #
-      # @param tag [Nokogiri::XML::Node] the node from which to extract visible text
+      # @param tag [Object] the node from which to extract visible text
       # @param separator [String] separator used to join text fragments (default is a space)
       # @return [String, nil] the concatenated visible text, or nil if none is found
       def extract_visible_text(tag, separator: ' ')

--- a/lib/html2rss/html_navigator.rb
+++ b/lib/html2rss/html_navigator.rb
@@ -9,9 +9,9 @@ module Html2rss
       # Returns the first parent that satisfies the condition.
       # If the condition is met, it returns the node itself.
       #
-      # @param node [Nokogiri::XML::Node] The node to start the search from.
+      # @param node [Object] The node to start the search from.
       # @param condition [Proc] The condition to be met.
-      # @return [Nokogiri::XML::Node, nil] The first parent that satisfies the condition.
+      # @return [Object, nil] The first parent that satisfies the condition.
       def parent_until_condition(node, condition)
         while node && !node.document? && node.name != 'html'
           return node if condition.call(node)

--- a/lib/html2rss/html_parser.rb
+++ b/lib/html2rss/html_parser.rb
@@ -1,0 +1,229 @@
+# frozen_string_literal: true
+
+require 'concurrent/atomic/atomic_reference'
+require 'nokogiri'
+
+module Html2rss
+  ##
+  # Provides an abstraction layer around the HTML/XML parsing backend.
+  #
+  # All Html2rss code should interact with HTML parsing via this class so the
+  # underlying backend can be swapped (e.g. Nokogiri, Nokolexbor, REXML).
+  # The backend must respond to the public methods defined here.
+  class HtmlParser
+    BACKEND = Concurrent::AtomicReference.new
+
+    class << self
+      ##
+      # Sets the parser backend.
+      #
+      # @param backend [Object] object responding to parser interface
+      def use(backend)
+        backend_ref.value = backend
+      end
+
+      ##
+      # @return [Object] the configured parser backend
+      def backend
+        backend_ref.value || initialize_backend
+      end
+
+      ##
+      # Parses an HTML document string.
+      #
+      # @param html [String]
+      # @return [Object] backend specific document
+      def parse_html(html)
+        backend.parse_html(html)
+      end
+
+      ##
+      # Parses an HTML fragment string.
+      #
+      # @param html [String]
+      # @return [Object]
+      def parse_html_fragment(html)
+        backend.parse_html_fragment(html)
+      end
+
+      ##
+      # Parses an HTML5 fragment string.
+      #
+      # @param html [String]
+      # @return [Object]
+      def parse_html5_fragment(html)
+        backend.parse_html5_fragment(html)
+      end
+
+      ##
+      # Parses an XML document string.
+      #
+      # @param xml [String]
+      # @return [Object]
+      def parse_xml(xml)
+        backend.parse_xml(xml)
+      end
+
+      ##
+      # Parses an XML fragment string.
+      #
+      # @param xml [String]
+      # @return [Object]
+      def parse_xml_fragment(xml)
+        backend.parse_xml_fragment(xml)
+      end
+
+      ##
+      # @return [Class] backend specific HTML document class
+      def document_class
+        backend.document_class
+      end
+
+      ##
+      # @return [Class] backend specific HTML fragment class
+      def fragment_class
+        backend.fragment_class
+      end
+
+      ##
+      # @return [Class] backend specific XML document class
+      def xml_document_class
+        backend.xml_document_class
+      end
+
+      ##
+      # @return [Class] backend specific XML element class
+      def element_class
+        backend.element_class
+      end
+
+      ##
+      # @return [Class] backend specific XML node class
+      def node_class
+        backend.node_class
+      end
+
+      ##
+      # @return [Class] backend specific XML node set class
+      def node_set_class
+        backend.node_set_class
+      end
+
+      ##
+      # Creates a new node using the backend.
+      #
+      # @param name [String] node name
+      # @param document [Object] backend specific document
+      # @return [Object]
+      def create_node(name, document)
+        backend.create_node(name, document)
+      end
+
+      private
+
+      def backend_ref
+        BACKEND
+      end
+
+      def initialize_backend
+        backend_ref.compare_and_set(nil, Backends::Nokogiri.new)
+        backend_ref.value
+      end
+    end
+
+    module Backends
+      ##
+      # Default backend powered by Nokogiri.
+      class Nokogiri
+        ##
+        # Parses an HTML document string.
+        #
+        # @param html [String]
+        # @return [Nokogiri::HTML::Document]
+        def parse_html(html)
+          ::Nokogiri::HTML(html)
+        end
+
+        ##
+        # Parses an HTML fragment string.
+        #
+        # @param html [String]
+        # @return [Nokogiri::HTML::DocumentFragment]
+        def parse_html_fragment(html)
+          ::Nokogiri::HTML.fragment(html)
+        end
+
+        ##
+        # Parses an HTML5 fragment string.
+        #
+        # @param html [String]
+        # @return [Nokogiri::HTML5::DocumentFragment]
+        def parse_html5_fragment(html)
+          ::Nokogiri::HTML5.fragment(html)
+        end
+
+        ##
+        # Parses an XML document string.
+        #
+        # @param xml [String]
+        # @return [Nokogiri::XML::Document]
+        def parse_xml(xml)
+          ::Nokogiri::XML(xml)
+        end
+
+        ##
+        # Parses an XML fragment string.
+        #
+        # @param xml [String]
+        # @return [Nokogiri::XML::DocumentFragment]
+        def parse_xml_fragment(xml)
+          ::Nokogiri::XML.fragment(xml)
+        end
+
+        ##
+        # @return [Class]
+        def document_class
+          ::Nokogiri::HTML::Document
+        end
+
+        ##
+        # @return [Class]
+        def fragment_class
+          ::Nokogiri::HTML::DocumentFragment
+        end
+
+        ##
+        # @return [Class]
+        def xml_document_class
+          ::Nokogiri::XML::Document
+        end
+
+        ##
+        # @return [Class]
+        def element_class
+          ::Nokogiri::XML::Element
+        end
+
+        ##
+        # @return [Class]
+        def node_class
+          ::Nokogiri::XML::Node
+        end
+
+        ##
+        # @return [Class]
+        def node_set_class
+          ::Nokogiri::XML::NodeSet
+        end
+
+        ##
+        # @param name [String]
+        # @param document [Nokogiri::XML::Document]
+        # @return [Nokogiri::XML::Node]
+        def create_node(name, document)
+          ::Nokogiri::XML::Node.new(name, document)
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/request_service/response.rb
+++ b/lib/html2rss/request_service/response.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'nokogiri'
-
 module Html2rss
   class RequestService
     ##
@@ -34,11 +32,11 @@ module Html2rss
       def html_response? = content_type.include?('text/html')
 
       ##
-      # @return [Nokogiri::HTML::Document, Hash] the parsed body of the response, frozen object
+      # @return [HtmlParser.document_class, Hash] the parsed body of the response, frozen object
       # @raise [UnsupportedResponseContentType] if the content type is not supported
       def parsed_body
         @parsed_body ||= if html_response?
-                           Nokogiri::HTML(body).tap do |doc|
+                           HtmlParser.parse_html(body).tap do |doc|
                              # Remove comments from the document to avoid processing irrelevant content
                              doc.xpath('//comment()').each(&:remove)
                            end.freeze

--- a/lib/html2rss/rss_builder/article.rb
+++ b/lib/html2rss/rss_builder/article.rb
@@ -2,7 +2,6 @@
 
 require 'zlib'
 require 'sanitize'
-require 'nokogiri'
 
 module Html2rss
   class RssBuilder

--- a/lib/html2rss/selectors/extractors.rb
+++ b/lib/html2rss/selectors/extractors.rb
@@ -27,18 +27,18 @@ module Html2rss
 
       class << self
         ##
-        # Retrieves an element from Nokogiri XML based on the selector.
+        # Retrieves elements from the configured HTML backend based on the selector.
         #
-        # @param xml [Nokogiri::XML::Document]
+        # @param xml [Object]
         # @param selector [String, nil]
-        # @return [Nokogiri::XML::ElementSet] selected XML elements
+        # @return [Object] selected elements
         def element(xml, selector)
           selector ? xml.css(selector) : xml
         end
 
         # @param attribute_options [Hash<Symbol, Object>]
         #   Should contain at least `:extractor` (the name) and required options for that extractor.
-        # @param xml [Nokogiri::XML::Document]
+        # @param xml [Object]
         # @return [Object] instance of the specified item extractor class
         def get(attribute_options, xml)
           extractor_class = NAME_TO_CLASS[attribute_options[:extractor]&.to_sym || DEFAULT_EXTRACTOR]

--- a/lib/html2rss/selectors/extractors/attribute.rb
+++ b/lib/html2rss/selectors/extractors/attribute.rb
@@ -30,7 +30,7 @@ module Html2rss
         ##
         # Initializes the Attribute extractor.
         #
-        # @param xml [Nokogiri::XML::Element]
+        # @param xml [Object]
         # @param options [Options]
         def initialize(xml, options)
           @options = options

--- a/lib/html2rss/selectors/extractors/href.rb
+++ b/lib/html2rss/selectors/extractors/href.rb
@@ -30,7 +30,7 @@ module Html2rss
         ##
         # Initializes the Href extractor.
         #
-        # @param xml [Nokogiri::XML::Element]
+        # @param xml [Object]
         # @param options [Options]
         def initialize(xml, options)
           @options = options

--- a/lib/html2rss/selectors/extractors/html.rb
+++ b/lib/html2rss/selectors/extractors/html.rb
@@ -29,7 +29,7 @@ module Html2rss
         ##
         # Initializes the Html extractor.
         #
-        # @param xml [Nokogiri::XML::Element]
+        # @param xml [Object]
         # @param options [Options]
         def initialize(xml, options)
           @element = Extractors.element(xml, options.selector)

--- a/lib/html2rss/selectors/extractors/static.rb
+++ b/lib/html2rss/selectors/extractors/static.rb
@@ -22,7 +22,7 @@ module Html2rss
         ##
         # Initializes the Static extractor.
         #
-        # @param _xml [nil, Nokogiri::XML::Element] Unused parameter for compatibility with other extractors.
+        # @param _xml [nil, Object] Unused parameter for compatibility with other extractors.
         # @param options [Options] Options containing the static value.
         def initialize(_xml, options)
           @options = options

--- a/lib/html2rss/selectors/extractors/text.rb
+++ b/lib/html2rss/selectors/extractors/text.rb
@@ -27,7 +27,7 @@ module Html2rss
         ##
         # Initializes the Text extractor.
         #
-        # @param xml [Nokogiri::XML::Element]
+        # @param xml [Object]
         # @param options [Options]
         def initialize(xml, options)
           @element = Extractors.element(xml, options.selector)

--- a/lib/html2rss/selectors/post_processors/html_transformers/wrap_img_in_a.rb
+++ b/lib/html2rss/selectors/post_processors/html_transformers/wrap_img_in_a.rb
@@ -11,7 +11,7 @@ module Html2rss
           # Wraps <img> tags into <a> tags that link to `img.src`.
           #
           # @param node_name [String]
-          # @param node [Nokogiri::XML::Node]
+          # @param node [Object]
           # @return [nil]
           def call(node_name:, node:, **_env)
             return unless should_process?(node_name)
@@ -32,10 +32,10 @@ module Html2rss
           ##
           # Wraps the <img> node in an <a> tag.
           #
-          # @param node [Nokogiri::XML::Node]
+          # @param node [Object]
           # @return [nil]
           def wrap_image_in_anchor(node)
-            anchor = Nokogiri::XML::Node.new('a', node.document)
+            anchor = HtmlParser.create_node('a', node.document)
             anchor['href'] = node['src']
             node.add_next_sibling(anchor)
             anchor.add_child(node.remove)

--- a/spec/lib/html2rss/auto_source/scraper/html_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper/html_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Html2rss::AutoSource::Scraper::Html do
     HTML
   end
   let(:parsed_body) do
-    Nokogiri::HTML(html)
+    Html2rss::HtmlParser.parse_html(html)
   end
 
   describe '.options_key' do
@@ -169,7 +169,7 @@ RSpec.describe Html2rss::AutoSource::Scraper::Html do
       HTML
     end
 
-    let(:parsed_body) { Nokogiri::HTML(html) }
+    let(:parsed_body) { Html2rss::HtmlParser.parse_html(html) }
     let(:scraper) { described_class.new(parsed_body, url: 'http://example.com') }
 
     it 'returns false for nodes within ignored tags' do

--- a/spec/lib/html2rss/auto_source/scraper/json_state_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper/json_state_spec.rb
@@ -10,31 +10,31 @@ RSpec.describe Html2rss::AutoSource::Scraper::JsonState do
 
   describe '.articles?' do
     it 'detects Next.js JSON state' do
-      parsed_body = Nokogiri::HTML(load_fixture('next.html'))
+      parsed_body = Html2rss::HtmlParser.parse_html(load_fixture('next.html'))
 
       expect(described_class).to be_articles(parsed_body)
     end
 
     it 'detects Nuxt JSON state' do
-      parsed_body = Nokogiri::HTML(load_fixture('nuxt.html'))
+      parsed_body = Html2rss::HtmlParser.parse_html(load_fixture('nuxt.html'))
 
       expect(described_class).to be_articles(parsed_body)
     end
 
     it 'detects custom window state blobs' do
-      parsed_body = Nokogiri::HTML(load_fixture('state.html'))
+      parsed_body = Html2rss::HtmlParser.parse_html(load_fixture('state.html'))
 
       expect(described_class).to be_articles(parsed_body)
     end
 
     it 'detects arrays containing nested article arrays' do
-      parsed_body = Nokogiri::HTML(load_fixture('nested_array.html'))
+      parsed_body = Html2rss::HtmlParser.parse_html(load_fixture('nested_array.html'))
 
       expect(described_class).to be_articles(parsed_body)
     end
 
     it 'returns false when no JSON state is present' do
-      parsed_body = Nokogiri::HTML('<html><body><script>console.log("hello")</script></body></html>')
+      parsed_body = Html2rss::HtmlParser.parse_html('<html><body><script>console.log("hello")</script></body></html>')
 
       expect(described_class).not_to be_articles(parsed_body)
     end
@@ -44,7 +44,7 @@ RSpec.describe Html2rss::AutoSource::Scraper::JsonState do
     subject(:articles) { described_class.new(parsed_body, url: base_url).each.to_a }
 
     context 'with Next.js data' do
-      let(:parsed_body) { Nokogiri::HTML(load_fixture('next.html')) }
+      let(:parsed_body) { Html2rss::HtmlParser.parse_html(load_fixture('next.html')) }
 
       it 'normalises the article data' do # rubocop:disable RSpec/ExampleLength
         expect(articles).to contain_exactly(
@@ -62,7 +62,7 @@ RSpec.describe Html2rss::AutoSource::Scraper::JsonState do
     end
 
     context 'with Nuxt data' do
-      let(:parsed_body) { Nokogiri::HTML(load_fixture('nuxt.html')) }
+      let(:parsed_body) { Html2rss::HtmlParser.parse_html(load_fixture('nuxt.html')) }
 
       it 'extracts relative URLs and nested categories' do # rubocop:disable RSpec/ExampleLength
         expect(articles).to contain_exactly(
@@ -80,7 +80,7 @@ RSpec.describe Html2rss::AutoSource::Scraper::JsonState do
     end
 
     context 'with custom window state' do
-      let(:parsed_body) { Nokogiri::HTML(load_fixture('state.html')) }
+      let(:parsed_body) { Html2rss::HtmlParser.parse_html(load_fixture('state.html')) }
 
       it 'handles bespoke globals' do # rubocop:disable RSpec/ExampleLength
         expect(articles).to contain_exactly(
@@ -98,7 +98,7 @@ RSpec.describe Html2rss::AutoSource::Scraper::JsonState do
     end
 
     context 'with nested array data' do
-      let(:parsed_body) { Nokogiri::HTML(load_fixture('nested_array.html')) }
+      let(:parsed_body) { Html2rss::HtmlParser.parse_html(load_fixture('nested_array.html')) }
 
       it 'finds articles nested inside array entries' do
         expect(articles).to contain_exactly(a_hash_including(

--- a/spec/lib/html2rss/auto_source/scraper/rss_feed_detector_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper/rss_feed_detector_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Html2rss::AutoSource::Scraper::RssFeedDetector do
   subject(:instance) { described_class.new(parsed_body, url:) }
 
   let(:url) { 'https://example.com' }
-  let(:parsed_body) { Nokogiri::HTML(html) }
+  let(:parsed_body) { Html2rss::HtmlParser.parse_html(html) }
 
   describe '.articles?' do
     context 'when RSS feed links are present' do
@@ -166,7 +166,7 @@ RSpec.describe Html2rss::AutoSource::Scraper::RssFeedDetector do
       end
 
       it 'sanitizes HTML in feed titles for security', :aggregate_failures do
-        xss_instance = described_class.new(Nokogiri::HTML(html_with_xss), url:)
+        xss_instance = described_class.new(Html2rss::HtmlParser.parse_html(html_with_xss), url:)
         first_article = xss_instance.first
 
         expect(first_article[:description]).to include 'RSS Feed'

--- a/spec/lib/html2rss/auto_source/scraper/semantic_html_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper/semantic_html_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Html2rss::AutoSource::Scraper::SemanticHtml do
 
   describe '.articles?' do
     let(:parsed_body) do
-      Nokogiri::HTML.parse <<~HTML
+      Html2rss::HtmlParser.parse_html <<~HTML
         <html><body><article><a href="">Article 1</a></article></body></html>
       HTML
     end
@@ -24,7 +24,7 @@ RSpec.describe Html2rss::AutoSource::Scraper::SemanticHtml do
   describe '#each' do
     subject(:new) { described_class.new(parsed_body, url: 'https://page.com') }
 
-    let(:parsed_body) { Nokogiri::HTML.parse(File.read('spec/fixtures/page_1.html')) }
+    let(:parsed_body) { Html2rss::HtmlParser.parse_html(File.read('spec/fixtures/page_1.html')) }
 
     let(:grouped_expected_articles) do
       # rubocop:disable Layout/LineLength

--- a/spec/lib/html2rss/auto_source/scraper_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Html2rss::AutoSource::Scraper do
   describe '.from(parsed_body, opts)' do
     context 'when suitable scraper is found' do
       let(:parsed_body) do
-        Nokogiri::HTML('<html><body><article><a href="#"></a></article></body></html>')
+        Html2rss::HtmlParser.parse_html('<html><body><article><a href="#"></a></article></body></html>')
       end
 
       it 'returns an array of scrapers' do
@@ -18,7 +18,7 @@ RSpec.describe Html2rss::AutoSource::Scraper do
     end
 
     context 'when no suitable scraper is found' do
-      let(:parsed_body) { Nokogiri::HTML('<html><body></body></html>') }
+      let(:parsed_body) { Html2rss::HtmlParser.parse_html('<html><body></body></html>') }
 
       it 'raises NoScraperFound error' do
         expect do

--- a/spec/lib/html2rss/category_extractor_spec.rb
+++ b/spec/lib/html2rss/category_extractor_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe Html2rss::CategoryExtractor do
   describe '.call' do
-    let(:html) { Nokogiri::HTML.fragment(html_content) }
+    let(:html) { Html2rss::HtmlParser.parse_html_fragment(html_content) }
     let(:article_tag) { html.at_css('article') }
 
     context 'when article has category classes' do

--- a/spec/lib/html2rss/error_spec.rb
+++ b/spec/lib/html2rss/error_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'nokogiri'
-
 RSpec.describe Html2rss::Error do
   it { expect(described_class).to be < StandardError }
 end

--- a/spec/lib/html2rss/html_extractor/enclosure_extractor_spec.rb
+++ b/spec/lib/html2rss/html_extractor/enclosure_extractor_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'nokogiri'
-
 RSpec.describe Html2rss::HtmlExtractor::EnclosureExtractor do
   describe '.call' do
     subject(:enclosures) { described_class.call(article_tag, base_url) }
@@ -10,7 +8,7 @@ RSpec.describe Html2rss::HtmlExtractor::EnclosureExtractor do
 
     # Helper method to create article tag from HTML
     def article_tag_from(html)
-      Nokogiri::HTML(html).at('article')
+      Html2rss::HtmlParser.parse_html(html).at('article')
     end
 
     # Helper method to create expected enclosure hash

--- a/spec/lib/html2rss/html_extractor/image_extractor_spec.rb
+++ b/spec/lib/html2rss/html_extractor/image_extractor_spec.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-require 'nokogiri'
-
 RSpec.describe Html2rss::HtmlExtractor::ImageExtractor do
-  let(:article_tag) { Nokogiri::HTML.fragment(html) }
+  let(:article_tag) { Html2rss::HtmlParser.parse_html_fragment(html) }
 
   describe '.call' do
     subject(:url) { described_class.call(article_tag, base_url: 'https://example.com').to_s.encode('UTF-8') }

--- a/spec/lib/html2rss/html_extractor_spec.rb
+++ b/spec/lib/html2rss/html_extractor_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'nokogiri'
-
 RSpec.describe Html2rss::HtmlExtractor do
   subject(:article_hash) { described_class.new(article_tag, base_url: 'https://example.com').call }
 
@@ -9,7 +7,9 @@ RSpec.describe Html2rss::HtmlExtractor do
     subject(:visible_text) { described_class.extract_visible_text(tag) }
 
     let(:tag) do
-      Nokogiri::HTML.fragment('<div>Hello <span>World</span><script>App = {}</script></div>').at_css('div')
+      Html2rss::HtmlParser.parse_html_fragment(
+        '<div>Hello <span>World</span><script>App = {}</script></div>'
+      ).at_css('div')
     end
 
     it 'returns the visible text from the tag and its children' do
@@ -34,7 +34,7 @@ RSpec.describe Html2rss::HtmlExtractor do
     end
 
     describe '#call' do
-      let(:article_tag) { Nokogiri::HTML.fragment(html) }
+      let(:article_tag) { Html2rss::HtmlParser.parse_html_fragment(html) }
       let(:heading) { article_tag.at_css('h1') }
 
       it 'returns the article_hash', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
@@ -70,7 +70,7 @@ RSpec.describe Html2rss::HtmlExtractor do
           </article>
         HTML
       end
-      let(:article_tag) { Nokogiri::HTML.fragment(html) }
+      let(:article_tag) { Html2rss::HtmlParser.parse_html_fragment(html) }
 
       it 'returns the article_hash with a nil published_at' do
         expect(article_hash[:published_at]).to be_nil
@@ -89,7 +89,7 @@ RSpec.describe Html2rss::HtmlExtractor do
       HTML
     end
 
-    let(:article_tag) { Nokogiri::HTML.fragment(html) }
+    let(:article_tag) { Html2rss::HtmlParser.parse_html_fragment(html) }
     let(:details) do
       { title: nil,
         url: nil,
@@ -112,7 +112,7 @@ RSpec.describe Html2rss::HtmlExtractor do
   describe '#heading' do
     subject(:heading) { described_class.new(article_tag, base_url: 'https://example.com').send(:heading) }
 
-    let(:article_tag) { Nokogiri::HTML.fragment(html) }
+    let(:article_tag) { Html2rss::HtmlParser.parse_html_fragment(html) }
 
     context 'when heading is present' do
       let(:html) do
@@ -159,7 +159,7 @@ RSpec.describe Html2rss::HtmlExtractor do
           </article>
         HTML
       end
-      let(:article_tag) { Nokogiri::HTML.fragment(html) }
+      let(:article_tag) { Html2rss::HtmlParser.parse_html_fragment(html) }
 
       it 'extracts categories from elements with category-related class names' do
         expect(article_hash[:categories]).to contain_exactly('News', 'Technology', 'Science')
@@ -175,7 +175,7 @@ RSpec.describe Html2rss::HtmlExtractor do
           </article>
         HTML
       end
-      let(:article_tag) { Nokogiri::HTML.fragment(html) }
+      let(:article_tag) { Html2rss::HtmlParser.parse_html_fragment(html) }
 
       it 'returns empty categories array' do
         expect(article_hash[:categories]).to eq([])

--- a/spec/lib/html2rss/html_navigator_spec.rb
+++ b/spec/lib/html2rss/html_navigator_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'nokogiri'
-
 RSpec.describe Html2rss::HtmlNavigator do
   describe '.parent_until_condition' do
     let(:html) do
@@ -16,7 +14,7 @@ RSpec.describe Html2rss::HtmlNavigator do
       HTML
     end
 
-    let(:document) { Nokogiri::HTML(html) }
+    let(:document) { Html2rss::HtmlParser.parse_html(html) }
     let(:target_node) { document.at_css('#target') }
 
     it 'returns the node itself if the condition is met' do
@@ -58,7 +56,7 @@ RSpec.describe Html2rss::HtmlNavigator do
       HTML
     end
 
-    let(:document) { Nokogiri::HTML(html) }
+    let(:document) { Html2rss::HtmlParser.parse_html(html) }
 
     let(:expected_anchor) { document.at_css('a') }
 
@@ -94,7 +92,7 @@ RSpec.describe Html2rss::HtmlNavigator do
       HTML
     end
 
-    let(:document) { Nokogiri::HTML(html) }
+    let(:document) { Html2rss::HtmlParser.parse_html(html) }
     let(:current_tag) { document.at_css('#link') }
 
     context 'when the anchor is inside the specified tag' do

--- a/spec/lib/html2rss/rendering/description_builder_spec.rb
+++ b/spec/lib/html2rss/rendering/description_builder_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'nokogiri'
 
 RSpec.describe Html2rss::Rendering::DescriptionBuilder do
   describe '#call' do
@@ -57,7 +56,7 @@ RSpec.describe Html2rss::Rendering::DescriptionBuilder do
       subject(:doc) do
         html = described_class.new(base:, title: 'Sample instance', url: 'http://example.com', enclosures:,
                                    image: nil).call
-        Nokogiri::HTML.fragment(html)
+        Html2rss::HtmlParser.parse_html_fragment(html)
       end
 
       let(:base) { 'Caption' }
@@ -75,7 +74,7 @@ RSpec.describe Html2rss::Rendering::DescriptionBuilder do
       subject(:doc) do
         html = described_class.new(base:, title: 'Sample instance', url: 'http://example.com', enclosures: nil,
                                    image:).call
-        Nokogiri::HTML.fragment(html)
+        Html2rss::HtmlParser.parse_html_fragment(html)
       end
 
       let(:base) { 'Something' }
@@ -91,7 +90,7 @@ RSpec.describe Html2rss::Rendering::DescriptionBuilder do
       subject(:doc) do
         html = described_class.new(base:, title: 'Sample instance', url: 'http://example.com', enclosures:,
                                    image: nil).call
-        Nokogiri::HTML.fragment(html)
+        Html2rss::HtmlParser.parse_html_fragment(html)
       end
 
       let(:base) { 'Watch this' }
@@ -111,7 +110,7 @@ RSpec.describe Html2rss::Rendering::DescriptionBuilder do
       subject(:doc) do
         html = described_class.new(base:, title: 'Sample instance', url: 'http://example.com', enclosures:,
                                    image: nil).call
-        Nokogiri::HTML.fragment(html)
+        Html2rss::HtmlParser.parse_html_fragment(html)
       end
 
       let(:base) { 'Listen to this' }
@@ -131,7 +130,7 @@ RSpec.describe Html2rss::Rendering::DescriptionBuilder do
       subject(:doc) do
         html = described_class.new(base:, title: 'Sample instance', url: 'http://example.com', enclosures:,
                                    image: nil).call
-        Nokogiri::HTML.fragment(html)
+        Html2rss::HtmlParser.parse_html_fragment(html)
       end
 
       let(:base) { 'See this document' }

--- a/spec/lib/html2rss/rendering/media_table_renderer_spec.rb
+++ b/spec/lib/html2rss/rendering/media_table_renderer_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'nokogiri'
 
 RSpec.describe Html2rss::Rendering::MediaTableRenderer do
   describe '#to_html' do
@@ -14,7 +13,7 @@ RSpec.describe Html2rss::Rendering::MediaTableRenderer do
     end
 
     context 'when only enclosures are present' do
-      subject(:doc) { Nokogiri::HTML.fragment(html) }
+      subject(:doc) { Html2rss::HtmlParser.parse_html_fragment(html) }
 
       let(:html) { renderer.to_html }
 
@@ -61,7 +60,7 @@ RSpec.describe Html2rss::Rendering::MediaTableRenderer do
     end
 
     context 'when only fallback image is present' do
-      subject(:doc) { Nokogiri::HTML.fragment(html) }
+      subject(:doc) { Html2rss::HtmlParser.parse_html_fragment(html) }
 
       let(:html) { renderer.to_html }
 
@@ -80,7 +79,7 @@ RSpec.describe Html2rss::Rendering::MediaTableRenderer do
     end
 
     context 'when both enclosures and fallback image are present' do
-      subject(:doc) { Nokogiri::HTML.fragment(html) }
+      subject(:doc) { Html2rss::HtmlParser.parse_html_fragment(html) }
 
       let(:html) { renderer.to_html }
 
@@ -102,7 +101,7 @@ RSpec.describe Html2rss::Rendering::MediaTableRenderer do
     end
 
     context 'when fallback image duplicates an image enclosure' do
-      subject(:doc) { Nokogiri::HTML.fragment(html) }
+      subject(:doc) { Html2rss::HtmlParser.parse_html_fragment(html) }
 
       let(:html) { renderer.to_html }
 
@@ -124,7 +123,7 @@ RSpec.describe Html2rss::Rendering::MediaTableRenderer do
     end
 
     context 'with unknown file types' do
-      subject(:doc) { Nokogiri::HTML.fragment(html) }
+      subject(:doc) { Html2rss::HtmlParser.parse_html_fragment(html) }
 
       let(:html) { renderer.to_html }
 

--- a/spec/lib/html2rss/rss_builder_spec.rb
+++ b/spec/lib/html2rss/rss_builder_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Html2rss::RssBuilder do
     end
 
     context 'with <channel> tag' do
-      subject(:channel_tag) { Nokogiri::XML(rss.to_s).css('channel').first }
+      subject(:channel_tag) { Html2rss::HtmlParser.parse_xml(rss.to_s).css('channel').first }
 
       let(:tags) do
         {
@@ -77,7 +77,7 @@ RSpec.describe Html2rss::RssBuilder do
     end
 
     context 'with the <item> tags' do
-      let(:items) { Nokogiri::XML(rss.to_s).css('item') }
+      let(:items) { Html2rss::HtmlParser.parse_xml(rss.to_s).css('item') }
 
       it 'has the correct number of items' do
         expect(items.size).to eq(articles.size)
@@ -85,7 +85,7 @@ RSpec.describe Html2rss::RssBuilder do
     end
 
     context 'with one <item> tags' do
-      let(:item) { Nokogiri::XML(rss.to_s).css('item').first }
+      let(:item) { Html2rss::HtmlParser.parse_xml(rss.to_s).css('item').first }
       let(:article) { articles.first }
 
       it 'has tags with correct values', :aggregate_failures do

--- a/spec/lib/html2rss/selectors/extractors/attribute_spec.rb
+++ b/spec/lib/html2rss/selectors/extractors/attribute_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Html2rss::Selectors::Extractors::Attribute do
   subject { described_class.new(xml, options).get }
 
-  let(:xml) { Nokogiri.HTML('<div><time datetime="2019-07-01">...</time></div>') }
+  let(:xml) { Html2rss::HtmlParser.parse_html('<div><time datetime="2019-07-01">...</time></div>') }
   let(:options) { instance_double(Struct::AttributeOptions, selector: 'time', attribute: 'datetime') }
 
   it { is_expected.to eq '2019-07-01' }

--- a/spec/lib/html2rss/selectors/extractors/href_spec.rb
+++ b/spec/lib/html2rss/selectors/extractors/href_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'nokogiri'
-
 RSpec.describe Html2rss::Selectors::Extractors::Href do
   subject { described_class.new(xml, options).get }
 
@@ -9,7 +7,7 @@ RSpec.describe Html2rss::Selectors::Extractors::Href do
   let(:options) { instance_double(Struct::HrefOptions, selector: 'a', channel:) }
 
   context 'with relative href url' do
-    let(:xml) { Nokogiri.HTML('<div><a href="/posts/latest-findings">...</a></div>') }
+    let(:xml) { Html2rss::HtmlParser.parse_html('<div><a href="/posts/latest-findings">...</a></div>') }
 
     specify(:aggregate_failures) do
       expect(subject).to be_a(Html2rss::Url)
@@ -18,7 +16,7 @@ RSpec.describe Html2rss::Selectors::Extractors::Href do
   end
 
   context 'with absolute href url' do
-    let(:xml) { Nokogiri.HTML('<div><a href="http://example.com/posts/absolute">...</a></div>') }
+    let(:xml) { Html2rss::HtmlParser.parse_html('<div><a href="http://example.com/posts/absolute">...</a></div>') }
 
     specify(:aggregate_failures) do
       expect(subject).to be_a(Html2rss::Url)

--- a/spec/lib/html2rss/selectors/extractors/html_spec.rb
+++ b/spec/lib/html2rss/selectors/extractors/html_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Html2rss::Selectors::Extractors::Html do
   subject { described_class.new(xml, options).get }
 
-  let(:xml) { Nokogiri.HTML('<p>Lorem <b>ipsum</b> dolor ...</p>') }
+  let(:xml) { Html2rss::HtmlParser.parse_html('<p>Lorem <b>ipsum</b> dolor ...</p>') }
   let(:options) { instance_double(Struct::HtmlOptions, selector: 'p') }
 
   it { is_expected.to eq '<p>Lorem <b>ipsum</b> dolor ...</p>' }

--- a/spec/lib/html2rss/selectors/extractors/text_spec.rb
+++ b/spec/lib/html2rss/selectors/extractors/text_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Html2rss::Selectors::Extractors::Text do
   subject { described_class.new(xml, options).get }
 
-  let(:xml) { Nokogiri.HTML('<p>Lorem <b>ipsum</b> dolor ...</p>') }
+  let(:xml) { Html2rss::HtmlParser.parse_html('<p>Lorem <b>ipsum</b> dolor ...</p>') }
   let(:options) { instance_double(Struct::TextOptions, 'selector' => 'p') }
 
   it { is_expected.to eq 'Lorem ipsum dolor ...' }

--- a/spec/lib/html2rss/selectors/post_processors/html_transformers/wrap_img_in_a_spec.rb
+++ b/spec/lib/html2rss/selectors/post_processors/html_transformers/wrap_img_in_a_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Html2rss::Selectors::PostProcessors::HtmlTransformers::WrapImgInA
     subject(:call) { transformer.call(node_name:, node:) }
 
     let(:node_name) { 'img' }
-    let(:node) { Nokogiri::HTML('<html><p><img src="https://example.com/image.jpg"></p></html>').at('img') }
+    let(:node) { Html2rss::HtmlParser.parse_html('<html><p><img src="https://example.com/image.jpg"></p></html>').at('img') }
 
     it 'wraps the image in an anchor tag', :aggregate_failures do
       expect { call }.to change { node.parent.name }.from('p').to('a')

--- a/spec/lib/html2rss/selectors/post_processors/sanitize_html_spec.rb
+++ b/spec/lib/html2rss/selectors/post_processors/sanitize_html_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe Html2rss::Selectors::PostProcessors::SanitizeHtml do
     end
 
     it do
-      result = Nokogiri::HTML.fragment(subject).to_html.chomp.gsub(/\s+/, ' ')
-      expected_html = Nokogiri::HTML.fragment(sanitized_html).to_html.chomp.gsub(/\s+/, ' ')
+      result = Html2rss::HtmlParser.parse_html_fragment(subject).to_html.chomp.gsub(/\s+/, ' ')
+      expected_html = Html2rss::HtmlParser.parse_html_fragment(sanitized_html).to_html.chomp.gsub(/\s+/, ' ')
 
       expect(result).to eq(expected_html)
     end

--- a/spec/lib/html2rss/selectors_spec.rb
+++ b/spec/lib/html2rss/selectors_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Html2rss::Selectors do
   describe '#extract_article(item)' do
     subject(:article) { instance.extract_article(item) }
 
-    let(:item) { Nokogiri::HTML(body).at('html') }
+    let(:item) { Html2rss::HtmlParser.parse_html(body).at('html') }
 
     context 'when title is static and description the html of <body>' do
       # Issue was reported at: https://github.com/html2rss/html2rss/issues/157
@@ -109,7 +109,7 @@ RSpec.describe Html2rss::Selectors do
 
   describe '#enhance_article_hash(article_hash, item)' do
     subject(:enhanced_article) do
-      item = Nokogiri::HTML(body).at('article:first')
+      item = Html2rss::HtmlParser.parse_html(body).at('article:first')
 
       instance.enhance_article_hash(article_hash, item)
     end
@@ -144,7 +144,7 @@ RSpec.describe Html2rss::Selectors do
   describe '#select' do
     subject(:value) { instance.select(:title, item) }
 
-    let(:item) { Nokogiri::HTML(body).at('article:first') }
+    let(:item) { Html2rss::HtmlParser.parse_html(body).at('article:first') }
 
     it 'returns the selected value' do
       expect(value).to eq('article1')

--- a/spec/lib/html2rss_spec.rb
+++ b/spec/lib/html2rss_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'nokogiri'
-
 RSpec.describe Html2rss do
   let(:config_file) { File.join(%w[spec fixtures feeds.test.yml]) }
   let(:name) { 'nuxt-releases' }
@@ -28,7 +26,7 @@ RSpec.describe Html2rss do
 
   describe '.feed' do
     context 'with config being a Hash' do
-      subject(:xml) { Nokogiri.XML(feed_return.to_s) }
+      subject(:xml) { Html2rss::HtmlParser.parse_xml(feed_return.to_s) }
 
       let(:config) do
         described_class.config_from_yaml_file(config_file, name)
@@ -101,13 +99,13 @@ RSpec.describe Html2rss do
           end
 
           it 'adds rel="nofollow noopener noreferrer" to all anchor elements' do
-            Nokogiri.HTML(description).css('a').each do |anchor|
+            Html2rss::HtmlParser.parse_html(description).css('a').each do |anchor|
               expect(anchor.attr('rel')).to eq 'nofollow noopener noreferrer'
             end
           end
 
           it 'changes target="_blank" on all anchor elements' do
-            Nokogiri.HTML(description).css('a').each { |anchor| expect(anchor.attr('target')).to eq '_blank' }
+            Html2rss::HtmlParser.parse_html(description).css('a').each { |anchor| expect(anchor.attr('target')).to eq '_blank' }
           end
         end
 
@@ -188,7 +186,7 @@ RSpec.describe Html2rss do
       let(:name) { 'json' }
 
       context 'with returned config' do
-        subject(:xml) { Nokogiri.XML(feed.to_s) }
+        subject(:xml) { Html2rss::HtmlParser.parse_xml(feed.to_s) }
 
         it 'has the description derived from markdown' do
           expect(


### PR DESCRIPTION
## Summary
- add an HtmlParser abstraction to centralize all parsing backend interactions
- update the library and specs to call the HtmlParser instead of touching Nokogiri directly
- adapt utilities like the wrap-image transformer to create nodes through the parser backend

## Testing
- bundle exec rubocop
- bundle exec reek
- bundle exec rspec

------
https://chatgpt.com/codex/tasks/task_e_68e750612d1c832d83aedd36f395b3db