### PR TITLE
feat: make total_timeout_seconds configurable

### DIFF
--- a/lib/html2rss/config.rb
+++ b/lib/html2rss/config.rb
@@ -31,7 +31,8 @@ module Html2rss
       @request_controls = request_controls.with_effective_values(
         strategy: validated_config[:strategy],
         max_redirects: validated_config.dig(:request, :max_redirects),
-        max_requests: validated_config.dig(:request, :max_requests)
+        max_requests: validated_config.dig(:request, :max_requests),
+        total_timeout_seconds: validated_config.dig(:request, :total_timeout_seconds)
       )
     end
 
@@ -41,6 +42,8 @@ module Html2rss
     def max_redirects = request_controls.max_redirects
     # @return [Integer, nil] configured request budget
     def max_requests = request_controls.max_requests
+    # @return [Integer, nil] configured request timeout
+    def total_timeout_seconds = request_controls.total_timeout_seconds
     # @return [Array<Hash>] stylesheet definitions
     def stylesheets = config[:stylesheets]
 

--- a/lib/html2rss/config/class_methods.rb
+++ b/lib/html2rss/config/class_methods.rb
@@ -132,11 +132,7 @@ module Html2rss
       def default_config
         {
           strategy: default_strategy_name,
-          request: {
-            max_redirects: RequestService::Policy::DEFAULTS[:max_redirects],
-            max_requests: RequestService::Policy::DEFAULTS[:max_requests],
-            total_timeout_seconds: RequestService::Policy::DEFAULTS[:total_timeout_seconds]
-          },
+          request: default_request_config,
           channel: { time_zone: 'UTC' },
           headers: RequestHeaders.browser_defaults,
           stylesheets: Html2rss.configuration.stylesheets || []
@@ -149,6 +145,14 @@ module Html2rss
       end
 
       private
+
+      def default_request_config
+        {
+          max_redirects: RequestService::Policy::DEFAULTS[:max_redirects],
+          max_requests: RequestService::Policy::DEFAULTS[:max_requests],
+          total_timeout_seconds: RequestService::Policy::DEFAULTS[:total_timeout_seconds]
+        }
+      end
 
       def resolve_effective_config(config, params:)
         effective_config = HashUtil.deep_symbolize_keys(config, context: 'config')

--- a/lib/html2rss/config/class_methods.rb
+++ b/lib/html2rss/config/class_methods.rb
@@ -134,7 +134,8 @@ module Html2rss
           strategy: default_strategy_name,
           request: {
             max_redirects: RequestService::Policy::DEFAULTS[:max_redirects],
-            max_requests: RequestService::Policy::DEFAULTS[:max_requests]
+            max_requests: RequestService::Policy::DEFAULTS[:max_requests],
+            total_timeout_seconds: RequestService::Policy::DEFAULTS[:total_timeout_seconds]
           },
           channel: { time_zone: 'UTC' },
           headers: RequestHeaders.browser_defaults,

--- a/lib/html2rss/config/validator.rb
+++ b/lib/html2rss/config/validator.rb
@@ -80,6 +80,7 @@ module Html2rss
       RequestConfig = Dry::Schema.Params do
         optional(:max_redirects).filled(:integer, gteq?: 0)
         optional(:max_requests).filled(:integer, gt?: 0)
+        optional(:total_timeout_seconds).filled(:integer, gt?: 0)
         optional(:browserless).hash(BrowserlessRequestConfig)
         optional(:botasaurus).hash(BotasaurusRequestConfig)
       end

--- a/lib/html2rss/request_controls.rb
+++ b/lib/html2rss/request_controls.rb
@@ -7,7 +7,7 @@ module Html2rss
     # Request-control keys accepted at the top level of feed config.
     TOP_LEVEL_KEYS = %i[strategy].freeze
     # Request-control keys accepted under the nested `request` config.
-    REQUEST_KEYS = %i[max_redirects max_requests].freeze
+    REQUEST_KEYS = %i[max_redirects max_requests total_timeout_seconds].freeze
 
     ##
     # @param config [Hash{Symbol => Object}] raw config input
@@ -20,6 +20,7 @@ module Html2rss
         strategy: config[:strategy],
         max_redirects: request_value_for(config, :max_redirects),
         max_requests: request_value_for(config, :max_requests),
+        total_timeout_seconds: request_value_for(config, :total_timeout_seconds),
         explicit_keys: explicit_keys_for(config)
       )
     end
@@ -47,11 +48,13 @@ module Html2rss
     # @param strategy [Symbol, nil] effective request strategy
     # @param max_redirects [Integer, nil] effective redirect limit
     # @param max_requests [Integer, nil] effective request budget
