### PR TITLE
feat(strategy): add Botasaurus strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,38 @@ Config -> Request -> Extraction -> Processing -> Building -> Output
 - `browserless`: remote browser rendering via Browserless (`BROWSERLESS_IO_WEBSOCKET_URL` and token as needed).
 - `botasaurus`: delegates fetching to a Botasaurus scrape API. Requires `BOTASAURUS_SCRAPER_URL` (for example `http://localhost:4010`).
 
-Botasaurus strategy sends this request shape:
+Botasaurus is explicit opt-in only. Use `strategy: botasaurus` (or `--strategy botasaurus`) when you want Botasaurus transport.
+
+Supported `request.botasaurus` options:
+
+- `navigation_mode` (`auto`, `get`, `google_get`, `google_get_bypass`; default `auto`)
+- `max_retries` (`0..3`; default `2`)
+- `wait_for_selector` (string)
+- `wait_timeout_seconds` (integer)
+- `block_images` (boolean)
+- `block_images_and_css` (boolean)
+- `wait_for_complete_page_load` (boolean)
+- `headless` (boolean, default `false`)
+- `proxy` (string)
+- `user_agent` (string)
+- `window_size` (two-item integer array, for example `[1920, 1080]`)
+- `lang` (string, for example `en-US`)
+
+Minimal YAML config example:
+
+```yaml
+channel:
+  url: https://example.com
+strategy: botasaurus
+auto_source: {}
+request:
+  botasaurus:
+    navigation_mode: auto
+    max_retries: 2
+    headless: false
+```
+
+Example request payload shape:
 
 ```json
 {
@@ -69,6 +100,8 @@ Example usage:
 ```bash
 BOTASAURUS_SCRAPER_URL=http://localhost:4010 html2rss auto https://example.com --strategy botasaurus
 ```
+
+Policy note: html2rss still enforces local request policy preflight and timeout budget. Botasaurus handles browser navigation/rendering internals, so some policy details are delegated to upstream execution.
 
 ### Config schema workflow
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Please see the [contributing guide](https://html2rss.github.io/get-involved/cont
 ### Core Components
 
 1. **Config** - Loads and validates configuration (YAML/hash)
-2. **RequestService** - Fetches pages using Faraday, Browserless, or Botasaurus
+2. **RequestService** - Fetches pages using Faraday, Botasaurus, or Browserless
 3. **Selectors** - Extracts content via CSS selectors with extractors/post-processors
 4. **AutoSource** - Auto-detects content using Schema.org, JSON state blobs, semantic HTML, and structural patterns
 5. **RssBuilder** - Assembles Article objects and renders RSS 2.0
@@ -50,8 +50,8 @@ Config -> Request -> Extraction -> Processing -> Building -> Output
 ### Request Strategies
 
 - `faraday` (default): direct HTTP fetch.
-- `browserless`: remote browser rendering via Browserless (`BROWSERLESS_IO_WEBSOCKET_URL` and token as needed).
 - `botasaurus`: delegates fetching to a Botasaurus scrape API. Requires `BOTASAURUS_SCRAPER_URL` (for example `http://localhost:4010`).
