### PR TITLE
fix: allow @ in channel URL paths while rejecting unsafe components

### DIFF
--- a/lib/html2rss/url.rb
+++ b/lib/html2rss/url.rb
@@ -108,7 +108,10 @@ module Html2rss
     def self.validate_channel_url(url)
       raise ArgumentError, 'URL must be absolute' unless url.absolute?
 
-      raise ArgumentError, 'URL must not contain an @ character' if url.to_s.include?('@')
+      uri = url.instance_variable_get(:@uri)
+      has_forbidden_at = uri.user || uri.password
+      has_forbidden_at ||= [uri.query, uri.fragment].compact.any? { |value| value.include?('@') }
+      raise ArgumentError, 'URL must not contain an @ character' if has_forbidden_at
 
       scheme = url.scheme
       raise ArgumentError, "URL scheme '#{scheme}' is not supported" unless SUPPORTED_SCHEMES.include?(scheme)
@@ -151,17 +154,13 @@ module Html2rss
     # Returns the URL query string as a hash of string keys and values.
     #
     # @return [Hash{String => String}] normalized query parameters
-    def query_values
-      @uri.query_values(Hash) || {}
-    end
+    def query_values = @uri.query_values(Hash) || {}
 
     ##
     # Returns the URL path split into non-empty segments.
     #
     # @return [Array<String>] normalized path segments
-    def path_segments
-      @uri.path.to_s.split('/').reject(&:empty?)
-    end
+    def path_segments = @uri.path.to_s.split('/').reject(&:empty?)
 
     ##
     # Returns a copy of the URL with the provided path.
@@ -236,42 +235,32 @@ module Html2rss
     #
     # @param other [Url] the other URL to compare with
     # @return [Integer] -1, 0, or 1 for less than, equal, or greater than
-    def <=>(other)
-      to_s <=> other.to_s
-    end
+    def <=>(other) = to_s <=> other.to_s
 
     ##
     # Returns true if this URL is equal to another URL.
     #
     # @param other [Object] the other object to compare with
     # @return [Boolean] true if the URLs are equal
-    def ==(other)
-      other.is_a?(Url) && to_s == other.to_s
-    end
+    def ==(other) = other.is_a?(Url) && to_s == other.to_s
 
     ##
     # Supports hash-based comparisons by ensuring equality semantics match `hash`.
     #
     # @param other [Object] the other object to compare with
     # @return [Boolean] true if the URLs are considered equal
-    def eql?(other)
-      other.is_a?(Url) && to_s == other.to_s
-    end
+    def eql?(other) = other.is_a?(Url) && to_s == other.to_s
 
     ##
     # Returns the hash code for this URL.
     #
     # @return [Integer] the hash code
-    def hash
-      to_s.hash
-    end
+    def hash = to_s.hash
 
     ##
     # Returns a string representation of the URL for debugging.
     #
     # @return [String] the debug representation
-    def inspect
-      "#<#{self.class}:#{object_id} @uri=#{@uri.inspect}>"
-    end
+    def inspect = "#<#{self.class}:#{object_id} @uri=#{@uri.inspect}>"
   end
 end

--- a/lib/html2rss/url.rb
+++ b/lib/html2rss/url.rb
@@ -108,7 +108,7 @@ module Html2rss
     def self.validate_channel_url(url)
       raise ArgumentError, 'URL must be absolute' unless url.absolute?
 
-      uri = url.instance_variable_get(:@uri)
+      uri = Addressable::URI.parse(url.to_s)
       has_forbidden_at = uri.user || uri.password
       has_forbidden_at ||= [uri.query, uri.fragment].compact.any? { |value| value.include?('@') }
       raise ArgumentError, 'URL must not contain an @ character' if has_forbidden_at

--- a/spec/lib/html2rss/url_spec.rb
+++ b/spec/lib/html2rss/url_spec.rb
@@ -191,7 +191,9 @@ RSpec.describe Html2rss::Url do
         'http://example.com' => 'http://example.com/',
         'https://www.example.com/path' => 'https://www.example.com/path',
         'http://subdomain.example.com:8080/path?query=value#fragment' => 'http://subdomain.example.com:8080/path?query=value#fragment',
-        'https://example.com/path with spaces' => 'https://example.com/path%20with%20spaces'
+        'https://example.com/path with spaces' => 'https://example.com/path%20with%20spaces',
+        'https://example.com/path@segment' => 'https://example.com/path@segment',
+        'https://truthsocial.com/@realDonaldTrump' => 'https://truthsocial.com/@realDonaldTrump'
       }.each_pair do |input_url, expected_url|
         it "accepts #{input_url.inspect} and returns normalized URL" do
           result = described_class.for_channel(input_url)
@@ -219,11 +221,11 @@ RSpec.describe Html2rss::Url do
       end
     end
 
-    context 'with URLs containing @ character' do
+    context 'with URLs containing @ character outside the path' do
       [
         'https://user@example.com',
-        'https://example.com/path@fragment',
-        'https://example.com?param=value@test'
+        'https://example.com?param=value@test',
+        'https://example.com/#frag@test'
       ].each do |url_with_at|
         it "raises ArgumentError for URL with @ character: #{url_with_at.inspect}" do
           expect { described_class.for_channel(url_with_at) }
@@ -245,9 +247,9 @@ RSpec.describe Html2rss::Url do
         end
       end
 
-      it 'raises ArgumentError for mailto URL (contains @ character)' do
+      it 'raises ArgumentError for mailto URL (unsupported scheme)' do
         expect { described_class.for_channel('mailto:test@example.com') }
-          .to raise_error(ArgumentError, 'URL must not contain an @ character')
+          .to raise_error(ArgumentError, "URL scheme 'mailto' is not supported")
       end
     end
 


### PR DESCRIPTION
## Summary
- allow `@` in `channel.url` path segments (e.g. `https://truthsocial.com/@realDonaldTrump`)
- keep rejecting `@` in userinfo, query, and fragment components
- preserve existing validation error message (`URL must not contain an @ character`)
- replace internal ivar access with explicit URI parsing in validator path

## Why
The previous validation rejected any URL containing `@`, which blocked valid profile URLs where `@` is part of the path.

## Tests
- updated `spec/lib/html2rss/url_spec.rb` to:
  - accept path `@` URLs (including Truth Social handle URL)
  - reject `@` in userinfo/query/fragment
  - keep unsupported scheme behavior explicit for `mailto:`
- ran full quality gate:
  - `make ready` (pass)

## Notes
- no public API signature changes
- behavior change is intentional and scoped to channel URL validation semantics
