### PR TITLE
chore: add rubocop-yard and fix YARD hash type annotations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ plugins:
   - rubocop-md
   - rubocop-rake
   - rubocop-thread_safety
+  - rubocop-yard
 
 AllCops:
   DisplayCopNames: true

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :development, :test do
   gem 'rubocop-rake', require: false
   gem 'rubocop-rspec', require: false
   gem 'rubocop-thread_safety', require: false
+  gem 'rubocop-yard', require: false
 
   gem 'rspec', '~> 3.0', require: false
   gem 'rspec-instafail', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,6 +202,10 @@ GEM
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
       rubocop-ast (>= 1.44.0, < 2.0)
+    rubocop-yard (1.1.0)
+      lint_roller
+      rubocop (~> 1.72)
+      yard
     ruby-progressbar (1.13.0)
     sanitize (7.0.0)
       crass (~> 1.0.2)
@@ -257,6 +261,7 @@ DEPENDENCIES
   rubocop-rake
   rubocop-rspec
   rubocop-thread_safety
+  rubocop-yard
   simplecov
   timecop
   vcr
@@ -339,6 +344,7 @@ CHECKSUMS
   rubocop-rake (0.7.1) sha256=3797f2b6810c3e9df7376c26d5f44f3475eda59eb1adc38e6f62ecf027cbae4d
   rubocop-rspec (3.9.0) sha256=8fa70a3619408237d789aeecfb9beef40576acc855173e60939d63332fdb55e2
   rubocop-thread_safety (0.7.3) sha256=067cdd52fbf5deffc18995437e45b5194236eaff4f71de3375a1f6052e48f431
+  rubocop-yard (1.1.0) sha256=a9a4051c852e58a1b967e41abb85c94698f482782e6261f747a9acae79fe6f73
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   sanitize (7.0.0) sha256=269d1b9d7326e69307723af5643ec032ff86ad616e72a3b36d301ac75a273984
   simplecov (0.22.0) sha256=fe2622c7834ff23b98066bb0a854284b2729a569ac659f82621fc22ef36213a5

--- a/lib/html2rss/auto_source/scraper/microdata.rb
+++ b/lib/html2rss/auto_source/scraper/microdata.rb
@@ -76,7 +76,7 @@ module Html2rss
         ##
         # Iterates over normalized article hashes extracted from supported Microdata roots.
         #
-        # @yieldparam article [Hash<Symbol, Object>] the normalized article attributes.
+        # @yieldparam article [Hash{Symbol => Object}] the normalized article attributes.
         # @return [Enumerator, void] an enumerator when no block is given.
         def each
           return enum_for(:each) unless block_given?

--- a/lib/html2rss/auto_source/scraper/wordpress_api.rb
+++ b/lib/html2rss/auto_source/scraper/wordpress_api.rb
@@ -50,7 +50,7 @@ module Html2rss
         ##
         # Yields article hashes from the WordPress posts API.
         #
-        # @yieldparam article [Hash<Symbol, Object>] normalized article hash
+        # @yieldparam article [Hash{Symbol => Object}] normalized article hash
         # @return [Enumerator, void] enumerator when no block is given
         def each
           return enum_for(:each) unless block_given?


### PR DESCRIPTION
## Summary
- add rubocop-yard plugin to RuboCop config and gem dependencies
- update YARD hash type syntax in scraper docs to satisfy lint

## Validation
- attempted mise exec -- bundle exec rubocop on changed files
- blocked because this base branch has no mise tool config and system Ruby cannot load Bundler 4.0.9