### PR TITLE
fix: restore RubyGems release provenance

### DIFF
--- a/.github/workflows/release_gem.yml
+++ b/.github/workflows/release_gem.yml
@@ -92,14 +92,6 @@ jobs:
           bundler-cache: true
           ruby-version: ruby
 
-      - name: Configure RubyGems trusted publishing
-        if: steps.release.outputs.releases_created == 'true'
-        uses: rubygems/configure-rubygems-credentials@v2.0.0
-
-      - name: Build gem
-        if: steps.release.outputs.releases_created == 'true'
-        run: gem build html2rss.gemspec --output html2rss.gem
-
       - name: Publish gem
         if: steps.release.outputs.releases_created == 'true'
-        run: gem push html2rss.gem
+        uses: rubygems/release-gem@v1


### PR DESCRIPTION
## Summary
- publish gems through rubygems/release-gem@v1 again so RubyGems gets the trusted publishing provenance path
- keep the release PR lockfile refresh from the previous workflow change
- remove the manual configure/build/gem push sequence that published 0.19.0 without provenance

## Note
RubyGems provenance is attached at publish time, so the already-published 0.19.0 artifact cannot be retroactively given provenance. This fixes future releases.

## Verification
- ruby -ryaml -e 'YAML.load_file(%q[.github/workflows/release_gem.yml]); puts :ok'
- git diff --check -- .github/workflows/release_gem.yml