+- `browserless`: remote browser rendering via Browserless (`BROWSERLESS_IO_WEBSOCKET_URL` and token as needed).
 
 Botasaurus is explicit opt-in only. Use `strategy: botasaurus` (or `--strategy botasaurus`) when you want Botasaurus transport.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Please see the [contributing guide](https://html2rss.github.io/get-involved/cont
 ### Core Components
 
 1. **Config** - Loads and validates configuration (YAML/hash)
-2. **RequestService** - Fetches pages using Faraday or Browserless
+2. **RequestService** - Fetches pages using Faraday, Browserless, or Botasaurus
 3. **Selectors** - Extracts content via CSS selectors with extractors/post-processors
 4. **AutoSource** - Auto-detects content using Schema.org, JSON state blobs, semantic HTML, and structural patterns
 5. **RssBuilder** - Assembles Article objects and renders RSS 2.0
@@ -45,6 +45,29 @@ Please see the [contributing guide](https://html2rss.github.io/get-involved/cont
 
 ```text
 Config -> Request -> Extraction -> Processing -> Building -> Output
+```
+
+### Request Strategies
+
+- `faraday` (default): direct HTTP fetch.
+- `browserless`: remote browser rendering via Browserless (`BROWSERLESS_IO_WEBSOCKET_URL` and token as needed).
+- `botasaurus`: delegates fetching to a Botasaurus scrape API. Requires `BOTASAURUS_SCRAPER_URL` (for example `http://localhost:4010`).
+
+Botasaurus strategy sends this request shape:
+
+```json
+{
+  "url": "https://example.com",
+  "navigation_mode": "auto",
+  "max_retries": 2,
+  "headless": false
+}
+```
+
+Example usage:
+
+```bash
+BOTASAURUS_SCRAPER_URL=http://localhost:4010 html2rss auto https://example.com --strategy botasaurus
 ```
 
 ### Config schema workflow

--- a/lib/html2rss/cli.rb
+++ b/lib/html2rss/cli.rb
@@ -26,7 +26,7 @@ module Html2rss
     method_option :strategy,
                   type: :string,
                   desc: 'The strategy to request the URL',
-                  enum: %w[faraday browserless botasaurus]
+                  enum: %w[faraday botasaurus browserless]
     method_option :max_redirects,
                   type: :numeric,
                   desc: 'Maximum redirects to follow per request'
@@ -48,7 +48,7 @@ module Html2rss
     method_option :strategy,
                   type: :string,
                   desc: 'The strategy to request the URL',
-                  enum: %w[faraday browserless botasaurus]
+                  enum: %w[faraday botasaurus browserless]
     method_option :format,
                   type: :string,
                   desc: 'Output format for the auto-sourced feed',

--- a/lib/html2rss/cli.rb
+++ b/lib/html2rss/cli.rb
@@ -26,7 +26,7 @@ module Html2rss
     method_option :strategy,
                   type: :string,
                   desc: 'The strategy to request the URL',
-                  enum: %w[faraday browserless]
+                  enum: %w[faraday browserless botasaurus]
     method_option :max_redirects,
                   type: :numeric,
                   desc: 'Maximum redirects to follow per request'
@@ -48,7 +48,7 @@ module Html2rss
     method_option :strategy,
                   type: :string,
                   desc: 'The strategy to request the URL',
-                  enum: %w[faraday browserless]
+                  enum: %w[faraday browserless botasaurus]
     method_option :format,
                   type: :string,
                   desc: 'Output format for the auto-sourced feed',
@@ -192,6 +192,8 @@ module Html2rss
             'or increase request.max_requests in the config.'
     rescue Html2rss::RequestService::BrowserlessConfigurationError,
            Html2rss::RequestService::BrowserlessConnectionFailed,
+           Html2rss::RequestService::BotasaurusConfigurationError,
+           Html2rss::RequestService::BotasaurusConnectionFailed,
            Html2rss::RequestService::BlockedSurfaceDetected => error
       raise Thor::Error, error.message
     end

--- a/lib/html2rss/config/validator.rb
+++ b/lib/html2rss/config/validator.rb
@@ -56,11 +56,30 @@ module Html2rss
         optional(:preload).hash(BrowserlessPreloadConfig)
       end
 
+      # Contract for Botasaurus-specific request options.
+      BotasaurusRequestConfig = Dry::Schema.Params do
+        config.validate_keys = true
+
+        optional(:navigation_mode).filled(:string, included_in?: %w[auto get google_get google_get_bypass])
+        optional(:max_retries).filled(:integer, gteq?: 0, lteq?: 3)
+        optional(:wait_for_selector).maybe(:string)
+        optional(:wait_timeout_seconds).filled(:integer, gt?: 0)
+        optional(:block_images).filled(:bool)
+        optional(:block_images_and_css).filled(:bool)
+        optional(:wait_for_complete_page_load).filled(:bool)
+        optional(:headless).filled(:bool)
+        optional(:proxy).filled(:string)
+        optional(:user_agent).filled(:string)
+        optional(:window_size).value(:array, min_size?: 2, max_size?: 2).each(:integer, gt?: 0)
+        optional(:lang).filled(:string)
+      end
+
       # Contract for the top-level `request` section.
       RequestConfig = Dry::Schema.Params do
         optional(:max_redirects).filled(:integer, gteq?: 0)
         optional(:max_requests).filled(:integer, gt?: 0)
         optional(:browserless).hash(BrowserlessRequestConfig)
+        optional(:botasaurus).hash(BotasaurusRequestConfig)
       end
 
       params do

--- a/lib/html2rss/request_service.rb
+++ b/lib/html2rss/request_service.rb
@@ -56,8 +56,8 @@ module Html2rss
     def initialize
       @strategies = {
         faraday: FaradayStrategy,
-        browserless: BrowserlessStrategy,
-        botasaurus: BotasaurusStrategy
+        botasaurus: BotasaurusStrategy,
+        browserless: BrowserlessStrategy
       }
       @default_strategy_name = :faraday
     end

--- a/lib/html2rss/request_service.rb
+++ b/lib/html2rss/request_service.rb
@@ -34,6 +34,10 @@ module Html2rss
     class BrowserlessConfigurationError < Html2rss::Error; end
     # Raised when Browserless cannot be reached.
     class BrowserlessConnectionFailed < Html2rss::Error; end
+    # Raised when Botasaurus configuration is missing or invalid.
+    class BotasaurusConfigurationError < Html2rss::Error; end
+    # Raised when Botasaurus cannot be reached or returns invalid payloads.
+    class BotasaurusConnectionFailed < Html2rss::Error; end
 
     class << self
       extend Forwardable
@@ -52,7 +56,8 @@ module Html2rss
     def initialize
       @strategies = {
         faraday: FaradayStrategy,
-        browserless: BrowserlessStrategy
+        browserless: BrowserlessStrategy,
+        botasaurus: BotasaurusStrategy
       }
       @default_strategy_name = :faraday
     end

--- a/lib/html2rss/request_service/botasaurus_contract.rb
+++ b/lib/html2rss/request_service/botasaurus_contract.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require 'json'
+
+##
+# Main html2rss namespace.
+module Html2rss
+  ##
+  # Request transport orchestration and strategies.
+  class RequestService
+    ##
+    # Maps html2rss request/response handling to the botasaurus-scrape-api contract.
+    class BotasaurusContract
+      # Default Botasaurus scrape options when no explicit config is provided.
+      DEFAULT_OPTIONS = {
+        navigation_mode: 'auto',
+        max_retries: 2,
+        headless: false
+      }.freeze
+
+      # Allowlisted request.botasaurus keys forwarded to upstream.
+      OPTION_KEYS = %i[
+        navigation_mode
+        max_retries
+        wait_for_selector
+        wait_timeout_seconds
+        block_images
+        block_images_and_css
+        wait_for_complete_page_load
+        headless
+        proxy
+        user_agent
+        window_size
+        lang
+      ].freeze
+
+      # Parsed Botasaurus response wrapper.
+      class ParsedResponse
+        # Fallback headers when upstream omits response headers.
+        DEFAULT_HEADERS = { 'content-type' => 'text/html' }.freeze
+
+        # @param payload [Hash{String => Object}] parsed Botasaurus response payload
+        # @param transport_status [Integer] HTTP status returned by Botasaurus
+        def initialize(payload:, transport_status:)
+          @payload = payload
+          @transport_status = transport_status
+        end
+
+        # @return [Boolean] true when upstream classified request as challenge blocked
+        def challenge_block? = error_category == 'challenge_block'
+
+        # @return [Boolean] true when upstream returned non-200 or an error payload
+        def upstream_failure?
+          status != 200 || error_message?
+        end
+
+        # @return [String] normalized challenge error message
+        def challenge_message
+          error || 'Botasaurus challenge block detected.'
+        end
+
+        # @return [String] actionable upstream failure summary
+        def upstream_failure_message
+          details = ["status=#{status}"]
+          details << "error_category=#{error_category}" if error_category
+          details << "error=#{error}" if error
+          details << "request_id=#{request_id}" if request_id
+          "Botasaurus scrape failed (#{details.join(', ')})."
+        end
+
+        # @return [String] rendered HTML body from Botasaurus
+        # @raise [BotasaurusConnectionFailed] when html is missing
+        def html
+          value = payload['html']
+          raise BotasaurusConnectionFailed, "Botasaurus response missing required 'html' field" if value.nil?
+
+          value.to_s
+        end
+
+        # @return [Hash{String => String}] normalized response headers
+        def headers
+          raw_headers = payload['headers']
+          return DEFAULT_HEADERS.dup unless raw_headers.is_a?(Hash) && raw_headers.any?
+
+          raw_headers.to_h { |key, value| [key.to_s, value.to_s] }
+        end
+
+        # @return [Integer] resolved status code (payload status_code or transport status)
+        def status
+          status_code = payload['status_code']
+          status_code.is_a?(Integer) ? status_code : transport_status
+        end
+
+        # @return [String, nil] final URL reported by upstream
+        def final_url = payload['final_url']
+
+        private
+
+        attr_reader :payload, :transport_status
+
+        def error = payload['error']
+
+        def request_id = payload['request_id']
+
+        def error_category = payload['error_category']
+
+        def error_message?
+          value = error
+          value.is_a?(String) ? !value.empty? : !value.nil?
+        end
+      end
+
+      ##
+      # @param url [Html2rss::Url] canonical URL to scrape
+      # @param options [Hash] validated request.botasaurus options
+      # @option options [String] :navigation_mode
+      # @option options [Integer] :max_retries
+      # @option options [String] :wait_for_selector
+      # @option options [Integer] :wait_timeout_seconds
+      # @option options [Boolean] :block_images
+      # @option options [Boolean] :block_images_and_css
+      # @option options [Boolean] :wait_for_complete_page_load
+      # @option options [Boolean] :headless
+      # @option options [String] :proxy
+      # @option options [String] :user_agent
+      # @option options [Array<Integer>] :window_size
+      # @option options [String] :lang
+      def initialize(url:, options: {})
+        @url = url
+        @options = options
+      end
+
+      # @return [Hash] payload for POST /scrape
+      def request_payload
+        DEFAULT_OPTIONS.merge(filtered_options).merge(url: url.to_s)
+      end
+
+      # @param transport_response [Faraday::Response] upstream HTTP response
+      # @return [ParsedResponse]
+      # @raise [BotasaurusConnectionFailed] when payload is not valid JSON object
+      def parse_response(transport_response)
+        payload = JSON.parse(transport_response.body.to_s)
+        raise BotasaurusConnectionFailed, 'Botasaurus response must be a JSON object' unless payload.is_a?(Hash)
+
+        ParsedResponse.new(payload:, transport_status: transport_response.status)
+      rescue JSON::ParserError => error
+        raise BotasaurusConnectionFailed, "Botasaurus response JSON parse failed: #{error.message}"
+      end
+
+      private
+
+      attr_reader :url, :options
+
+      def filtered_options
+        OPTION_KEYS.each_with_object({}) do |key, normalized|
+          normalized[key] = options[key] if options.key?(key)
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/request_service/botasaurus_strategy.rb
+++ b/lib/html2rss/request_service/botasaurus_strategy.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'faraday'
+require 'json'
+
+module Html2rss
+  class RequestService
+    ##
+    # Strategy to delegate fetching to a Botasaurus scrape API.
+    class BotasaurusStrategy < Strategy
+      # Default Botasaurus navigation mode.
+      DEFAULT_NAVIGATION_MODE = 'auto'
+      # Default retry count used by Botasaurus auto mode.
+      DEFAULT_MAX_RETRIES = 2
+      # Default Botasaurus headless flag.
+      DEFAULT_HEADLESS = false
+      # Fallback response headers when upstream omits headers.
+      DEFAULT_HEADERS = { 'content-type' => 'text/html' }.freeze
+
+      ##
+      # Executes a Botasaurus-backed request with shared request policy guards.
+      #
+      # @return [Response] normalized request response
+      # @raise [BotasaurusConfigurationError] when BOTASAURUS_SCRAPER_URL is missing or invalid
+      # @raise [BotasaurusConnectionFailed] when Botasaurus cannot be reached or returns an invalid payload
+      # @raise [RequestTimedOut] when the Botasaurus request exceeds configured timeout
+      def execute
+        validate_request!
+        transport_response = client.post('/scrape', JSON.generate(scrape_payload), content_type_header)
+        build_response(parse_payload(transport_response), transport_response)
+      rescue Faraday::TimeoutError, Timeout::Error => error
+        raise RequestTimedOut, error.message
+      rescue JSON::ParserError => error
+        raise BotasaurusConnectionFailed, "Botasaurus response JSON parse failed: #{error.message}"
+      rescue Faraday::ConnectionFailed, Faraday::SSLError => error
+        raise BotasaurusConnectionFailed, "Botasaurus connection failed: #{error.message}"
+      end
+
+      private
+
+      def validate_request!
+        ctx.budget.consume!
+        ctx.policy.validate_request!(url: ctx.url, origin_url: ctx.origin_url, relation: ctx.relation)
+      end
+
+      def build_response(response_payload, transport_response)
+        body = response_payload.fetch('html').to_s
+        ResponseGuard.new(policy: ctx.policy).inspect_body!(body)
+
+        Response.new(
+          body:,
+          headers: response_headers(response_payload),
+          url: response_url(response_payload),
+          status: response_status(response_payload, transport_response)
+        )
+      end
+
+      def parse_payload(transport_response)
+        payload = JSON.parse(transport_response.body.to_s)
+        raise BotasaurusConnectionFailed, 'Botasaurus response must be a JSON object' unless payload.is_a?(Hash)
+        unless payload.key?('html')
+          raise BotasaurusConnectionFailed, "Botasaurus response missing required 'html' field"
+        end
+
+        raise_if_challenge_blocked!(payload)
+
+        payload
+      end
+
+      def raise_if_challenge_blocked!(response_payload)
+        return unless response_payload['error_category'] == 'challenge_block'
+
+        message = response_payload['error'] || 'Botasaurus challenge block detected.'
+        raise BlockedSurfaceDetected, "Blocked surface detected: #{message}"
+      end
+
+      def response_headers(response_payload)
+        raw_headers = response_payload['headers']
+        return DEFAULT_HEADERS.dup unless raw_headers.is_a?(Hash) && raw_headers.any?
+
+        raw_headers.to_h { |key, value| [key.to_s, value.to_s] }
+      end
+
+      def response_status(response_payload, transport_response)
+        status_code = response_payload['status_code']
+        status_code.is_a?(Integer) ? status_code : transport_response.status
+      end
+
+      def response_url(response_payload)
+        return ctx.url unless response_payload['final_url']
+
+        Html2rss::Url.from_absolute(response_payload['final_url'])
+      rescue ArgumentError
+        ctx.url
+      end
+
+      def client
+        @client ||= Faraday.new(url: scraper_base_url.to_s, request: request_options)
+      end
+
+      def request_options
+        { timeout: ctx.policy.total_timeout_seconds }
+      end
+
+      def scrape_payload
+        {
+          url: ctx.url.to_s,
+          navigation_mode: DEFAULT_NAVIGATION_MODE,
+          max_retries: DEFAULT_MAX_RETRIES,
+          headless: DEFAULT_HEADLESS
+        }
+      end
+
+      def content_type_header
+        { 'Content-Type' => 'application/json' }
+      end
+
+      def scraper_base_url
+        @scraper_base_url ||= begin
+          configured = ENV.fetch('BOTASAURUS_SCRAPER_URL') do
+            raise BotasaurusConfigurationError, 'BOTASAURUS_SCRAPER_URL is required for strategy=botasaurus.'
+          end
+          Html2rss::Url.for_channel(configured)
+        rescue ArgumentError => error
+          raise BotasaurusConfigurationError, "BOTASAURUS_SCRAPER_URL is invalid: #{error.message}"
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/request_service/botasaurus_strategy.rb
+++ b/lib/html2rss/request_service/botasaurus_strategy.rb
@@ -8,15 +8,6 @@ module Html2rss
     ##
     # Strategy to delegate fetching to a Botasaurus scrape API.
     class BotasaurusStrategy < Strategy
-      # Default Botasaurus navigation mode.
-      DEFAULT_NAVIGATION_MODE = 'auto'
-      # Default retry count used by Botasaurus auto mode.
-      DEFAULT_MAX_RETRIES = 2
-      # Default Botasaurus headless flag.
-      DEFAULT_HEADLESS = false
-      # Fallback response headers when upstream omits headers.
-      DEFAULT_HEADERS = { 'content-type' => 'text/html' }.freeze
-
       ##
       # Executes a Botasaurus-backed request with shared request policy guards.
       #
@@ -26,12 +17,13 @@ module Html2rss
       # @raise [RequestTimedOut] when the Botasaurus request exceeds configured timeout
       def execute
         validate_request!
-        transport_response = client.post('/scrape', JSON.generate(scrape_payload), content_type_header)
-        build_response(parse_payload(transport_response), transport_response)
+        transport_response = client.post('/scrape', JSON.generate(contract.request_payload), content_type_header)
+        parsed_response = contract.parse_response(transport_response)
+        raise_if_challenge_blocked!(parsed_response)
+        raise_if_upstream_failed!(parsed_response)
+        build_response(parsed_response)
       rescue Faraday::TimeoutError, Timeout::Error => error
         raise RequestTimedOut, error.message
-      rescue JSON::ParserError => error
-        raise BotasaurusConnectionFailed, "Botasaurus response JSON parse failed: #{error.message}"
       rescue Faraday::ConnectionFailed, Faraday::SSLError => error
         raise BotasaurusConnectionFailed, "Botasaurus connection failed: #{error.message}"
       end
@@ -43,55 +35,40 @@ module Html2rss
         ctx.policy.validate_request!(url: ctx.url, origin_url: ctx.origin_url, relation: ctx.relation)
       end
 
-      def build_response(response_payload, transport_response)
-        body = response_payload.fetch('html').to_s
+      def build_response(parsed_response)
+        body = parsed_response.html
         ResponseGuard.new(policy: ctx.policy).inspect_body!(body)
 
         Response.new(
           body:,
-          headers: response_headers(response_payload),
-          url: response_url(response_payload),
-          status: response_status(response_payload, transport_response)
+          headers: parsed_response.headers,
+          url: response_url(parsed_response.final_url),
+          status: parsed_response.status
         )
       end
 
-      def parse_payload(transport_response)
-        payload = JSON.parse(transport_response.body.to_s)
-        raise BotasaurusConnectionFailed, 'Botasaurus response must be a JSON object' unless payload.is_a?(Hash)
-        unless payload.key?('html')
-          raise BotasaurusConnectionFailed, "Botasaurus response missing required 'html' field"
-        end
+      def raise_if_challenge_blocked!(parsed_response)
+        return unless parsed_response.challenge_block?
 
-        raise_if_challenge_blocked!(payload)
-
-        payload
+        raise BlockedSurfaceDetected, "Blocked surface detected: #{parsed_response.challenge_message}"
       end
 
-      def raise_if_challenge_blocked!(response_payload)
-        return unless response_payload['error_category'] == 'challenge_block'
+      def raise_if_upstream_failed!(parsed_response)
+        return unless parsed_response.upstream_failure?
 
-        message = response_payload['error'] || 'Botasaurus challenge block detected.'
-        raise BlockedSurfaceDetected, "Blocked surface detected: #{message}"
+        raise BotasaurusConnectionFailed, parsed_response.upstream_failure_message
       end
 
-      def response_headers(response_payload)
-        raw_headers = response_payload['headers']
-        return DEFAULT_HEADERS.dup unless raw_headers.is_a?(Hash) && raw_headers.any?
+      def response_url(final_url)
+        return ctx.url if final_url.nil?
 
-        raw_headers.to_h { |key, value| [key.to_s, value.to_s] }
-      end
-
-      def response_status(response_payload, transport_response)
-        status_code = response_payload['status_code']
-        status_code.is_a?(Integer) ? status_code : transport_response.status
-      end
-
-      def response_url(response_payload)
-        return ctx.url unless response_payload['final_url']
-
-        Html2rss::Url.from_absolute(response_payload['final_url'])
+        Html2rss::Url.from_absolute(final_url)
       rescue ArgumentError
         ctx.url
+      end
+
+      def contract
+        @contract ||= BotasaurusContract.new(url: ctx.url, options: ctx.request.fetch(:botasaurus, {}))
       end
 
       def client
@@ -100,15 +77,6 @@ module Html2rss
 
       def request_options
         { timeout: ctx.policy.total_timeout_seconds }
-      end
-
-      def scrape_payload
-        {
-          url: ctx.url.to_s,
-          navigation_mode: DEFAULT_NAVIGATION_MODE,
-          max_retries: DEFAULT_MAX_RETRIES,
-          headless: DEFAULT_HEADLESS
-        }
       end
 
       def content_type_header

--- a/schema/html2rss-config.schema.json
+++ b/schema/html2rss-config.schema.json
@@ -445,6 +445,88 @@
             }
           },
           "required": []
