### PR TITLE
feat: implement global configuration defaults and customizable logger

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run linting
         run: make lint
       - name: Run YARD lint
-        run: make yard-lint
+        run: make lint-yard
       - name: Generate config schema
         run: bundle exec rake config:schema
       - name: Ensure config schema is committed

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,14 @@ SHELL_SCRIPTS = \
 	bin/ready \
 	bin/setup
 
-.PHONY: help lint-changed test-fast test lint yard-lint shellcheck schema validate-fixtures docs quick ready clean
+.PHONY: help lint-changed test-fast test lint lint-yard shellcheck schema validate-fixtures docs quick ready clean
 
 help: ## Show available commands
 	@echo "Available commands:"
 	@echo "  make quick   - Run the fast local feedback loop"
 	@echo "  make test    - Run tests"
 	@echo "  make lint    - Run linting"
-	@echo "  make yard-lint - Run YARD linting on lib/"
+	@echo "  make lint-yard - Run YARD linting on lib/"
 	@echo "  make shellcheck - Run shellcheck on maintained shell scripts"
 	@echo "  make schema  - Regenerate and verify the config schema"
 	@echo "  make validate-fixtures - Validate fixture configs"

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,11 @@ test: ## Run tests
 
 lint: ## Run linting
 	bin/rubocop
+
+lint-reek:
 	$(RUBY_RUNNER)bundle exec reek
 
-yard-lint: ## Run YARD linting on lib/
+lint-yard: ## Run YARD linting on lib/
 	$(RUBY_RUNNER)bundle exec yard-lint lib/
 
 shellcheck: ## Run shellcheck on maintained shell scripts

--- a/bin/ready
+++ b/bin/ready
@@ -4,4 +4,4 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-make -j 6 lint yard-lint test schema validate-fixtures docs shellcheck
+make -j 6 lint lint-yard test schema validate-fixtures docs shellcheck

--- a/lib/html2rss.rb
+++ b/lib/html2rss.rb
@@ -7,18 +7,21 @@ loader.inflector.inflect('cli' => 'CLI')
 loader.setup
 
 require 'logger'
+require 'forwardable'
+require 'html2rss/configuration'
 
 ##
 # The Html2rss namespace.
 module Html2rss
   ##
   # The logger instance.
-  Log = Logger.new($stdout)
+  module Log
+    class << self
+      extend Forwardable
 
-  Log.level = ENV.fetch('LOG_LEVEL', :warn).upcase.to_sym
-
-  Log.formatter = proc do |severity, datetime, _progname, msg|
-    "#{datetime} [#{severity}] #{msg}\n"
+      def_delegator 'Html2rss', :logger
+      def_delegators :logger, :debug, :info, :warn, :error, :fatal, :unknown, :level, :level=, :formatter, :formatter=
+    end
   end
 
   ##
@@ -75,6 +78,50 @@ module Html2rss
     json_feed(build_auto_source_config(url:, strategy:, items_selector:, max_redirects:, max_requests:))
   end
 
+  # rubocop:disable ThreadSafety/ClassInstanceVariable
+  class << self
+    ##
+    # @return [Html2rss::Configuration] the global configuration instance
+    def configuration
+      @configuration ||= Configuration.new.freeze
+    end
+
+    ##
+    # Configures global library defaults.
+    #
+    # @yieldparam config [Html2rss::Configuration]
+    # @return [Html2rss::Configuration] the frozen configuration
+    def configure
+      config = configuration.dup
+      yield config
+      @configuration = config.freeze
+    end
+
+    ##
+    # @return [Object] the logger
+    def logger
+      configuration.logger
+    end
+
+    ##
+    # @param logger [Object] the new logger
+    def logger=(logger)
+      configure { |config| config.logger = logger }
+    end
+
+    private
+
+    ##
+    # Resets the global configuration to defaults (mainly for testing).
+    #
+    # @return [void]
+    def reset_configuration!
+      @configuration = nil
+      logger.level = configuration.log_level if logger.respond_to?(:level=)
+    end
+  end
+  # rubocop:enable ThreadSafety/ClassInstanceVariable
+
   class << self
     private
 