+    # @param total_timeout_seconds [Integer, nil] effective request timeout
     # @param explicit_keys [Array<Symbol>] controls explicitly supplied by the caller
-    def initialize(strategy: nil, max_redirects: nil, max_requests: nil, explicit_keys: [])
+    def initialize(strategy: nil, max_redirects: nil, max_requests: nil, total_timeout_seconds: nil, explicit_keys: [])
       @strategy = strategy
       @max_redirects = max_redirects
       @max_requests = max_requests
+      @total_timeout_seconds = total_timeout_seconds
       @explicit_keys = explicit_keys.map(&:to_sym).uniq.freeze
       freeze
     end
@@ -69,6 +72,10 @@ module Html2rss
     attr_reader :max_requests
 
     ##
+    # @return [Integer, nil] effective request timeout
+    attr_reader :total_timeout_seconds
+
+    ##
     # @param name [Symbol, String] request control name
     # @return [Boolean] whether the control was explicitly supplied
     def explicit?(name)
@@ -79,12 +86,14 @@ module Html2rss
     # @param strategy [Symbol, nil] validated request strategy
     # @param max_redirects [Integer, nil] validated redirect limit
     # @param max_requests [Integer, nil] validated request budget
+    # @param total_timeout_seconds [Integer, nil] validated request timeout
     # @return [RequestControls] controls updated with validated effective values
-    def with_effective_values(strategy:, max_redirects:, max_requests:)
+    def with_effective_values(strategy:, max_redirects:, max_requests:, total_timeout_seconds:)
       self.class.new(
         strategy:,
         max_redirects:,
         max_requests:,
+        total_timeout_seconds:,
         explicit_keys:
       )
     end
@@ -98,6 +107,7 @@ module Html2rss
       config[:strategy] = strategy if explicit?(:strategy)
       apply_request_value(config, :max_redirects, max_redirects)
       apply_request_value(config, :max_requests, max_requests)
+      apply_request_value(config, :total_timeout_seconds, total_timeout_seconds)
       config
     end
 

--- a/lib/html2rss/request_service/policy.rb
+++ b/lib/html2rss/request_service/policy.rb
@@ -30,9 +30,9 @@ module Html2rss
 
       # Default policy values used when request controls are not explicitly set.
       DEFAULTS = {
-        connect_timeout_seconds: 5,
-        read_timeout_seconds: 10,
-        total_timeout_seconds: 30,
+        connect_timeout_seconds: Integer(ENV.fetch('HTML2RSS_CONNECT_TIMEOUT_SECONDS', 5)),
+        read_timeout_seconds: Integer(ENV.fetch('HTML2RSS_READ_TIMEOUT_SECONDS', 10)),
+        total_timeout_seconds: Integer(ENV.fetch('HTML2RSS_TOTAL_TIMEOUT_SECONDS', 30)),
         max_redirects: 3,
         max_response_bytes: 5_242_880,
         max_decompressed_bytes: 10_485_760,

--- a/lib/html2rss/request_session/runtime_policy.rb
+++ b/lib/html2rss/request_session/runtime_policy.rb
@@ -11,7 +11,8 @@ module Html2rss
       def self.from_config(config)
         RequestService::Policy.new(
           max_requests: effective_max_requests_for(config),
-          max_redirects: config.max_redirects
+          max_redirects: config.max_redirects,
+          total_timeout_seconds: config.total_timeout_seconds || RequestService::Policy::DEFAULTS[:total_timeout_seconds]
         )
       end
 

--- a/schema/html2rss-config.schema.json
+++ b/schema/html2rss-config.schema.json
@@ -379,6 +379,13 @@
           },
           "exclusiveMinimum": 0
         },
+        "total_timeout_seconds": {
+          "type": "integer",
+          "not": {
+            "type": "null"
+          },
+          "exclusiveMinimum": 0
+        },
         "browserless": {
           "type": "object",
           "properties": {

--- a/spec/lib/html2rss/request_session/runtime_policy_spec.rb
+++ b/spec/lib/html2rss/request_session/runtime_policy_spec.rb
@@ -102,6 +102,14 @@ RSpec.describe Html2rss::RequestSession::RuntimePolicy do
       end
     end
 
+    context 'when total_timeout_seconds is configured' do
+      let(:config) { Html2rss::Config.from_hash(raw_config.merge(request: raw_config[:request].merge(total_timeout_seconds: 42))) }
+
+      it 'passes the timeout to the policy' do
+        expect(runtime_policy.total_timeout_seconds).to eq(42)
+      end
+    end
+
     context 'when preload only scrolls without waits' do
       let(:config) do
         Html2rss::Config.from_hash(


### PR DESCRIPTION
Unlocks timeout configuration via environment variables and feed config.

Main PR: https://github.com/html2rss/html2rss-web/pull/1009