+        },
+        "botasaurus": {
+          "type": "object",
+          "properties": {
+            "navigation_mode": {
+              "type": "string",
+              "minLength": 1,
+              "enum": [
+                "auto",
+                "get",
+                "google_get",
+                "google_get_bypass"
+              ]
+            },
+            "max_retries": {
+              "type": "integer",
+              "not": {
+                "type": "null"
+              },
+              "minimum": 0,
+              "maximum": 3
+            },
+            "wait_for_selector": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "wait_timeout_seconds": {
+              "type": "integer",
+              "not": {
+                "type": "null"
+              },
+              "exclusiveMinimum": 0
+            },
+            "block_images": {
+              "type": "boolean",
+              "not": {
+                "type": "null"
+              }
+            },
+            "block_images_and_css": {
+              "type": "boolean",
+              "not": {
+                "type": "null"
+              }
+            },
+            "wait_for_complete_page_load": {
+              "type": "boolean",
+              "not": {
+                "type": "null"
+              }
+            },
+            "headless": {
+              "type": "boolean",
+              "not": {
+                "type": "null"
+              }
+            },
+            "proxy": {
+              "type": "string",
+              "minLength": 1
+            },
+            "user_agent": {
+              "type": "string",
+              "minLength": 1
+            },
+            "window_size": {
+              "type": "array",
+              "items": {
+                "minLength": 2,
+                "maxLength": 2,
+                "type": "integer",
+                "exclusiveMinimum": 0
+              }
+            },
+            "lang": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": []
         }
       },
       "required": []