@@ -103,6 +150,8 @@ module Html2rss
       keys
     end
   end
+
+  logger.level = configuration.log_level if logger.respond_to?(:level=)
 end
 
 loader.eager_load

--- a/lib/html2rss/config/class_methods.rb
+++ b/lib/html2rss/config/class_methods.rb
@@ -138,13 +138,13 @@ module Html2rss
           },
           channel: { time_zone: 'UTC' },
           headers: RequestHeaders.browser_defaults,
-          stylesheets: []
+          stylesheets: Html2rss.configuration.stylesheets || []
         }
       end
 
       # @return [Symbol] the default strategy for feed orchestration
       def default_strategy_name
-        :auto
+        Html2rss.configuration.default_strategy || :auto
       end
 
       private

--- a/lib/html2rss/config/request_headers.rb
+++ b/lib/html2rss/config/request_headers.rb
@@ -40,9 +40,23 @@ module Html2rss
 
       class << self
         ##
-        # @return [Hash{String => String}] the unmodified default header set
+        # :reek:ManualDispatch
+        # :reek:TooManyStatements
+        #
+        # @return [Hash{String => String}] the default header set merged with global defaults
         def browser_defaults
-          DEFAULT_HEADERS.dup
+          defaults = DEFAULT_HEADERS.dup
+          global_headers = Html2rss.configuration.headers
+          global_headers = global_headers.call if global_headers.respond_to?(:call)
+
+          if global_headers.is_a?(Hash)
+            global_headers.each do |key, value|
+              canonical_key = key.to_s.split('-').map(&:capitalize).join('-')
+              defaults[canonical_key] = value.to_s
+            end
+          end
+
+          defaults
         end
 
         ##

