### PR TITLE
feat: bump minimum required ruby to 3.3 and modernize

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["3.2", "3.3", "3.4", "4.0"]
+        ruby-version: ["3.3", "3.4", "4.0"]
     name: Ruby ${{ matrix.ruby-version }}
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,8 @@ plugins:
 AllCops:
   DisplayCopNames: true
   NewCops: enable
+  TargetRubyVersion: 3.3
+  ParserEngine: parser_prism
   Exclude:
     - vendor/**/*
 

--- a/html2rss.gemspec
+++ b/html2rss.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Supports JSON content, custom HTTP headers, and post-processing of extracted content.'
   spec.homepage      = 'https://github.com/html2rss/html2rss'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>= 3.2'
+  spec.required_ruby_version = '>= 3.3'
 
   if spec.respond_to?(:metadata)
     spec.metadata['allowed_push_host'] = 'https://rubygems.org'

--- a/lib/html2rss/auto_source/scraper/json_state.rb
+++ b/lib/html2rss/auto_source/scraper/json_state.rb
@@ -184,8 +184,9 @@ module Html2rss
           # @param jsonish [String] JSON-like string with potentially unquoted keys
           # @return [String] payload with unquoted object keys quoted
           def quote_unquoted_keys(jsonish)
-            jsonish.gsub(/(\A\s*|[{,\[]\s*)([A-Za-z_]\w*)(\s*:)/) do
-              "#{Regexp.last_match(1)}\"#{Regexp.last_match(2)}\"#{Regexp.last_match(3)}"
+            jsonish.gsub(/(?<prefix>\A\s*|[{,\[]\s*)(?<key>[A-Za-z_]\w*)(?<suffix>\s*:)/) do
+              captures = Regexp.last_match.named_captures(symbolize_names: true)
+              "#{captures[:prefix]}\"#{captures[:key]}\"#{captures[:suffix]}"
             end
           end
 

--- a/lib/html2rss/selectors/post_processors/substring.rb
+++ b/lib/html2rss/selectors/post_processors/substring.rb
@@ -48,6 +48,9 @@ module Html2rss
         #
         # @return [String] The extracted substring.
         def get
+          normalized_range = build_normalized_range
+          return nil unless normalized_range&.overlap?(0...value.length)
+
           value[range]
         end
 
@@ -67,6 +70,21 @@ module Html2rss
         end
 
         private
+
+        def build_normalized_range
+          len = value.length
+          start_normalized = start_index.negative? ? len + start_index : start_index
+          return nil if start_normalized.negative?
+
+          if end_index?
+            end_normalized = end_index.negative? ? len + end_index : end_index
+            return nil if start_normalized > end_normalized
+
+            (start_normalized..end_normalized)
+          else
+            (start_normalized..)
+          end
+        end
 
         def end_index?  = !context[:options][:end].to_s.empty?
         def end_index   = context[:options][:end].to_i

--- a/lib/html2rss/selectors/post_processors/substring.rb
+++ b/lib/html2rss/selectors/post_processors/substring.rb
@@ -34,23 +34,18 @@ module Html2rss
         # @param context [Selectors::Context] post-processor context
         # @return [void]
         def self.validate_args!(value, context)
-          assert_type value, String, :value, context:
+          assert_type(value, String, :value, context:)
 
           options = context[:options]
-          assert_type options[:start], Integer, :start, context:
-
-          end_index = options[:end]
-          assert_type(end_index, Integer, :end, context:) if end_index
+          assert_type(options[:start], Integer, :start, context:)
+          assert_type(options[:end], Integer, :end, context:) if options.key?(:end)
         end
 
         ##
         # Extracts the substring from the original string based on the provided start and end indices.
         #
-        # @return [String] The extracted substring.
+        # @return [String, nil] The extracted substring.
         def get
-          normalized_range = build_normalized_range
-          return nil unless normalized_range&.overlap?(0...value.length)
-
           value[range]
         end
 
@@ -59,36 +54,16 @@ module Html2rss
         #
         # @return [Range] The range object representing the start and end/Infinity (integers).
         def range
-          return (start_index..) unless end_index?
+          options = context[:options]
+          start = options[:start]
 
-          if start_index == end_index
-            raise ArgumentError,
-                  'The `start` value must be unequal to the `end` value.'
-          end
+          return (start..) unless options.key?(:end)
 
-          (start_index..end_index)
+          finish = options[:end]
+          raise ArgumentError, 'The `start` value must be unequal to the `end` value.' if start == finish
+
+          (start..finish)
         end
-
-        private
-
-        def build_normalized_range
-          len = value.length
-          start_normalized = start_index.negative? ? len + start_index : start_index
-          return nil if start_normalized.negative?
-
-          if end_index?
-            end_normalized = end_index.negative? ? len + end_index : end_index
-            return nil if start_normalized > end_normalized
-
-            (start_normalized..end_normalized)
-          else
-            (start_normalized..)
-          end
-        end
-
-        def end_index?  = !context[:options][:end].to_s.empty?
-        def end_index   = context[:options][:end].to_i
-        def start_index = context[:options][:start].to_i
       end
     end
   end

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -15,4 +15,4 @@ RSpec::Core::RakeTask.new(:spec) do |t|
   t.ruby_opts = %w[-w]
 end
 
-Dir.glob('lib/tasks/**/*.rake').each { |file| import file }
+Dir.glob('**/*.rake', base: 'lib/tasks').each { |file| import File.join('lib/tasks', file) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,8 @@
 
 require 'vcr'
 
+Warning[:performance] = true if defined?(Warning) && Warning.respond_to?(:[])
+
 if ENV['COVERAGE']
   require 'simplecov'
 
@@ -36,7 +38,9 @@ require_relative 'support/helpers/configuration_helpers'
 require_relative 'support/helpers/example_helpers'
 
 # Load shared examples
-Dir[File.join(__dir__, 'support', 'shared_examples', '**', '*.rb')].each { |f| require f }
+Dir.glob('**/*.rb', base: File.join(__dir__, 'support/shared_examples')).each do |f|
+  require File.join(__dir__, 'support/shared_examples', f)
+end
 
 Zeitwerk::Loader.eager_load_all # flush all potential loading issues
 


### PR DESCRIPTION
Bumps required Ruby version in gemspec to >= 3.3 and removes Ruby 3.2 from GitHub Actions. Configures RuboCop with the Prism parser. Modernizes Dir.glob, Substring, and JsonState using Ruby 3.3 features.