### PR TITLE
ci: resolve release PR branch without label race

### DIFF
--- a/.github/workflows/release_gem.yml
+++ b/.github/workflows/release_gem.yml
@@ -43,9 +43,8 @@ jobs:
           release_branch="$(gh pr list \
             --repo "$GITHUB_REPOSITORY" \
             --state open \
-            --label "autorelease: pending" \
-            --json headRefName \
-            --jq 'map(select(.headRefName | startswith("release-please--branches--"))) | .[0].headRefName // ""')"
+            --json baseRefName,headRefName \
+            --jq 'map(select(.baseRefName == "master" and (.headRefName | startswith("release-please--branches--")))) | .[0].headRefName // ""')"
 
           if [ -z "$release_branch" ]; then
             echo "No pending release-please PR branch found" >&2


### PR DESCRIPTION
## Summary
- stop resolving the release-please PR branch through the freshly-added autorelease label
- resolve by open release-please branch prefix and master base instead, avoiding the label search consistency race seen on PR #364

## Verification
- ruby -ryaml -e 'YAML.load_file(%q[.github/workflows/release_gem.yml]); puts :ok'
- git diff --check -- .github/workflows/release_gem.yml
- verified the new gh query resolves the open release-please branch for PR #364