### PR TITLE
feat: default to html2rss/VERSION user-agent

### DIFF
--- a/lib/html2rss/config/request_headers.rb
+++ b/lib/html2rss/config/request_headers.rb
@@ -17,13 +17,8 @@ module Html2rss
         */*;q=0.8
       ].join(',')
 
-      # Browser-like default `User-Agent` header value.
-      DEFAULT_USER_AGENT = [
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
-        'AppleWebKit/537.36 (KHTML, like Gecko)',
-        'Chrome/123.0.0.0',
-        'Safari/537.36'
-      ].join(' ')
+      # Default `User-Agent` header value.
+      DEFAULT_USER_AGENT = "html2rss/#{Html2rss::VERSION}".freeze
 
       # Baseline browser-like header set used for outbound requests.
       DEFAULT_HEADERS = {

--- a/spec/lib/html2rss/config/request_headers_spec.rb
+++ b/spec/lib/html2rss/config/request_headers_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe Html2rss::Config::RequestHeaders do
       expect { described_class.browser_defaults['User-Agent'] = 'Custom' }
         .not_to(change { described_class.browser_defaults['User-Agent'] })
     end
+
+    it 'sets the default User-Agent to the gem version' do
+      expect(described_class.browser_defaults['User-Agent']).to eq("html2rss/#{Html2rss::VERSION}")
+    end
   end
 
   describe '#to_h' do
@@ -31,7 +35,7 @@ RSpec.describe Html2rss::Config::RequestHeaders do
 
     context 'when overrides are provided' do
       let(:headers) do
-        { 'accept' => 'application/json', 'x-test-header' => 'abc' }
+        { 'accept' => 'application/json', 'x-test-header' => 'abc', 'user-agent' => 'MyCustomAgent/1.0' }
       end
 
       it 'capitalizes custom header keys' do
@@ -42,6 +46,10 @@ RSpec.describe Html2rss::Config::RequestHeaders do
         expected = "application/json,#{described_class::DEFAULT_ACCEPT}"
 
         expect(normalized).to include('Accept' => expected)
+      end
+
+      it 'uses the provided User-Agent, overriding the default' do
+        expect(normalized).to include('User-Agent' => 'MyCustomAgent/1.0')
       end
     end
 


### PR DESCRIPTION
Fixes #207 by setting the appropriate User-Agent header when requesting sites by default. The header remains configurable via `Html2rss.configure` or feed-level headers configuration.

```yml
headers:
  User-Agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"
```