--- a/lib/html2rss/configuration.rb
+++ b/lib/html2rss/configuration.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+module Html2rss
+  ##
+  # Global configuration defaults for the Html2rss gem.
+  #
+  class Configuration
+    # The valid symbol log levels.
+    VALID_LOG_LEVELS = %i[debug info warn error fatal unknown].freeze
+
+    # @return [Object] the logger
+    attr_reader :logger
+
+    # @return [Proc, nil] the logger formatter
+    attr_reader :logger_formatter
+
+    # @return [Symbol, Integer] the current log level
+    attr_reader :log_level
+
+    # @return [Hash, Proc, nil] the globally configured headers
+    attr_reader :headers
+
+    # @return [Symbol, nil] the default strategy name
+    attr_reader :default_strategy
+
+    # @return [Integer, nil] the minimum TTL in minutes
+    attr_reader :min_ttl
+
+    # @return [Array<Hash>] the globally configured stylesheets
+    attr_reader :stylesheets
+
+    ##
+    # Initializes a new Configuration instance with defaults.
+    def initialize
+      @logger_formatter = proc do |severity, datetime, _progname, msg|
+        "#{datetime} [#{severity}] #{msg}\n"
+      end
+      @logger = Logger.new($stdout)
+      @logger.formatter = @logger_formatter
+      self.log_level = ENV.fetch('LOG_LEVEL', :warn)
+      @headers = nil
+      @default_strategy = nil
+      @min_ttl = nil
+      @stylesheets = []
+    end
+
+    ##
+    # Sets the logger.
+    #
+    # @param logger [Object] the logger
+    # @return [Object] the logger
+    def logger=(logger)
+      @logger = logger
+      @logger.level = @log_level if @logger.respond_to?(:level=)
+      @logger.formatter = @logger_formatter if @logger_formatter && @logger.respond_to?(:formatter=)
+    end
+
+    ##
+    # Sets the log level.
+    #
+    # @param level [Symbol, String, Integer] the new log level
+    # @return [Integer] the normalized log level
+    # @raise [ArgumentError] if the log level is invalid
+    def log_level=(level)
+      @log_level = normalize_log_level(level)
+      @logger.level = @log_level if @logger.respond_to?(:level=)
+    end
+
+    ##
+    # Sets the logger formatter.
+    #
+    # @param formatter [Proc, #call, nil] the new logger formatter
+    # @return [Proc, #call, nil] the new logger formatter
+    # @raise [ArgumentError] if formatter does not respond to #call
+    def logger_formatter=(formatter)
+      raise ArgumentError, 'formatter must respond to #call or be nil' if formatter && !formatter.respond_to?(:call)
+
+      @logger_formatter = formatter
+      @logger.formatter = @logger_formatter if @logger.respond_to?(:formatter=)
+    end
+
+    ##
+    # Sets the global request headers.
+    #
+    # @param headers [Hash, Proc, #call, nil] the HTTP request headers to globally apply
+    # @return [Hash, Proc, #call, nil] the assigned headers
+    # @raise [ArgumentError] if headers is not a Hash or callable
+    def headers=(headers)
+      if headers && !headers.is_a?(Hash) && !headers.respond_to?(:call)
+        raise ArgumentError, 'headers must be a Hash or respond to #call'
+      end
+
+      @headers = headers
+    end
+
+    ##
+    # Sets the default strategy.
+    #
+    # @param strategy [Symbol, String, nil] the strategy name
+    # @return [Symbol, nil] the normalized strategy name
+    # @raise [ArgumentError] if the strategy is not registered
+    def default_strategy=(strategy)
+      if strategy.nil?
+        @default_strategy = nil
+      else
+        normalized = strategy.to_sym
+        raise ArgumentError, "unknown strategy: #{strategy}" unless RequestService.strategy_registered?(normalized)
+
+        @default_strategy = normalized
+      end
+    end
+
+    ##
+    # Sets the minimum TTL in minutes.
+    #
+    # @param ttl [Integer, String, nil] the minimum TTL
+    # @return [Integer, nil] the normalized minimum TTL
+    # @raise [ArgumentError] if ttl is not a positive integer
+    def min_ttl=(ttl)
+      if ttl.nil?
+        @min_ttl = nil
+      else
+        val = Integer(ttl)
+        raise ArgumentError unless val.positive?
+
+        @min_ttl = val
+      end
+    rescue ArgumentError, TypeError
+      raise ArgumentError, "min_ttl must be a positive integer, got #{ttl.inspect}"
+    end
+
+    ##
+    # Sets the global stylesheets.
+    #
+    # @param stylesheets [Array<Hash>] the XML stylesheet processing instructions to include in the generated feed
+    # @return [Array<Hash>] the assigned stylesheets
+    # @raise [ArgumentError] if stylesheets is not an Array of hashes
+    def stylesheets=(stylesheets)
+      raise ArgumentError, 'stylesheets must be an Array' unless stylesheets.is_a?(Array)
+      raise ArgumentError, 'stylesheets must be an Array of Hashes' unless stylesheets.all?(Hash)
+
+      @stylesheets = stylesheets
+    end
+
+    protected
+
+    ##
+    # Copy constructor for duplicating configuration.
+    #
+    # @param other [Html2rss::Configuration] the original configuration
+    # @return [void]
+    def initialize_copy(other)
+      super
+      @headers = @headers.dup if @headers.is_a?(Hash)
+      @stylesheets = @stylesheets.map(&:dup) if @stylesheets.is_a?(Array)
+    end
+
+    private
+
+    def normalize_log_level(level)
+      if level.is_a?(Integer)
+        raise ArgumentError, "invalid log level: #{level}" unless level.between?(0, 5)
+
+        level
+      else
+        sym = level.to_s.downcase.to_sym
+        raise ArgumentError, "invalid log level: #{level}" unless VALID_LOG_LEVELS.include?(sym)
+
+        Logger.const_get(sym.upcase)
+      end
+    end
+  end
+end