--- a/spec/lib/html2rss/cli_spec.rb
+++ b/spec/lib/html2rss/cli_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe Html2rss::CLI do
       expect(Html2rss).to have_received(:feed).with(hash_including(strategy: :browserless))
     end
 
+    it 'passes botasaurus strategy option to the config' do
+      allow(Html2rss).to receive(:config_from_yaml_file).and_return({})
+
+      cli.invoke(:feed, ['example.yml'], { strategy: 'botasaurus' })
+
+      expect(Html2rss).to have_received(:feed).with(hash_including(strategy: :botasaurus))
+    end
+
     it 'passes the max_redirects option to the config' do
       allow(Html2rss).to receive(:config_from_yaml_file).and_return({})
 
@@ -100,6 +108,14 @@ RSpec.describe Html2rss::CLI do
 
       expect(Html2rss).to have_received(:auto_source)
         .with('https://example.com', strategy: :browserless, items_selector: nil, max_redirects: nil,
+                                     max_requests: nil)
+    end
+
+    it 'passes botasaurus strategy option to Html2rss.auto_source' do
+      cli.invoke(:auto, ['https://example.com'], { strategy: 'botasaurus' })
+
+      expect(Html2rss).to have_received(:auto_source)
+        .with('https://example.com', strategy: :botasaurus, items_selector: nil, max_redirects: nil,
                                      max_requests: nil)
     end
 
@@ -184,6 +200,20 @@ RSpec.describe Html2rss::CLI do
       it 'raises a CLI error with browserless diagnostics' do
         expect { cli.invoke(:auto, ['https://example.com'], { strategy: 'browserless' }) }
           .to raise_error(Thor::Error, /Browserless connection failed/)
+      end
+    end
+
+    context 'when botasaurus connectivity fails' do
+      before do
+        allow(Html2rss).to receive(:auto_source).and_raise(
+          Html2rss::RequestService::BotasaurusConnectionFailed,
+          'Botasaurus connection failed: Connection refused'
+        )
+      end
+
+      it 'raises a CLI error with botasaurus diagnostics' do
+        expect { cli.invoke(:auto, ['https://example.com'], { strategy: 'botasaurus' }) }
+          .to raise_error(Thor::Error, /Botasaurus connection failed/)
       end
     end
 

--- a/spec/lib/html2rss/config/schema_spec.rb
+++ b/spec/lib/html2rss/config/schema_spec.rb
@@ -56,6 +56,21 @@ RSpec.describe Html2rss::Config::Schema do
     it 'does not expose internal validation helper properties' do
       expect(json_schema.fetch('properties')).not_to include('dynamic_params_error')
     end
+
+    it 'exposes botasaurus request options and constraints', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      botasaurus = json_schema.dig('properties', 'request', 'properties', 'botasaurus', 'properties')
+      window_size = botasaurus.fetch('window_size')
+      min_window_size = window_size['minItems'] || window_size.dig('items', 'minLength')
+      max_window_size = window_size['maxItems'] || window_size.dig('items', 'maxLength')
+
+      expect(botasaurus.fetch('navigation_mode').fetch('enum'))
+        .to contain_exactly('auto', 'get', 'google_get', 'google_get_bypass')
+      expect(botasaurus.dig('max_retries', 'minimum')).to eq(0)
+      expect(botasaurus.dig('max_retries', 'maximum')).to eq(3)
+      expect(botasaurus.dig('wait_timeout_seconds', 'exclusiveMinimum')).to eq(0)
+      expect(min_window_size).to eq(2)
+      expect(max_window_size).to eq(2)
+    end
   end
 
   describe '.path' do

--- a/spec/lib/html2rss/config_spec.rb
+++ b/spec/lib/html2rss/config_spec.rb
@@ -258,6 +258,76 @@ RSpec.describe Html2rss::Config do
       expect(result.to_h.dig(:channel, :time_zone)).to eq('UTC')
     end
 
+    context 'when request includes valid botasaurus options' do
+      let(:config) do
+        {
+          channel: { url: 'http://example.com' },
+          selectors: { items: { selector: '.item' }, title: { selector: 'h2' } },
+          request: {
+            botasaurus: {
+              navigation_mode: 'google_get_bypass',
+              max_retries: 3,
+              wait_for_selector: '.main',
+              wait_timeout_seconds: 15,
+              block_images: true,
+              block_images_and_css: false,
+              wait_for_complete_page_load: true,
+              headless: false,
+              proxy: 'http://user:pass@proxy:8080',
+              user_agent: 'Mozilla/5.0',
+              window_size: [1920, 1080],
+              lang: 'en-US'
+            }
+          }
+        }
+      end
+
+      it 'accepts the botasaurus config contract', :aggregate_failures do
+        result = described_class.validate(config)
+
+        expect(result).to be_success
+        expect(result.to_h.dig(:request, :botasaurus, :navigation_mode)).to eq('google_get_bypass')
+      end
+    end
+
+    context 'when request includes invalid botasaurus options' do
+      let(:config) do
+        {
+          channel: { url: 'http://example.com' },
+          selectors: { items: { selector: '.item' }, title: { selector: 'h2' } },
+          request: {
+            botasaurus: {
+              navigation_mode: 'invalid_mode',
+              max_retries: 4,
+              wait_timeout_seconds: 0
+            }
+          }
+        }
+      end
+
+      it 'rejects values outside the contract' do
+        expect(described_class.validate(config)).to be_failure
+      end
+    end
+
+    context 'when botasaurus window_size length is not exactly two items' do
+      let(:config) do
+        {
+          channel: { url: 'http://example.com' },
+          selectors: { items: { selector: '.item' }, title: { selector: 'h2' } },
+          request: {
+            botasaurus: {
+              window_size: [1920]
+            }
+          }
+        }
+      end
+
+      it 'rejects the botasaurus config' do
+        expect(described_class.validate(config)).to be_failure
+      end
+    end
+
     it 'fails when guid references an unknown selector' do
       config[:selectors][:guid] = ['missing']
 

