### PR TITLE
Add Nokolexbor HTML parser backend

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ PATH
       kramdown
       mime-types (> 3.0)
       nokogiri (>= 1.10, < 2.0)
+      nokolexbor (~> 0.6)
       parallel
       puppeteer-ruby
       regexp_parser
@@ -112,6 +113,9 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
+    nokolexbor (0.6.2)
+    nokolexbor (0.6.2-x86_64-darwin)
+    nokolexbor (0.6.2-x86_64-linux)
     parallel (1.27.0)
     parser (3.3.9.0)
       ast (~> 2.4.1)
@@ -294,6 +298,9 @@ CHECKSUMS
   nokogiri (1.18.10) sha256=d5cc0731008aa3b3a87b361203ea3d19b2069628cb55e46ac7d84a0445e69cc1
   nokogiri (1.18.10-x86_64-darwin) sha256=536e74bed6db2b5076769cab5e5f5af0cd1dccbbd75f1b3e1fa69d1f5c2d79e2
   nokogiri (1.18.10-x86_64-linux-gnu) sha256=ff5ba26ba2dbce5c04b9ea200777fd225061d7a3930548806f31db907e500f72
+  nokolexbor (0.6.2) sha256=5f010bc33e3810961ecefd291d97ec02bd2fbc12653c583ba08e2afbaa00a62b
+  nokolexbor (0.6.2-x86_64-darwin) sha256=60869e2b7a0f40fc8d3834d4c6274c527c721b1107941c76a75e42e1aada9a50
+  nokolexbor (0.6.2-x86_64-linux) sha256=8d0fbebf17a7a027c5c6adc3c68bb798ce84bdfb00e880c186c7b448f7fd8298
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.9.0) sha256=94d6929354b1a6e3e1f89d79d4d302cc8f5aa814431a6c9c7e0623335d7687f2
   pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6

--- a/html2rss.gemspec
+++ b/html2rss.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'kramdown'
   spec.add_dependency 'mime-types', '> 3.0'
   spec.add_dependency 'nokogiri', '>= 1.10', '< 2.0'
+  spec.add_dependency 'nokolexbor', '~> 0.6'
   spec.add_dependency 'parallel'
   spec.add_dependency 'puppeteer-ruby'
   spec.add_dependency 'regexp_parser'

--- a/lib/html2rss/html_parser.rb
+++ b/lib/html2rss/html_parser.rb
@@ -2,6 +2,7 @@
 
 require 'concurrent/atomic/atomic_reference'
 require 'nokogiri'
+require 'nokolexbor'
 
 module Html2rss
   ##
@@ -174,6 +175,75 @@ module Html2rss
         # @return [Nokogiri::XML::Node]
         def create_node(name, document)
           ::Nokogiri::XML::Node.new(name, document)
+        end
+      end
+
+      ##
+      # Alternative backend powered by Nokolexbor.
+      class Nokolexbor
+        ##
+        # Parses an HTML document string.
+        #
+        # @param html [String]
+        # @return [::Nokolexbor::Document]
+        def parse_html(html)
+          ::Nokolexbor::HTML(html)
+        end
+
+        ##
+        # Parses an HTML fragment string.
+        #
+        # @param html [String]
+        # @return [::Nokolexbor::DocumentFragment]
+        def parse_html_fragment(html)
+          ::Nokolexbor::DocumentFragment.parse(html)
+        end
+
+        ##
+        # Parses an HTML5 fragment string.
+        #
+        # @param html [String]
+        # @return [::Nokolexbor::DocumentFragment]
+        def parse_html5_fragment(html)
+          ::Nokolexbor::DocumentFragment.parse(html)
+        end
+
+        ##
+        # @return [Class]
+        def document_class
+          ::Nokolexbor::Document
+        end
+
+        ##
+        # @return [Class]
+        def fragment_class
+          ::Nokolexbor::DocumentFragment
+        end
+
+        ##
+        # @return [Class]
+        def element_class
+          ::Nokolexbor::Element
+        end
+
+        ##
+        # @return [Class]
+        def node_class
+          ::Nokolexbor::Node
+        end
+
+        ##
+        # @return [Class]
+        def node_set_class
+          ::Nokolexbor::NodeSet
+        end
+
+        ##
+        # @param name [String]
+        # @param document [::Nokolexbor::Document]
+        # @return [::Nokolexbor::Element]
+        def create_node(name, document)
+          document.create_element(name)
         end
       end
     end

--- a/spec/lib/html2rss/html_parser/nokolexbor_backend_spec.rb
+++ b/spec/lib/html2rss/html_parser/nokolexbor_backend_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Html2rss::HtmlParser::Backends::Nokolexbor do
+  subject(:backend) { described_class.new }
+
+  describe '#parse_html' do
+    let(:html) { '<html><body><p>Example</p></body></html>' }
+
+    it 'returns a Nokolexbor document' do
+      expect(backend.parse_html(html)).to be_a(::Nokolexbor::Document)
+    end
+  end
+
+  describe '#parse_html_fragment' do
+    let(:html) { '<p>fragment</p>' }
+
+    it 'returns a Nokolexbor document fragment' do
+      expect(backend.parse_html_fragment(html)).to be_a(::Nokolexbor::DocumentFragment)
+    end
+  end
+
+  describe '#parse_html5_fragment' do
+    let(:html) { '<div><img src="/image.png"></div>' }
+
+    it 'returns a Nokolexbor document fragment' do
+      expect(backend.parse_html5_fragment(html)).to be_a(::Nokolexbor::DocumentFragment)
+    end
+  end
+
+  describe '#document_class' do
+    it 'returns the Nokolexbor document class' do
+      expect(backend.document_class).to eq(::Nokolexbor::Document)
+    end
+  end
+
+  describe '#fragment_class' do
+    it 'returns the Nokolexbor fragment class' do
+      expect(backend.fragment_class).to eq(::Nokolexbor::DocumentFragment)
+    end
+  end
+
+  describe '#element_class' do
+    it 'returns the Nokolexbor element class' do
+      expect(backend.element_class).to eq(::Nokolexbor::Element)
+    end
+  end
+
+  describe '#node_class' do
+    it 'returns the Nokolexbor node class' do
+      expect(backend.node_class).to eq(::Nokolexbor::Node)
+    end
+  end
+
+  describe '#node_set_class' do
+    it 'returns the Nokolexbor node set class' do
+      expect(backend.node_set_class).to eq(::Nokolexbor::NodeSet)
+    end
+  end
+
+  describe '#create_node' do
+    let(:document) { backend.parse_html('<html></html>') }
+
+    it 'creates an element using the backend document' do
+      node = backend.create_node('span', document)
+
+      expect(node).to be_a(::Nokolexbor::Element)
+      expect(node.name).to eq('span')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add a Nokolexbor-powered backend implementation to the HTML parser
- depend on the nokolexbor gem and lock the bundle
- cover the new backend behaviour with unit specs

## Testing
- bundle exec rspec

------
https://chatgpt.com/codex/tasks/task_e_68e7e2f61acc832d88d4c884b5b5830c