--- a/lib/html2rss/configuration.rb
+++ b/lib/html2rss/configuration.rb
@@ -41,7 +41,7 @@ module Html2rss
       @headers = nil
       @default_strategy = nil
       @min_ttl = nil
-      @stylesheets = []
+      @stylesheets = [].freeze
     end
 
     ##
@@ -90,7 +90,7 @@ module Html2rss
         raise ArgumentError, 'headers must be a Hash or respond to #call'
       end
 
-      @headers = headers
+      @headers = headers.is_a?(Hash) ? headers.dup.freeze : headers
     end
 
     ##
@@ -103,6 +103,10 @@ module Html2rss
       if strategy.nil?
         @default_strategy = nil
       else
+        unless strategy.is_a?(Symbol) || strategy.is_a?(String)
+          raise ArgumentError, 'strategy must be a Symbol or String'
+        end
+
         normalized = strategy.to_sym
         raise ArgumentError, "unknown strategy: #{strategy}" unless RequestService.strategy_registered?(normalized)
 
@@ -139,7 +143,7 @@ module Html2rss
       raise ArgumentError, 'stylesheets must be an Array' unless stylesheets.is_a?(Array)
       raise ArgumentError, 'stylesheets must be an Array of Hashes' unless stylesheets.all?(Hash)
 
-      @stylesheets = stylesheets
+      @stylesheets = stylesheets.map { |h| h.dup.freeze }.freeze
     end
 
     protected

--- a/lib/html2rss/rss_builder/channel.rb
+++ b/lib/html2rss/rss_builder/channel.rb
@@ -41,13 +41,16 @@ module Html2rss
 
       # @return [Integer] cache time-to-live in minutes
       def ttl
-        return overrides[:ttl] if overrides[:ttl]
+        calculated = if overrides[:ttl]
+                       overrides[:ttl].to_i
+                     elsif (max_age = headers['cache-control']&.match(/max-age=(\d+)/)&.[](1))
+                       max_age.to_i.fdiv(60).ceil
+                     else
+                       DEFAULT_TTL_IN_MINUTES
+                     end
 
-        if (ttl = headers['cache-control']&.match(/max-age=(\d+)/)&.[](1))
-          return ttl.to_i.fdiv(60).ceil
-        end
-
-        DEFAULT_TTL_IN_MINUTES
+        min_ttl = Html2rss.configuration.min_ttl
+        min_ttl ? [calculated, min_ttl].max : calculated
       end
 
       # @return [String, nil] ISO-like language code when available