--- a/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'climate_control'
+
+RSpec.describe Html2rss::RequestService::BotasaurusStrategy do # rubocop:disable RSpec/MultipleMemoizedHelpers
+  subject(:execute) { described_class.new(ctx).execute }
+
+  let(:policy) do
+    instance_double(
+      Html2rss::RequestService::Policy,
+      total_timeout_seconds: 30,
+      max_decompressed_bytes: 700_000,
+      validate_request!: nil
+    )
+  end
+  let(:budget) { instance_double(Html2rss::RequestService::Budget, consume!: nil) }
+  let(:ctx) { Html2rss::RequestService::Context.new(url: 'https://example.com', policy:, budget:) }
+  let(:connection) { instance_double(Faraday::Connection) }
+  let(:api_response) do
+    instance_double(Faraday::Response, status: 200, body: response_body)
+  end
+  let(:response_body) do
+    {
+      url: 'https://redacted.example/technology',
+      final_url: 'https://redacted.example/technology/',
+      status_code: 200,
+      headers: { 'content-type' => 'text/html' },
+      html: '<html><body>ok</body></html>',
+      error: nil,
+      metadata_error: nil,
+      request_id: 'request-id',
+      attempts: 2,
+      strategy_used: 'google_get_bypass',
+      render_ms: 5000,
+      blocked_detected: false,
+      challenge_detected: false,
+      error_category: nil
+    }.to_json
+  end
+  let(:captured_post_args) { [] }
+  let(:source_fixture_path) { '/Users/gil/versioned/html2rss/botasaurus-scrape-api/reuters_tech.response.json' }
+  let(:inline_sample_payload) do
+    {
+      'url' => 'https://redacted.example/technology',
+      'final_url' => 'https://redacted.example/technology/',
+      'status_code' => 200,
+      'headers' => { 'content-type' => 'text/html' },
+      'html' => '<html>redacted</html>',
+      'error' => nil,
+      'metadata_error' => nil,
+      'request_id' => '8d78d630-280c-407f-9884-d71f3c092956',
+      'attempts' => 2,
+      'strategy_used' => 'google_get_bypass',
+      'render_ms' => 8074,
+      'blocked_detected' => false,
+      'challenge_detected' => false,
+      'error_category' => nil
+    }
+  end
+  let(:sample_payload) do
+    raw_payload = if File.exist?(source_fixture_path)
+                    JSON.parse(File.read(source_fixture_path))
+                  else
+                    inline_sample_payload
+                  end
+    raw_payload['url'] = raw_payload['url']&.sub(%r{https?://[^/]+}, 'https://redacted.example')
+    raw_payload['final_url'] = raw_payload['final_url']&.sub(%r{https?://[^/]+}, 'https://redacted.example')
+    raw_payload
+  end
+
+  around do |example|
+    ClimateControl.modify(BOTASAURUS_SCRAPER_URL: 'http://localhost:4010') { example.run }
+  end
+
+  before do
+    allow(Faraday).to receive(:new).and_return(connection)
+    allow(connection).to receive(:post) do |path, body, headers|
+      captured_post_args << [path, body, headers]
+      api_response
+    end
+  end
+
+  it 'posts with td-like defaults, validates policy, and maps response', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+    result = execute
+
+    expect(budget).to have_received(:consume!)
+    expect(policy).to have_received(:validate_request!).with(
+      url: ctx.url,
+      origin_url: ctx.origin_url,
+      relation: :initial
+    )
+    expect(Faraday).to have_received(:new).with(url: 'http://localhost:4010/', request: { timeout: 30 })
+    expect(captured_post_args.size).to eq(1)
+    path, body, headers = captured_post_args.first
+    expect(path).to eq('/scrape')
+    expect(headers).to eq('Content-Type' => 'application/json')
+    expect(JSON.parse(body)).to include(
+      'url' => 'https://example.com/',
+      'navigation_mode' => 'auto',
+      'max_retries' => 2,
+      'headless' => false
+    )
+    expect(result).to be_a(Html2rss::RequestService::Response)
+    expect(result.url.to_s).to eq('https://redacted.example/technology/')
+    expect(result.status).to eq(200)
+    expect(result.headers.fetch('content-type')).to include('text/html')
+    expect(result.body).to include('ok')
+  end
+
+  it 'uses status and fallback headers from transport when payload omits them', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+    allow(api_response).to receive_messages(status: 202, body: {
+      final_url: nil,
+      status_code: nil,
+      headers: nil,
+      html: '<html>fallback</html>'
+    }.to_json)
+
+    result = execute
+
+    expect(result.status).to eq(202)
+    expect(result.url.to_s).to eq('https://example.com/')
+    expect(result.headers).to eq('content-type' => 'text/html')
+  end
+
+  it 'raises configuration error when BOTASAURUS_SCRAPER_URL is missing' do # rubocop:disable RSpec/ExampleLength
+    ClimateControl.modify(BOTASAURUS_SCRAPER_URL: nil) do
+      expect { execute }
+        .to raise_error(
+          Html2rss::RequestService::BotasaurusConfigurationError,
+          /BOTASAURUS_SCRAPER_URL is required/
+        )
+    end
+  end
+
+  it 'raises configuration error when BOTASAURUS_SCRAPER_URL is invalid' do
+    ClimateControl.modify(BOTASAURUS_SCRAPER_URL: 'not-a-url') do
+      expect { execute }
+        .to raise_error(Html2rss::RequestService::BotasaurusConfigurationError, /is invalid/)
+    end
+  end
+
+  it 'maps timeout errors to RequestTimedOut' do
+    allow(connection).to receive(:post).and_raise(Faraday::TimeoutError, 'Timed out')
+
+    expect { execute }
+      .to raise_error(Html2rss::RequestService::RequestTimedOut, /Timed out/)
+  end
+
+  it 'maps network errors to BotasaurusConnectionFailed' do
+    allow(connection).to receive(:post).and_raise(Faraday::ConnectionFailed, 'Connection refused')
+
+    expect { execute }
+      .to raise_error(Html2rss::RequestService::BotasaurusConnectionFailed, /connection failed/i)
+  end
+
+  it 'raises BotasaurusConnectionFailed on invalid JSON payload' do
+    allow(api_response).to receive(:body).and_return('not-json')
+
+    expect { execute }
+      .to raise_error(Html2rss::RequestService::BotasaurusConnectionFailed, /JSON parse failed/)
+  end
+
+  it 'raises BotasaurusConnectionFailed when required html field is missing' do
+    allow(api_response).to receive(:body).and_return({ final_url: 'https://redacted.example/path' }.to_json)
+
+    expect { execute }
+      .to raise_error(Html2rss::RequestService::BotasaurusConnectionFailed, /missing required 'html'/)
+  end
+
+  it 'maps challenge blocks to BlockedSurfaceDetected' do # rubocop:disable RSpec/ExampleLength
+    allow(api_response).to receive(:body).and_return({
+      html: '<html>challenge</html>',
+      error: 'Challenge block detected',
+      error_category: 'challenge_block'
+    }.to_json)
+
+    expect { execute }
+      .to raise_error(Html2rss::RequestService::BlockedSurfaceDetected, /Blocked surface detected/)
+  end
+
+  it 'verifies sample contract shape from sanitized fixture', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+    fixture = sample_payload
+    fixture['html'] = 'x' * 562_671
+    allow(api_response).to receive(:body).and_return(JSON.generate(fixture))
+
+    result = execute
+
+    expect(fixture).to include(
+      'status_code' => 200,
+      'error' => nil,
+      'metadata_error' => nil,
+      'attempts' => 2,
+      'strategy_used' => 'google_get_bypass',
+      'blocked_detected' => false,
+      'challenge_detected' => false,
+      'error_category' => nil
+    )
+    expect(result.url.to_s).to eq('https://redacted.example/technology/')
+    expect(result.headers.fetch('content-type')).to include('text/html')
+    expect(result.body.bytesize).to eq(562_671)
+  end
+end

--- a/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
@@ -15,15 +15,14 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do # rubocop:disable
     )
   end
   let(:budget) { instance_double(Html2rss::RequestService::Budget, consume!: nil) }
-  let(:ctx) { Html2rss::RequestService::Context.new(url: 'https://example.com', policy:, budget:) }
+  let(:request_config) { {} }
+  let(:ctx) { Html2rss::RequestService::Context.new(url: 'https://example.com', request: request_config, policy:, budget:) }
   let(:connection) { instance_double(Faraday::Connection) }
-  let(:api_response) do
-    instance_double(Faraday::Response, status: 200, body: response_body)
-  end
+  let(:api_response) { instance_double(Faraday::Response, status: 200, body: response_body) }
   let(:response_body) do
     {
-      url: 'https://redacted.example/technology',
-      final_url: 'https://redacted.example/technology/',
+      url: 'https://redacted.example/path',
+      final_url: 'https://redacted.example/path/',
       status_code: 200,
       headers: { 'content-type' => 'text/html' },
       html: '<html><body>ok</body></html>',
@@ -42,8 +41,8 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do # rubocop:disable
   let(:source_fixture_path) { '/Users/gil/versioned/html2rss/botasaurus-scrape-api/reuters_tech.response.json' }
   let(:inline_sample_payload) do
     {
-      'url' => 'https://redacted.example/technology',
-      'final_url' => 'https://redacted.example/technology/',
+      'url' => 'https://redacted.example/path',
+      'final_url' => 'https://redacted.example/path/',
       'status_code' => 200,
       'headers' => { 'content-type' => 'text/html' },
       'html' => '<html>redacted</html>',
@@ -81,7 +80,7 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do # rubocop:disable
     end
   end
 
-  it 'posts with td-like defaults, validates policy, and maps response', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+  it 'posts defaults, validates policy, and maps response', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
     result = execute
 
     expect(budget).to have_received(:consume!)
@@ -95,32 +94,111 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do # rubocop:disable
     path, body, headers = captured_post_args.first
     expect(path).to eq('/scrape')
     expect(headers).to eq('Content-Type' => 'application/json')
-    expect(JSON.parse(body)).to include(
+    expect(JSON.parse(body)).to eq(
       'url' => 'https://example.com/',
       'navigation_mode' => 'auto',
       'max_retries' => 2,
       'headless' => false
     )
     expect(result).to be_a(Html2rss::RequestService::Response)
-    expect(result.url.to_s).to eq('https://redacted.example/technology/')
+    expect(result.url.to_s).to eq('https://redacted.example/path/')
     expect(result.status).to eq(200)
     expect(result.headers.fetch('content-type')).to include('text/html')
     expect(result.body).to include('ok')
   end
 
-  it 'uses status and fallback headers from transport when payload omits them', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    allow(api_response).to receive_messages(status: 202, body: {
+  it 'includes allowlisted botasaurus options and excludes unknown keys', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+    request_overrides = {
+      botasaurus: {
+        navigation_mode: 'google_get_bypass',
+        max_retries: 3,
+        wait_for_selector: 'h1',
+        wait_timeout_seconds: 15,
+        block_images: true,
+        block_images_and_css: false,
+        wait_for_complete_page_load: true,
+        headless: true,
+        proxy: 'http://proxy.local:8080',
+        user_agent: 'Agent/1.0',
+        window_size: [1920, 1080],
+        lang: 'en-US',
+        ignored_key: 'drop-me'
+      }
+    }
+    ctx_with_options = Html2rss::RequestService::Context.new(
+      url: 'https://example.com',
+      request: request_overrides,
+      policy:,
+      budget:
+    )
+
+    described_class.new(ctx_with_options).execute
+
+    payload = JSON.parse(captured_post_args.first.fetch(1))
+    expect(payload).to include(
+      'navigation_mode' => 'google_get_bypass',
+      'max_retries' => 3,
+      'wait_for_selector' => 'h1',
+      'wait_timeout_seconds' => 15,
+      'block_images' => true,
+      'block_images_and_css' => false,
+      'wait_for_complete_page_load' => true,
+      'headless' => true,
+      'proxy' => 'http://proxy.local:8080',
+      'user_agent' => 'Agent/1.0',
+      'window_size' => [1920, 1080],
+      'lang' => 'en-US'
+    )
+    expect(payload).not_to have_key('ignored_key')
+  end
+
+  it 'uses fallback headers from transport metadata defaults when payload omits headers', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+    allow(api_response).to receive_messages(status: 200, body: {
       final_url: nil,
       status_code: nil,
       headers: nil,
-      html: '<html>fallback</html>'
+      html: '<html>fallback</html>',
+      error: nil,
+      error_category: nil
     }.to_json)
 
     result = execute
 
-    expect(result.status).to eq(202)
+    expect(result.status).to eq(200)
     expect(result.url.to_s).to eq('https://example.com/')
     expect(result.headers).to eq('content-type' => 'text/html')
+  end
+
+  it 'raises BotasaurusConnectionFailed on non-200 upstream failures', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+    allow(api_response).to receive_messages(status: 502, body: {
+      html: '<html>error</html>',
+      status_code: 502,
+      error: 'navigation failed',
+      error_category: 'navigation_error',
+      request_id: 'trace-123'
+    }.to_json)
+
+    expect { execute }
+      .to raise_error(
+        Html2rss::RequestService::BotasaurusConnectionFailed,
+        /status=502, error_category=navigation_error, error=navigation failed, request_id=trace-123/
+      )
+  end
+
+  it 'raises BotasaurusConnectionFailed on upstream error payloads', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+    allow(api_response).to receive(:body).and_return({
+      html: '<html>error</html>',
+      status_code: 200,
+      error: 'metadata collection failed',
+      error_category: 'metadata_error',
+      request_id: 'trace-456'
+    }.to_json)
+
+    expect { execute }
+      .to raise_error(
+        Html2rss::RequestService::BotasaurusConnectionFailed,
+        /status=200, error_category=metadata_error, error=metadata collection failed, request_id=trace-456/
+      )
   end
 
   it 'raises configuration error when BOTASAURUS_SCRAPER_URL is missing' do # rubocop:disable RSpec/ExampleLength
@@ -161,8 +239,13 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do # rubocop:disable
       .to raise_error(Html2rss::RequestService::BotasaurusConnectionFailed, /JSON parse failed/)
   end
 
-  it 'raises BotasaurusConnectionFailed when required html field is missing' do
-    allow(api_response).to receive(:body).and_return({ final_url: 'https://redacted.example/path' }.to_json)
+  it 'raises BotasaurusConnectionFailed when required html field is missing' do # rubocop:disable RSpec/ExampleLength
+    allow(api_response).to receive(:body).and_return({
+      final_url: 'https://redacted.example/path/',
+      status_code: 200,
+      error: nil,
+      error_category: nil
+    }.to_json)
 
     expect { execute }
       .to raise_error(Html2rss::RequestService::BotasaurusConnectionFailed, /missing required 'html'/)
@@ -196,6 +279,8 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do # rubocop:disable
       'challenge_detected' => false,
       'error_category' => nil
     )
+    expect(fixture.fetch('url')).to start_with('https://redacted.example')
+    expect(fixture.fetch('final_url')).to start_with('https://redacted.example')
     expect(result.url.to_s).to eq('https://redacted.example/technology/')
     expect(result.headers.fetch('content-type')).to include('text/html')
     expect(result.body.bytesize).to eq(562_671)

--- a/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
@@ -3,7 +3,8 @@
 require 'spec_helper'
 require 'climate_control'
 
-RSpec.describe Html2rss::RequestService::BotasaurusStrategy do # rubocop:disable RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/MultipleMemoizedHelpers, RSpec/ExampleLength
+RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
   subject(:execute) { described_class.new(ctx).execute }
 
   let(:policy) do
@@ -18,8 +19,11 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do # rubocop:disable
   let(:request_config) { {} }
   let(:ctx) { Html2rss::RequestService::Context.new(url: 'https://example.com', request: request_config, policy:, budget:) }
   let(:connection) { instance_double(Faraday::Connection) }
-  let(:api_response) { instance_double(Faraday::Response, status: 200, body: response_body) }
-  let(:response_body) do
+  let(:response_status) { 200 }
+  let(:response_payload) { base_payload }
+  let(:api_response) { instance_double(Faraday::Response, status: response_status, body: JSON.generate(response_payload)) }
+  let(:captured_post_args) { [] }
+  let(:base_payload) do
     {
       url: 'https://redacted.example/path',
       final_url: 'https://redacted.example/path/',
@@ -35,14 +39,12 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do # rubocop:disable
       blocked_detected: false,
       challenge_detected: false,
       error_category: nil
-    }.to_json
+    }
   end
-  let(:captured_post_args) { [] }
-  let(:source_fixture_path) { '/Users/gil/versioned/html2rss/botasaurus-scrape-api/reuters_tech.response.json' }
-  let(:inline_sample_payload) do
+  let(:sanitized_sample_payload) do
     {
       'url' => 'https://redacted.example/path',
-      'final_url' => 'https://redacted.example/path/',
+      'final_url' => 'https://redacted.example/technology/',
       'status_code' => 200,
       'headers' => { 'content-type' => 'text/html' },
       'html' => '<html>redacted</html>',
@@ -57,16 +59,6 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do # rubocop:disable
       'error_category' => nil
     }
   end
-  let(:sample_payload) do
-    raw_payload = if File.exist?(source_fixture_path)
-                    JSON.parse(File.read(source_fixture_path))
-                  else
-                    inline_sample_payload
-                  end
-    raw_payload['url'] = raw_payload['url']&.sub(%r{https?://[^/]+}, 'https://redacted.example')
-    raw_payload['final_url'] = raw_payload['final_url']&.sub(%r{https?://[^/]+}, 'https://redacted.example')
-    raw_payload
-  end
 
   around do |example|
     ClimateControl.modify(BOTASAURUS_SCRAPER_URL: 'http://localhost:4010') { example.run }
@@ -80,209 +72,241 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do # rubocop:disable
     end
   end
 
-  it 'posts defaults, validates policy, and maps response', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    result = execute
+  describe 'request contract' do
+    it 'posts defaults and validates request policy', :aggregate_failures do
+      execute
 
-    expect(budget).to have_received(:consume!)
-    expect(policy).to have_received(:validate_request!).with(
-      url: ctx.url,
-      origin_url: ctx.origin_url,
-      relation: :initial
-    )
-    expect(Faraday).to have_received(:new).with(url: 'http://localhost:4010/', request: { timeout: 30 })
-    expect(captured_post_args.size).to eq(1)
-    path, body, headers = captured_post_args.first
-    expect(path).to eq('/scrape')
-    expect(headers).to eq('Content-Type' => 'application/json')
-    expect(JSON.parse(body)).to eq(
-      'url' => 'https://example.com/',
-      'navigation_mode' => 'auto',
-      'max_retries' => 2,
-      'headless' => false
-    )
-    expect(result).to be_a(Html2rss::RequestService::Response)
-    expect(result.url.to_s).to eq('https://redacted.example/path/')
-    expect(result.status).to eq(200)
-    expect(result.headers.fetch('content-type')).to include('text/html')
-    expect(result.body).to include('ok')
-  end
-
-  it 'includes allowlisted botasaurus options and excludes unknown keys', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    request_overrides = {
-      botasaurus: {
-        navigation_mode: 'google_get_bypass',
-        max_retries: 3,
-        wait_for_selector: 'h1',
-        wait_timeout_seconds: 15,
-        block_images: true,
-        block_images_and_css: false,
-        wait_for_complete_page_load: true,
-        headless: true,
-        proxy: 'http://proxy.local:8080',
-        user_agent: 'Agent/1.0',
-        window_size: [1920, 1080],
-        lang: 'en-US',
-        ignored_key: 'drop-me'
-      }
-    }
-    ctx_with_options = Html2rss::RequestService::Context.new(
-      url: 'https://example.com',
-      request: request_overrides,
-      policy:,
-      budget:
-    )
-
-    described_class.new(ctx_with_options).execute
-
-    payload = JSON.parse(captured_post_args.first.fetch(1))
-    expect(payload).to include(
-      'navigation_mode' => 'google_get_bypass',
-      'max_retries' => 3,
-      'wait_for_selector' => 'h1',
-      'wait_timeout_seconds' => 15,
-      'block_images' => true,
-      'block_images_and_css' => false,
-      'wait_for_complete_page_load' => true,
-      'headless' => true,
-      'proxy' => 'http://proxy.local:8080',
-      'user_agent' => 'Agent/1.0',
-      'window_size' => [1920, 1080],
-      'lang' => 'en-US'
-    )
-    expect(payload).not_to have_key('ignored_key')
-  end
-
-  it 'uses fallback headers from transport metadata defaults when payload omits headers', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    allow(api_response).to receive_messages(status: 200, body: {
-      final_url: nil,
-      status_code: nil,
-      headers: nil,
-      html: '<html>fallback</html>',
-      error: nil,
-      error_category: nil
-    }.to_json)
-
-    result = execute
-
-    expect(result.status).to eq(200)
-    expect(result.url.to_s).to eq('https://example.com/')
-    expect(result.headers).to eq('content-type' => 'text/html')
-  end
-
-  it 'raises BotasaurusConnectionFailed on non-200 upstream failures', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    allow(api_response).to receive_messages(status: 502, body: {
-      html: '<html>error</html>',
-      status_code: 502,
-      error: 'navigation failed',
-      error_category: 'navigation_error',
-      request_id: 'trace-123'
-    }.to_json)
-
-    expect { execute }
-      .to raise_error(
-        Html2rss::RequestService::BotasaurusConnectionFailed,
-        /status=502, error_category=navigation_error, error=navigation failed, request_id=trace-123/
+      expect(budget).to have_received(:consume!)
+      expect(policy).to have_received(:validate_request!).with(
+        url: ctx.url,
+        origin_url: ctx.origin_url,
+        relation: :initial
       )
-  end
-
-  it 'raises BotasaurusConnectionFailed on upstream error payloads', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    allow(api_response).to receive(:body).and_return({
-      html: '<html>error</html>',
-      status_code: 200,
-      error: 'metadata collection failed',
-      error_category: 'metadata_error',
-      request_id: 'trace-456'
-    }.to_json)
-
-    expect { execute }
-      .to raise_error(
-        Html2rss::RequestService::BotasaurusConnectionFailed,
-        /status=200, error_category=metadata_error, error=metadata collection failed, request_id=trace-456/
+      expect(Faraday).to have_received(:new).with(url: 'http://localhost:4010/', request: { timeout: 30 })
+      path, body, headers = captured_post_args.first
+      expect(path).to eq('/scrape')
+      expect(headers).to eq('Content-Type' => 'application/json')
+      expect(JSON.parse(body)).to eq(
+        'url' => 'https://example.com/',
+        'navigation_mode' => 'auto',
+        'max_retries' => 2,
+        'headless' => false
       )
-  end
+    end
 
-  it 'raises configuration error when BOTASAURUS_SCRAPER_URL is missing' do # rubocop:disable RSpec/ExampleLength
-    ClimateControl.modify(BOTASAURUS_SCRAPER_URL: nil) do
-      expect { execute }
-        .to raise_error(
-          Html2rss::RequestService::BotasaurusConfigurationError,
-          /BOTASAURUS_SCRAPER_URL is required/
+    context 'when request includes optional botasaurus fields' do
+      let(:request_config) do
+        {
+          botasaurus: {
+            navigation_mode: 'google_get_bypass',
+            max_retries: 3,
+            wait_for_selector: 'h1',
+            wait_timeout_seconds: 15,
+            block_images: true,
+            block_images_and_css: false,
+            wait_for_complete_page_load: true,
+            headless: true,
+            proxy: 'http://proxy.local:8080',
+            user_agent: 'Agent/1.0',
+            window_size: [1920, 1080],
+            lang: 'en-US',
+            ignored_key: 'drop-me'
+          }
+        }
+      end
+
+      it 'forwards allowlisted fields and drops unknown keys', :aggregate_failures do
+        execute
+
+        payload = JSON.parse(captured_post_args.first.fetch(1))
+        expect(payload).to include(
+          'navigation_mode' => 'google_get_bypass',
+          'max_retries' => 3,
+          'wait_for_selector' => 'h1',
+          'wait_timeout_seconds' => 15,
+          'block_images' => true,
+          'block_images_and_css' => false,
+          'wait_for_complete_page_load' => true,
+          'headless' => true,
+          'proxy' => 'http://proxy.local:8080',
+          'user_agent' => 'Agent/1.0',
+          'window_size' => [1920, 1080],
+          'lang' => 'en-US'
         )
+        expect(payload).not_to have_key('ignored_key')
+      end
     end
   end
 
-  it 'raises configuration error when BOTASAURUS_SCRAPER_URL is invalid' do
-    ClimateControl.modify(BOTASAURUS_SCRAPER_URL: 'not-a-url') do
+  describe 'response mapping' do
+    it 'maps upstream payload to response object', :aggregate_failures do
+      result = execute
+
+      expect(result).to be_a(Html2rss::RequestService::Response)
+      expect(result.url.to_s).to eq('https://redacted.example/path/')
+      expect(result.status).to eq(200)
+      expect(result.headers.fetch('content-type')).to include('text/html')
+      expect(result.body).to include('ok')
+    end
+
+    context 'when response omits headers and url metadata' do
+      let(:response_payload) do
+        {
+          final_url: nil,
+          status_code: nil,
+          headers: nil,
+          html: '<html>fallback</html>',
+          error: nil,
+          error_category: nil
+        }
+      end
+
+      it 'falls back to transport status, source url, and default headers', :aggregate_failures do
+        result = execute
+
+        expect(result.status).to eq(200)
+        expect(result.url.to_s).to eq('https://example.com/')
+        expect(result.headers).to eq('content-type' => 'text/html')
+      end
+    end
+
+    context 'with a deterministic sanitized contract sample' do
+      let(:response_payload) do
+        sanitized_sample_payload.merge('html' => 'x' * 562_671)
+      end
+
+      it 'accepts known sample fields and preserves large rendered body', :aggregate_failures do
+        result = execute
+
+        expect(sanitized_sample_payload).to include(
+          'status_code' => 200,
+          'error' => nil,
+          'metadata_error' => nil,
+          'attempts' => 2,
+          'strategy_used' => 'google_get_bypass',
+          'blocked_detected' => false,
+          'challenge_detected' => false,
+          'error_category' => nil
+        )
+        expect(result.url.to_s).to eq('https://redacted.example/technology/')
+        expect(result.headers.fetch('content-type')).to include('text/html')
+        expect(result.body.bytesize).to eq(562_671)
+      end
+    end
+  end
+
+  describe 'failure handling' do
+    context 'when upstream returns non-200 status with error details' do
+      let(:response_status) { 502 }
+      let(:response_payload) do
+        {
+          html: '<html>error</html>',
+          status_code: 502,
+          error: 'navigation failed',
+          error_category: 'navigation_error',
+          request_id: 'trace-123'
+        }
+      end
+
+      it 'raises BotasaurusConnectionFailed with diagnostics' do
+        expect { execute }
+          .to raise_error(
+            Html2rss::RequestService::BotasaurusConnectionFailed,
+            /status=502, error_category=navigation_error, error=navigation failed, request_id=trace-123/
+          )
+      end
+    end
+
+    context 'when upstream returns 200 with error payload' do
+      let(:response_payload) do
+        {
+          html: '<html>error</html>',
+          status_code: 200,
+          error: 'metadata collection failed',
+          error_category: 'metadata_error',
+          request_id: 'trace-456'
+        }
+      end
+
+      it 'raises BotasaurusConnectionFailed' do
+        expect { execute }
+          .to raise_error(
+            Html2rss::RequestService::BotasaurusConnectionFailed,
+            /status=200, error_category=metadata_error, error=metadata collection failed, request_id=trace-456/
+          )
+      end
+    end
+
+    context 'when upstream payload is invalid JSON' do
+      let(:api_response) { instance_double(Faraday::Response, status: 200, body: 'not-json') }
+
+      it 'raises BotasaurusConnectionFailed' do
+        expect { execute }
+          .to raise_error(Html2rss::RequestService::BotasaurusConnectionFailed, /JSON parse failed/)
+      end
+    end
+
+    context "when upstream payload omits required 'html'" do
+      let(:response_payload) do
+        {
+          final_url: 'https://redacted.example/path/',
+          status_code: 200,
+          error: nil,
+          error_category: nil
+        }
+      end
+
+      it 'raises BotasaurusConnectionFailed' do
+        expect { execute }
+          .to raise_error(Html2rss::RequestService::BotasaurusConnectionFailed, /missing required 'html'/)
+      end
+    end
+
+    context 'when upstream reports challenge_block' do
+      let(:response_payload) do
+        {
+          html: '<html>challenge</html>',
+          error: 'Challenge block detected',
+          error_category: 'challenge_block'
+        }
+      end
+
+      it 'raises BlockedSurfaceDetected' do
+        expect { execute }
+          .to raise_error(Html2rss::RequestService::BlockedSurfaceDetected, /Blocked surface detected/)
+      end
+    end
+
+    it 'maps timeout errors to RequestTimedOut' do
+      allow(connection).to receive(:post).and_raise(Faraday::TimeoutError, 'Timed out')
+
       expect { execute }
-        .to raise_error(Html2rss::RequestService::BotasaurusConfigurationError, /is invalid/)
+        .to raise_error(Html2rss::RequestService::RequestTimedOut, /Timed out/)
     end
-  end
 
-  it 'maps timeout errors to RequestTimedOut' do
-    allow(connection).to receive(:post).and_raise(Faraday::TimeoutError, 'Timed out')
+    it 'maps network errors to BotasaurusConnectionFailed' do
+      allow(connection).to receive(:post).and_raise(Faraday::ConnectionFailed, 'Connection refused')
 
-    expect { execute }
-      .to raise_error(Html2rss::RequestService::RequestTimedOut, /Timed out/)
-  end
+      expect { execute }
+        .to raise_error(Html2rss::RequestService::BotasaurusConnectionFailed, /connection failed/i)
+    end
 
-  it 'maps network errors to BotasaurusConnectionFailed' do
-    allow(connection).to receive(:post).and_raise(Faraday::ConnectionFailed, 'Connection refused')
+    it 'raises configuration error when BOTASAURUS_SCRAPER_URL is missing' do
+      ClimateControl.modify(BOTASAURUS_SCRAPER_URL: nil) do
+        expect { execute }
+          .to raise_error(
+            Html2rss::RequestService::BotasaurusConfigurationError,
+            /BOTASAURUS_SCRAPER_URL is required/
+          )
+      end
+    end
 
-    expect { execute }
-      .to raise_error(Html2rss::RequestService::BotasaurusConnectionFailed, /connection failed/i)
-  end
-
-  it 'raises BotasaurusConnectionFailed on invalid JSON payload' do
-    allow(api_response).to receive(:body).and_return('not-json')
-
-    expect { execute }
-      .to raise_error(Html2rss::RequestService::BotasaurusConnectionFailed, /JSON parse failed/)
-  end
-
-  it 'raises BotasaurusConnectionFailed when required html field is missing' do # rubocop:disable RSpec/ExampleLength
-    allow(api_response).to receive(:body).and_return({
-      final_url: 'https://redacted.example/path/',
-      status_code: 200,
-      error: nil,
-      error_category: nil
-    }.to_json)
-
-    expect { execute }
-      .to raise_error(Html2rss::RequestService::BotasaurusConnectionFailed, /missing required 'html'/)
-  end
-
-  it 'maps challenge blocks to BlockedSurfaceDetected' do # rubocop:disable RSpec/ExampleLength
-    allow(api_response).to receive(:body).and_return({
-      html: '<html>challenge</html>',
-      error: 'Challenge block detected',
-      error_category: 'challenge_block'
-    }.to_json)
-
-    expect { execute }
-      .to raise_error(Html2rss::RequestService::BlockedSurfaceDetected, /Blocked surface detected/)
-  end
-
-  it 'verifies sample contract shape from sanitized fixture', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-    fixture = sample_payload
-    fixture['html'] = 'x' * 562_671
-    allow(api_response).to receive(:body).and_return(JSON.generate(fixture))
-
-    result = execute
-
-    expect(fixture).to include(
-      'status_code' => 200,
-      'error' => nil,
-      'metadata_error' => nil,
-      'attempts' => 2,
-      'strategy_used' => 'google_get_bypass',
-      'blocked_detected' => false,
-      'challenge_detected' => false,
-      'error_category' => nil
-    )
-    expect(fixture.fetch('url')).to start_with('https://redacted.example')
-    expect(fixture.fetch('final_url')).to start_with('https://redacted.example')
-    expect(result.url.to_s).to eq('https://redacted.example/technology/')
-    expect(result.headers.fetch('content-type')).to include('text/html')
-    expect(result.body.bytesize).to eq(562_671)
+    it 'raises configuration error when BOTASAURUS_SCRAPER_URL is invalid' do
+      ClimateControl.modify(BOTASAURUS_SCRAPER_URL: 'not-a-url') do
+        expect { execute }
+          .to raise_error(Html2rss::RequestService::BotasaurusConfigurationError, /is invalid/)
+      end
+    end
   end
 end
+# rubocop:enable RSpec/MultipleMemoizedHelpers, RSpec/ExampleLength

--- a/spec/lib/html2rss/request_service_spec.rb
+++ b/spec/lib/html2rss/request_service_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe Html2rss::RequestService do
       described_class::ResponseTooLarge,
       described_class::RequestTimedOut,
       described_class::BrowserlessConfigurationError,
-      described_class::BrowserlessConnectionFailed
+      described_class::BrowserlessConnectionFailed,
+      described_class::BotasaurusConfigurationError,
+      described_class::BotasaurusConnectionFailed
     ]
   end
 
@@ -28,6 +30,7 @@ RSpec.describe Html2rss::RequestService do
     specify(:aggregate_failures) do
       expect(described_class.default_strategy_name).to be :faraday
       expect(described_class.strategy_registered?(:faraday)).to be true
+      expect(described_class.strategy_registered?(:botasaurus)).to be true
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,7 @@ if ENV['COVERAGE']
   end
 end
 
-require_relative '../lib/html2rss'
+require 'html2rss'
 require_relative 'support/cli_helpers'
 
 # Load custom matchers and helpers


### PR DESCRIPTION
## Summary
- add Botasaurus request strategy and contract-based request/response mapping
- wire strategy registration and CLI support for explicit strategy botasaurus
- add request.botasaurus validation in dry-schema and generated JSON schema
- extend Botasaurus-focused specs and docs

Requires https://github.com/html2rss/botasaurus-scrape-api (published as Docker container at https://hub.docker.com/r/html2rss/botasaurus-scrape-api )

---

This pull request adds support for a new "botasaurus" request strategy, allowing html2rss to delegate page fetching to a Botasaurus scrape API. This includes CLI, config, schema, and core implementation changes, as well as new error handling and tests. The documentation is updated to describe usage and configuration for the new strategy.

**New Botasaurus request strategy:**

* Added `BotasaurusStrategy` and `BotasaurusContract` classes to `lib/html2rss/request_service/`, enabling requests to be delegated to a Botasaurus scrape API, with robust error handling and payload normalization. [[1]](diffhunk://#diff-5d0ce7c6f7471732cd3846499531151370050c5c43d9503d0930fbac1b9f321aR1-R161) [[2]](diffhunk://#diff-8ed262353fb0e363d79b7f8c972e03ad51dcae2c8a607aebc60512e3e656e5d6R1-R98)
* Introduced new error classes `BotasaurusConfigurationError` and `BotasaurusConnectionFailed` for handling configuration and connectivity issues with Botasaurus.

**Configuration and schema updates:**

* Extended the config validator (`lib/html2rss/config/validator.rb`) and JSON schema (`schema/html2rss-config.schema.json`) to support and validate Botasaurus-specific request options such as `navigation_mode`, `max_retries`, `headless`, etc. [[1]](diffhunk://#diff-e86b242a4652e32e46f219c4ac8c1dfbdf318bc03c927e659fc6dd41c702f025R59-R82) [[2]](diffhunk://#diff-f03777c005fda0f6beced7549884114a4890a962da7a144ab193b970f469ff53R448-R529)
* Updated CLI options to allow `botasaurus` as a valid strategy for both `auto` and `feed` commands. [[1]](diffhunk://#diff-c937a68077b930fbe54d0e1c0772e773c20b1a9fb4f36074dd83f9321e16d9bfL29-R29) [[2]](diffhunk://#diff-c937a68077b930fbe54d0e1c0772e773c20b1a9fb4f36074dd83f9321e16d9bfL51-R51)
* Added handling for Botasaurus-related errors in CLI error reporting.

**Documentation improvements:**

* Updated the `README.md` to document the new Botasaurus strategy, its configuration options, environment variables, and example usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R39) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R50-R105)

**Testing enhancements:**

* Added and extended tests to ensure the CLI passes the Botasaurus strategy and options correctly, and that errors are handled and surfaced as expected. [[1]](diffhunk://#diff-ba7181be1df4b2e40990183293f3823bddebbfcfdf4873efcf0d79f1caa5f13dR37-R44) [[2]](diffhunk://#diff-ba7181be1df4b2e40990183293f3823bddebbfcfdf4873efcf0d79f1caa5f13dR114-R121) [[3]](diffhunk://#diff-ba7181be1df4b2e40990183293f3823bddebbfcfdf4873efcf0d79f1caa5f13dR206-R219) [[4]](diffhunk://#diff-c98a3559f4322f1d924137a5616ddbd3ce6ad2dbb6a5fa56f53c8ad833d5874dR59-R73)

**Core integration:**

* Registered the new `botasaurus` strategy in the `RequestService` strategies map.