### PR TITLE
refactor: fix encapsulation bypass in LinkHeuristics

### DIFF
--- a/lib/html2rss/auto_source/scraper/link_heuristics.rb
+++ b/lib/html2rss/auto_source/scraper/link_heuristics.rb
@@ -263,13 +263,6 @@ module Html2rss
             PostSuffixClassifier.new(segments).strong?
           end
 
-          private
-
-          def yearish_content_context?
-            segments.any? { |segment| segment.match?(YEARISH_SEGMENT) } &&
-              (strong_post_suffix? || LeadingSegments.new(segments).trusted_post_context?)
-          end
-
           def utility_only_route?
             junk_segments = SEGMENT_SETS.fetch(:high_confidence_junk)
 
@@ -287,6 +280,13 @@ module Html2rss
 
           def deep_utility_context_route?
             LeadingSegments.new(segments).all_junk?
+          end
+
+          private
+
+          def yearish_content_context?
+            segments.any? { |segment| segment.match?(YEARISH_SEGMENT) } &&
+              (strong_post_suffix? || LeadingSegments.new(segments).trusted_post_context?)
           end
         end
         # rubocop:enable Metrics/ClassLength
@@ -312,9 +312,9 @@ module Html2rss
             return false if excluded_content_route?
 
             @path.taxonomy_path? ||
-              @path.send(:utility_only_route?) ||
-              @path.send(:deep_utility_context_route?) ||
-              @path.send(:shallow_high_confidence_route?)
+              @path.utility_only_route? ||
+              @path.deep_utility_context_route? ||
+              @path.shallow_high_confidence_route?
           end
 
           def utility_destination?
@@ -329,8 +329,8 @@ module Html2rss
 
           def utility_route?
             @path.taxonomy_path? ||
-              @path.send(:utility_only_route?) ||
-              @path.send(:deep_utility_context_route?) ||
+              @path.utility_only_route? ||
+              @path.deep_utility_context_route? ||
               shallow_utility_route?
           end
 

--- a/lib/html2rss/auto_source/scraper/link_heuristics.rb
+++ b/lib/html2rss/auto_source/scraper/link_heuristics.rb
@@ -263,12 +263,14 @@ module Html2rss
             PostSuffixClassifier.new(segments).strong?
           end
 
+          # @return [Boolean] true when every path segment is utility chrome
           def utility_only_route?
             junk_segments = SEGMENT_SETS.fetch(:high_confidence_junk)
 
             segments.all? { |segment| junk_segments.include?(segment) }
           end
 
+          # @return [Boolean] true when the route is shallow and contains high-confidence noise
           def shallow_high_confidence_route?
             junk_segments = SEGMENT_SETS.fetch(:high_confidence_junk)
             vanity_segments = SEGMENT_SETS.fetch(:vanity)
@@ -278,6 +280,7 @@ module Html2rss
             end
           end
 
+          # @return [Boolean] true when the leading segments are all utility chrome
           def deep_utility_context_route?
             LeadingSegments.new(segments).all_junk?
           end

--- a/lib/html2rss/configuration.rb
+++ b/lib/html2rss/configuration.rb
@@ -3,7 +3,6 @@
 module Html2rss
   ##
   # Global configuration defaults for the Html2rss gem.
-  #
   class Configuration
     # The valid symbol log levels.
     VALID_LOG_LEVELS = %i[debug info warn error fatal unknown].freeze
@@ -47,7 +46,7 @@ module Html2rss
     ##
     # Sets the logger.
     #
-    # @param logger [Object] the logger
+    # @param logger [Object]
     # @return [Object] the logger
     def logger=(logger)
       @logger = logger


### PR DESCRIPTION
## Summary
- Fixed encapsulation bypass in `lib/html2rss/auto_source/scraper/link_heuristics.rb`.
- Moved internal classification methods (`utility_only_route?`, `shallow_high_confidence_route?`, `deep_utility_context_route?`) from private to public in `PathClassifier`.
- Updated `ConfidenceClassifier` to call these methods directly instead of using `.send`.

## Test Plan
- [x] Verified with existing RSpec tests: `bundle exec rspec spec/lib/html2rss/auto_source/scraper/link_heuristics_spec.rb`.