--- a/spec/lib/html2rss/configuration_spec.rb
+++ b/spec/lib/html2rss/configuration_spec.rb
@@ -1,0 +1,347 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Html2rss::Configuration do
+  after { Html2rss.send(:reset_configuration!) }
+
+  describe 'defaults' do
+    subject(:config) { described_class.new }
+
+    it 'has default log_level from ENV or :warn' do
+      expected_level = Logger.const_get(ENV.fetch('LOG_LEVEL', :warn).to_s.upcase.to_sym)
+      expect(config.log_level).to eq(expected_level)
+    end
+
+    it 'has default headers as nil' do
+      expect(config.headers).to be_nil
+    end
+
+    it 'has default default_strategy as nil' do
+      expect(config.default_strategy).to be_nil
+    end
+
+    it 'has default min_ttl as nil' do
+      expect(config.min_ttl).to be_nil
+    end
+
+    it 'has default stylesheets as empty array' do
+      expect(config.stylesheets).to eq([])
+    end
+  end
+
+  describe '#log_level=' do
+    subject(:config) { described_class.new }
+
+    it 'accepts valid symbol log levels and updates logger.level', :aggregate_failures do
+      config.log_level = :info
+      expect(config.log_level).to eq(Logger::INFO)
+      expect(config.logger.level).to eq(Logger::INFO)
+    end
+
+    it 'accepts valid string log levels', :aggregate_failures do
+      config.log_level = 'debug'
+      expect(config.log_level).to eq(Logger::DEBUG)
+      expect(config.logger.level).to eq(Logger::DEBUG)
+    end
+
+    it 'accepts valid integer log levels', :aggregate_failures do
+      config.log_level = Logger::ERROR
+      expect(config.log_level).to eq(Logger::ERROR)
+      expect(config.logger.level).to eq(Logger::ERROR)
+    end
+
+    it 'raises ArgumentError for invalid log level' do
+      expect { config.log_level = :foo }.to raise_error(ArgumentError, /invalid log level/)
+    end
+
+    it 'raises ArgumentError for invalid integer log level' do
+      expect { config.log_level = 6 }.to raise_error(ArgumentError, /invalid log level/)
+    end
+  end
+
+  describe '#headers=' do
+    subject(:config) { described_class.new }
+
+    it 'accepts a Hash' do
+      config.headers = { 'user-agent' => 'custom' }
+      expect(config.headers).to eq({ 'user-agent' => 'custom' })
+    end
+
+    it 'accepts a Proc/callable' do
+      callable = -> { { 'user-agent' => 'dynamic' } }
+      config.headers = callable
+      expect(config.headers).to eq(callable)
+    end
+
+    it 'raises ArgumentError for invalid headers' do
+      expect { config.headers = 'not' }.to raise_error(
+        ArgumentError, /headers must be a Hash or respond to #call/
+      )
+    end
+  end
+
+  describe '#default_strategy=' do
+    subject(:config) { described_class.new }
+
+    it 'accepts a registered strategy' do
+      config.default_strategy = :faraday
+      expect(config.default_strategy).to eq(:faraday)
+    end
+
+    it 'accepts string and normalizes to symbol' do
+      config.default_strategy = 'faraday'
+      expect(config.default_strategy).to eq(:faraday)
+    end
+
+    it 'accepts nil' do
+      config.default_strategy = nil
+      expect(config.default_strategy).to be_nil
+    end
+
+    it 'raises ArgumentError for unregistered strategy' do
+      expect { config.default_strategy = :invalid_strategy }.to raise_error(ArgumentError, /unknown strategy/)
+    end
+  end
+
+  describe '#min_ttl=' do
+    subject(:config) { described_class.new }
+
+    it 'accepts positive integer' do
+      config.min_ttl = 60
+      expect(config.min_ttl).to eq(60)
+    end
+
+    it 'accepts numeric string' do
+      config.min_ttl = '120'
+      expect(config.min_ttl).to eq(120)
+    end
+
+    it 'accepts nil' do
+      config.min_ttl = nil
+      expect(config.min_ttl).to be_nil
+    end
+
+    it 'raises ArgumentError for zero or negative numbers', :aggregate_failures do
+      expect { config.min_ttl = 0 }.to raise_error(ArgumentError, /must be a positive integer/)
+      expect { config.min_ttl = -10 }.to raise_error(ArgumentError, /must be a positive integer/)
+    end
+
+    it 'raises ArgumentError for invalid types' do
+      expect { config.min_ttl = 'abc' }.to raise_error(ArgumentError, /must be a positive integer/)
+    end
+  end
+
+  describe '#stylesheets=' do
+    subject(:config) { described_class.new }
+
+    it 'accepts an Array of Hashes' do
+      stylesheets = [{ href: 'style.css', type: 'text/css' }]
+      config.stylesheets = stylesheets
+      expect(config.stylesheets).to eq(stylesheets)
+    end
+
+    it 'raises ArgumentError if not an Array' do
+      expect { config.stylesheets = { href: 'style.css' } }.to raise_error(ArgumentError, /must be an Array/)
+    end
+
+    it 'raises ArgumentError if any item in the Array is not a Hash' do
+      expect { config.stylesheets = ['style.css'] }.to raise_error(ArgumentError, /must be an Array of Hashes/)
+    end
+  end
+
+  describe 'Html2rss::Log delegation' do
+    let(:custom_logger) { instance_double(Logger) }
+
+    before do
+      allow(custom_logger).to receive_messages(respond_to?: true, 'level=' => nil, 'formatter=' => nil)
+      allow(custom_logger).to receive(:info).with('delegated message')
+      Html2rss.configure { |config| config.logger = custom_logger }
+    end
+
+    it 'delegates to the active configuration logger' do
+      Html2rss::Log.info('delegated message')
+      expect(custom_logger).to have_received(:info).with('delegated message')
+    end
+  end
+
+  describe 'custom duck-typed logger' do
+    let(:messages) { [] }
+    let(:duck_logger) do
+      Class.new do
+        attr_accessor :level, :formatter
+
+        def info(msg)
+          @messages ||= []
+          @messages << msg
+        end
+
+        def messages
+          @messages ||= []
+        end
+      end.new
+    end
+
+    it 'accepts any object and forwards log levels if supported', :aggregate_failures do
+      Html2rss.configure { |c| [c.logger = duck_logger, c.log_level = :info] }
+
+      expect(duck_logger.level).to eq(Logger::INFO)
+      Html2rss::Log.info('duck message')
+      expect(duck_logger.messages).to eq(['duck message'])
+    end
+
+    it 'accepts objects that do not respond to level= or formatter=' do
+      simple_logger = Class.new { def info(_msg); end }.new
+      expect { Html2rss.configure { |c| c.logger = simple_logger } }.not_to raise_error
+    end
+  end
+
+  describe 'logger_formatter Proc' do
+    let(:log_output) { StringIO.new }
+    let(:logger) { Logger.new(log_output) }
+    let(:custom_formatter) { proc { |severity, _datetime, _progname, msg| "#{severity} - #{msg}" } }
+
+    before do
+      Html2rss.configure do |config|
+        config.logger = logger
+        config.log_level = :info
+        config.logger_formatter = custom_formatter
+      end
+    end
+
+    it 'formats log messages using the configured Proc', :aggregate_failures do
+      Html2rss::Log.info('formatted log')
+      expect(log_output.string).to include('INFO - formatted log')
+    end
+  end
+
+  describe 'invalid logger_formatter' do
+    it 'raises ArgumentError if formatter does not respond to call' do
+      expect { Html2rss.configure { |c| c.logger_formatter = 'not callable' } }
+        .to raise_error(ArgumentError, /formatter must respond to #call/)
+    end
+  end
+
+  describe 'global configuration integration' do
+    context 'when configuring min_ttl and stylesheets' do
+      before do
+        Html2rss.configure do |config|
+          config.min_ttl = 45
+          config.stylesheets = [{ href: 'global.css' }]
+        end
+      end
+
+      it 'freezes the configuration', :aggregate_failures do
+        expect(Html2rss.configuration).to be_frozen
+        expect(Html2rss.configuration.min_ttl).to eq(45)
+        expect(Html2rss.configuration.stylesheets).to eq([{ href: 'global.css' }])
+      end
+    end
+
+    context 'when evaluating RCU behavior' do
+      let!(:initial_config) { Html2rss.configuration }
+
+      before do
+        Html2rss.configure do |config|
+          config.min_ttl = 15
+        end
+      end
+
+      it 'is thread-safe and implements RCU duplicate/freeze', :aggregate_failures do
+        expect(initial_config).to be_frozen
+        expect(Html2rss.configuration).to be_frozen
+        expect(Html2rss.configuration).not_to eq(initial_config)
+      end
+    end
+
+    it 'raises FrozenError when trying to modify configuration directly' do
+      expect { Html2rss.configuration.min_ttl = 15 }.to raise_error(FrozenError)
+    end
+
+    context 'with global static headers' do
+      before do
+        Html2rss.configure do |config|
+          config.headers = {
+            'user-agent' => 'GlobalUA',
+            'X-Custom-Header' => 'CustomValue'
+          }
+        end
+      end
+
+      it 'merges global static headers and normalizes keys', :aggregate_failures do
+        defaults = Html2rss::Config::RequestHeaders.browser_defaults
+        expect(defaults['User-Agent']).to eq('GlobalUA')
+        expect(defaults['X-Custom-Header']).to eq('CustomValue')
+      end
+    end
+
+    context 'with dynamic headers' do
+      let(:counter) { { count: 0 } }
+
+      before do
+        cnt = counter
+        Html2rss.configure do |config|
+          config.headers = -> { { 'x-count' => (cnt[:count] += 1).to_s } }
+        end
+      end
+
+      it 'evaluates dynamic headers and increments count', :aggregate_failures do
+        expect(Html2rss::Config::RequestHeaders.browser_defaults['X-Count']).to eq('1')
+        expect(Html2rss::Config::RequestHeaders.browser_defaults['X-Count']).to eq('2')
+      end
+    end
+
+    describe 'integration with ClassMethods' do
+      before do
+        Html2rss.configure do |config|
+          config.default_strategy = :faraday
+        end
+      end
+
+      it 'uses global default strategy when strategy in config is default_strategy_name', :aggregate_failures do
+        expect(Html2rss::Config.default_strategy_name).to eq(:faraday)
+        expect(Html2rss::Config.default_config[:strategy]).to eq(:faraday)
+      end
+
+      it 'uses global stylesheets in default_config' do
+        global_stylesheets = [{ href: 'global.css', type: 'text/css' }]
+        Html2rss.configure { |config| config.stylesheets = global_stylesheets }
+
+        expect(Html2rss::Config.default_config[:stylesheets]).to eq(global_stylesheets)
+      end
+    end
+
+    describe 'integration with RssBuilder::Channel#ttl' do
+      let(:response) do
+        instance_double(
+          Html2rss::RequestService::Response,
+          url: 'http://example.com',
+          headers: { 'cache-control' => 'max-age=1800' }, # 30 minutes
+          html_response?: false,
+          parsed_body: nil
+        )
+      end
+
+      it 'enforces min_ttl as a strict lower bound' do
+        Html2rss.configure { |config| config.min_ttl = 60 }
+
+        channel = Html2rss::RssBuilder::Channel.new(response)
+        expect(channel.ttl).to eq(60) # 30 mins clamped to min_ttl (60)
+      end
+
+      it 'does not clamp if computed ttl is larger than min_ttl' do
+        Html2rss.configure { |config| config.min_ttl = 15 }
+
+        channel = Html2rss::RssBuilder::Channel.new(response)
+        expect(channel.ttl).to eq(30) # 30 mins is > 15, so unchanged
+      end
+
+      it 'clamps config overrides for ttl as well' do
+        Html2rss.configure { |config| config.min_ttl = 60 }
+
+        channel = Html2rss::RssBuilder::Channel.new(response, overrides: { ttl: 20 })
+        expect(channel.ttl).to eq(60) # override 20 clamped to min_ttl (60)
+      end
+    end
+  end
+end

--- a/spec/lib/html2rss/configuration_spec.rb
+++ b/spec/lib/html2rss/configuration_spec.rb
@@ -79,6 +79,14 @@ RSpec.describe Html2rss::Configuration do
         ArgumentError, /headers must be a Hash or respond to #call/
       )
     end
+
+    it 'dups and freezes the assigned Hash', :aggregate_failures do
+      headers_hash = { 'user-agent' => 'custom' }
+      config.headers = headers_hash
+      expect(config.headers).to be_frozen
+      headers_hash['user-agent'] = 'mutated'
+      expect(config.headers['user-agent']).to eq('custom')
+    end
   end
 
   describe '#default_strategy=' do
@@ -101,6 +109,13 @@ RSpec.describe Html2rss::Configuration do
 
     it 'raises ArgumentError for unregistered strategy' do
       expect { config.default_strategy = :invalid_strategy }.to raise_error(ArgumentError, /unknown strategy/)
+    end
+
+    it 'raises ArgumentError for invalid types', :aggregate_failures do
+      expect { config.default_strategy = 123 }
+        .to raise_error(ArgumentError, /strategy must be a Symbol or String/)
+      expect { config.default_strategy = { strategy: :faraday } }
+        .to raise_error(ArgumentError, /strategy must be a Symbol or String/)
     end
   end
 
@@ -147,6 +162,14 @@ RSpec.describe Html2rss::Configuration do
 
     it 'raises ArgumentError if any item in the Array is not a Hash' do
       expect { config.stylesheets = ['style.css'] }.to raise_error(ArgumentError, /must be an Array of Hashes/)
+    end
+
+    it 'copies and freezes the array and its hashes', :aggregate_failures do
+      sheet = { href: 'style.css', type: 'text/css' }
+      config.stylesheets = [sheet]
+      expect(config.stylesheets).to be_frozen.and(all(be_frozen))
+      sheet[:href] = 'mutated'
+      expect(config.stylesheets.first[:href]).to eq('style.css')
     end
   end
 


### PR DESCRIPTION
This pull request introduces a global configuration system for the `Html2rss` gem, enabling users to set library-wide defaults such as logger, log level, HTTP headers, default strategy, minimum TTL, and stylesheets. It refactors logger handling, enhances configuration flexibility, and updates the Makefile for consistency in linting commands.

**Global configuration and logger refactor:**

* Introduced a new `Html2rss::Configuration` class to encapsulate global settings, including logger, log level, headers, default strategy, minimum TTL, and stylesheets. Added methods to configure and reset these settings globally. (`lib/html2rss/configuration.rb`, `lib/html2rss.rb`) [[1]](diffhunk://#diff-b85486b80e02025efffbff21df811097f5885945c81affaf50f236cb96198ca5R1-R177) [[2]](diffhunk://#diff-a68158a97e9182c3004a10cfbb397e4d090470ffda51b962769351f5ad6f3eb9R10-R24) [[3]](diffhunk://#diff-a68158a97e9182c3004a10cfbb397e4d090470ffda51b962769351f5ad6f3eb9R81-R124) [[4]](diffhunk://#diff-a68158a97e9182c3004a10cfbb397e4d090470ffda51b962769351f5ad6f3eb9R153-R154)
* Refactored logger usage: `Html2rss::Log` is now a delegator module, forwarding logging methods to the global configuration's logger. (`lib/html2rss.rb`)

**Configuration-driven defaults:**

* Updated `lib/html2rss/config/class_methods.rb` to use global configuration for default stylesheets and strategy, allowing these to be set at the library level.
* Enhanced `RequestHeaders.browser_defaults` to merge in globally configured headers, supporting both static hashes and callables for dynamic headers. (`lib/html2rss/config/request_headers.rb`)
* Modified RSS channel TTL calculation to respect a globally configured minimum TTL, ensuring per-feed TTLs cannot be set below this value. (`lib/html2rss/rss_builder/channel.rb`)

**Makefile and CI improvements:**

* Renamed the YARD linting Makefile target from `yard-lint` to `lint-yard` for consistency, and updated the GitHub Actions workflow and help output accordingly. (`Makefile`, `.github/workflows/lint_and_test.yml`) [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L12-R19) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R41-R45) [[3]](diffhunk://#diff-98be497b2ce68fa11a9c2cf5e55971898e8ea1f46655b95eca6d43f7bb99b03aL40-R40)

These changes provide a more flexible and robust foundation for library-wide defaults and logging, and improve maintainability and usability of the configuration system.

Closes #210