### PR TITLE
feat(cli): add --input option support for feed and auto commands

### DIFF
--- a/lib/html2rss.rb
+++ b/lib/html2rss.rb
@@ -52,6 +52,8 @@ module Html2rss
     FeedPipeline.new(raw_config).to_json_feed
   end
 
+  # rubocop:disable Metrics/ParameterLists
+
   ##
   # Scrapes the provided URL and returns an RSS object.
   #
@@ -60,9 +62,15 @@ module Html2rss
   # @param items_selector [String, nil] optional selector hint for item extraction
   # @param max_redirects [Integer, nil] optional redirect limit override
   # @param max_requests [Integer, nil] optional request budget override
+  # @param local_file_path [String, nil] optional local HTML file path
   # @return [RSS::Rss] generated RSS feed
-  def self.auto_source(url, strategy: :auto, items_selector: nil, max_redirects: nil, max_requests: nil)
-    feed(build_auto_source_config(url:, strategy:, items_selector:, max_redirects:, max_requests:))
+  def self.auto_source(url,
+                       strategy: :auto,
+                       items_selector: nil,
+                       max_redirects: nil,
+                       max_requests: nil,
+                       local_file_path: nil)
+    feed(build_auto_source_config(url:, strategy:, items_selector:, max_redirects:, max_requests:, local_file_path:))
   end
 
   ##
@@ -73,10 +81,19 @@ module Html2rss
   # @param items_selector [String, nil] optional selector hint for item extraction
   # @param max_redirects [Integer, nil] optional redirect limit override
   # @param max_requests [Integer, nil] optional request budget override
+  # @param local_file_path [String, nil] optional local HTML file path
   # @return [Hash] JSONFeed-compliant hash
-  def self.auto_json_feed(url, strategy: :auto, items_selector: nil, max_redirects: nil, max_requests: nil)
-    json_feed(build_auto_source_config(url:, strategy:, items_selector:, max_redirects:, max_requests:))
+  def self.auto_json_feed(url,
+                          strategy: :auto,
+                          items_selector: nil,
+                          max_redirects: nil,
+                          max_requests: nil,
+                          local_file_path: nil)
+    json_feed(build_auto_source_config(url:, strategy:, items_selector:, max_redirects:, max_requests:,
+                                       local_file_path:))
   end
+
+  # rubocop:enable Metrics/ParameterLists
 
   # rubocop:disable ThreadSafety/ClassInstanceVariable
   class << self
@@ -125,12 +142,17 @@ module Html2rss
   class << self
     private
 
-    def build_auto_source_config(url:, strategy:, items_selector:, max_redirects:, max_requests:)
-      Config.auto_source_config(
+    def build_auto_source_config(url:, strategy:, items_selector:, max_redirects:, max_requests:, local_file_path: nil) # rubocop:disable Metrics/ParameterLists
+      config = Config.auto_source_config(
         url:,
         items_selector:,
         request_controls: shortcut_request_controls(strategy:, max_redirects:, max_requests:)
       )
+      if local_file_path
+        config[:request] ||= {}
+        config[:request][:local_file_path] = local_file_path
+      end
+      config
     end
 
     def shortcut_request_controls(strategy:, max_redirects:, max_requests:)

--- a/lib/html2rss/cli.rb
+++ b/lib/html2rss/cli.rb
@@ -48,6 +48,9 @@ module Html2rss
     method_option :max_requests,
                   type: :numeric,
                   desc: 'Maximum requests to allow for this feed build'
+    method_option :input,
+                  type: :string,
+                  desc: 'Local HTML file path to read input from'
     # @param yaml_file [String] path to YAML config
     # @param feed_name [String, nil] optional named feed in multi-feed config
     # @return [void]
@@ -55,6 +58,7 @@ module Html2rss
       config = Html2rss.config_from_yaml_file(yaml_file, feed_name)
       config[:params] = options[:params] || {}
       apply_runtime_request_overrides!(config)
+      apply_local_file_input!(config, options[:input]) if options[:input]
 
       puts(execute_feed { Html2rss.feed(config) })
     end
@@ -76,20 +80,17 @@ module Html2rss
     method_option :max_requests,
                   type: :numeric,
                   desc: 'Maximum requests to allow for this feed build'
-    # @param url [String] source page URL for auto discovery
+    method_option :input,
+                  type: :string,
+                  desc: 'Local HTML file path to read input from'
+    # @param url [String, nil] source page URL for auto discovery
     # @return [void]
-    def auto(url) # rubocop:disable Metrics/MethodLength
+    def auto(url = nil)
       format = options.fetch(:format, 'rss')
-      source_method = format == 'jsonfeed' ? Html2rss.method(:auto_json_feed) : Html2rss.method(:auto_source)
+      strategy, local_file_path, url = prepare_auto_inputs(url, options[:input])
 
       result = execute_feed do
-        source_method.call(
-          url,
-          strategy: current_strategy,
-          items_selector: options[:items_selector],
-          max_redirects: options[:max_redirects],
-          max_requests: options[:max_requests]
-        )
+        source_call(url, strategy, local_file_path, format == 'jsonfeed')
       end
 
       puts(format == 'jsonfeed' ? JSON.pretty_generate(result) : result)
@@ -159,6 +160,33 @@ module Html2rss
       config.delete(:request) if request_config.empty?
     end
 
+    def apply_local_file_input!(config, input_path)
+      file_path = check_file_exists!(input_path)
+      config[:strategy] = :local_file
+      config[:request] = (config[:request] || {}).merge(local_file_path: file_path)
+
+      return unless config.dig(:channel, :url).to_s.empty?
+
+      config[:channel] = (config[:channel] || {}).merge(
+        url: detect_base_url!(file_path, 'Please specify a channel.url in the config.')
+      )
+    end
+
+    def prepare_auto_inputs(url, input_option)
+      if input_option.nil?
+        raise Thor::Error, 'A URL is required unless --input is specified' unless url
+
+        return [current_strategy, nil, url]
+      end
+
+      file_path = check_file_exists!(input_option)
+      detected_url = url || detect_base_url!(
+        file_path, 'Please specify a URL: html2rss auto [URL] --input <file>'
+      )
+
+      [:local_file, file_path, detected_url]
+    end
+
     def request_controls
       Html2rss::RequestControls.new(
         strategy: options[:strategy]&.to_sym,
@@ -212,6 +240,29 @@ module Html2rss
            Html2rss::RequestService::BlockedSurfaceDetected,
            Html2rss::NoFeedItemsExtracted => error
       raise Thor::Error, error.message
+    end
+
+    def source_call(url, strategy, local_file_path, is_json)
+      method = is_json ? Html2rss.method(:auto_json_feed) : Html2rss.method(:auto_source)
+      method.call(
+        url,
+        strategy:,
+        items_selector: options[:items_selector],
+        max_redirects: options[:max_redirects],
+        max_requests: options[:max_requests],
+        local_file_path:
+      )
+    end
+
+    def check_file_exists!(path)
+      File.expand_path(path).tap do |file_path|
+        raise Thor::Error, "Input file does not exist: #{path}" unless File.exist?(file_path)
+      end
+    end
+
+    def detect_base_url!(file_path, error_hint)
+      Html2rss::Url.extract_from_html(File.read(file_path))&.to_s ||
+        raise(Thor::Error, "Could not auto-detect a base URL from HTML metadata. #{error_hint}")
     end
   end
 end

--- a/lib/html2rss/config/validator.rb
+++ b/lib/html2rss/config/validator.rb
@@ -83,6 +83,7 @@ module Html2rss
         optional(:total_timeout_seconds).filled(:integer, gt?: 0)
         optional(:browserless).hash(BrowserlessRequestConfig)
         optional(:botasaurus).hash(BotasaurusRequestConfig)
+        optional(:local_file_path).filled(:string)
       end
 
       params do

--- a/lib/html2rss/request_service.rb
+++ b/lib/html2rss/request_service.rb
@@ -57,7 +57,8 @@ module Html2rss
       @strategies = {
         faraday: FaradayStrategy,
         botasaurus: BotasaurusStrategy,
-        browserless: BrowserlessStrategy
+        browserless: BrowserlessStrategy,
+        local_file: LocalFileStrategy
       }
       @default_strategy_name = :faraday
     end

--- a/lib/html2rss/request_service/local_file_strategy.rb
+++ b/lib/html2rss/request_service/local_file_strategy.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Html2rss
+  class RequestService
+    ##
+    # Strategy to read a local HTML file.
+    class LocalFileStrategy < Strategy
+      ##
+      # Executes the local file read.
+      #
+      # @return [Response] the mock response wrapped around the file contents
+      # @raise [ArgumentError] if the local file path is missing
+      # @raise [Errno::ENOENT] if the file does not exist
+      def execute
+        file_path = ctx.request[:local_file_path]
+        raise ArgumentError, 'Local file path is required for local_file strategy' unless file_path
+        raise Errno::ENOENT, "File not found: #{file_path}" unless File.exist?(file_path)
+
+        body = File.read(file_path)
+        Response.new(
+          body:,
+          headers: { 'content-type' => 'text/html; charset=utf-8' },
+          url: ctx.url,
+          status: 200
+        )
+      end
+    end
+  end
+end

--- a/lib/html2rss/url.rb
+++ b/lib/html2rss/url.rb
@@ -2,6 +2,7 @@
 
 require 'addressable/uri'
 require 'cgi'
+require 'nokogiri'
 
 module Html2rss
   ##
@@ -55,10 +56,9 @@ module Html2rss
     # @return [Url, nil] the sanitized URL, or nil if no valid URL found
     def self.sanitize(raw_url)
       match = raw_url.to_s.match(%r{(?:(?:https?|ftp|mailto)://|mailto:)[^\s<>"]+})
-      url = match ? match[0].strip : ''
-      return nil if url.empty?
+      return unless match
 
-      new(Addressable::URI.parse(url).normalize)
+      new(Addressable::URI.parse(match[0].strip).normalize)
     end
 
     ##
@@ -70,10 +70,9 @@ module Html2rss
     def self.from_absolute(url_string)
       return url_string if url_string.is_a?(self)
 
-      url = new(Addressable::URI.parse(url_string.to_s.strip).normalize)
-      raise ArgumentError, 'URL must be absolute' unless url.absolute?
-
-      url
+      new(Addressable::URI.parse(url_string.to_s.strip).normalize).tap do |url|
+        raise ArgumentError, 'URL must be absolute' unless url.absolute?
+      end
     rescue Addressable::URI::InvalidURIError
       raise ArgumentError, 'URL must be absolute'
     end
@@ -92,14 +91,28 @@ module Html2rss
     #   Url.for_channel('/relative/path')
     #   # => raises ArgumentError: "URL must be absolute"
     def self.for_channel(url_string)
-      return nil if url_string.nil? || url_string.empty?
-
-      stripped = url_string.strip
+      stripped = url_string.to_s.strip
       return nil if stripped.empty?
 
-      url = from_absolute(stripped)
-      validate_channel_url(url)
-      url
+      from_absolute(stripped).tap { validate_channel_url(_1) }
+    end
+
+    ##
+    # Extracts a base URL from HTML metadata tags.
+    #
+    # @param html [String] raw HTML content
+    # @return [Url, nil] the extracted absolute URL, or nil if none is found
+    def self.extract_from_html(html)
+      doc = Nokogiri::HTML(html)
+      tags = { 'link[rel="canonical"]' => 'href', 'meta[property="og:url"]' => 'content',
+               'meta[name="twitter:url"]' => 'content', 'base[href]' => 'href' }
+      tags.each do |sel, attr|
+        val = doc.at_css(sel)&.[](attr).to_s.strip
+        return from_absolute(val) unless val.empty?
+      rescue ArgumentError
+        next
+      end
+      nil
     end
 
     ##

--- a/schema/html2rss-config.schema.json
+++ b/schema/html2rss-config.schema.json
@@ -535,6 +535,10 @@
             }
           },
           "required": []
+        },
+        "local_file_path": {
+          "type": "string",
+          "minLength": 1
         }
       },
       "required": []

--- a/spec/exe/html2rss_spec.rb
+++ b/spec/exe/html2rss_spec.rb
@@ -112,4 +112,32 @@ RSpec.describe 'exe/html2rss', :slow do
       expect($?.exitstatus).to eq(1) # rubocop:disable Style/SpecialGlobalVars
     end
   end
+
+  context 'with option: --input' do
+    context 'with command: feed' do
+      it 'generates RSS using the local HTML file', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+        output = `#{executable} feed spec/fixtures/local_feed_test.yml --input spec/fixtures/local_feed_test.html`
+
+        expect(output).to include(
+          '<title>Local Test Feed</title>',
+          '<title>Item 1</title>',
+          '<link>https://example.com/post-1</link>',
+          '<title>Item 2</title>',
+          '<link>https://example.com/post-2</link>'
+        )
+      end
+    end
+
+    context 'with command: auto' do
+      it 'automatically sources RSS using the local HTML file and canonical base URL', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+        output = `#{executable} auto --input spec/fixtures/local_feed_test.html`
+
+        expect(output).to include(
+          '<channel>',
+          '<title>example.com: Blog</title>',
+          '<link>https://example.com/blog</link>'
+        )
+      end
+    end
+  end
 end

--- a/spec/fixtures/local_feed_test.html
+++ b/spec/fixtures/local_feed_test.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <link rel="canonical" href="https://example.com/blog">
+</head>
+<body>
+  <div class="item">
+    <h2>Item 1</h2>
+    <a href="/post-1">Link 1</a>
+  </div>
+  <div class="item">
+    <h2>Item 2</h2>
+    <a href="/post-2">Link 2</a>
+  </div>
+</body>
+</html>

--- a/spec/fixtures/local_feed_test.yml
+++ b/spec/fixtures/local_feed_test.yml
@@ -1,0 +1,11 @@
+channel:
+  title: Local Test Feed
+  url: https://example.com/blog
+selectors:
+  items:
+    selector: ".item"
+  title:
+    selector: "h2"
+  link:
+    selector: "a"
+    extractor: href

--- a/spec/lib/html2rss/cli_spec.rb
+++ b/spec/lib/html2rss/cli_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require 'tmpdir'
+require 'tempfile'
 
 RSpec.describe Html2rss::CLI do
   subject(:cli) { described_class.new }
@@ -89,6 +90,40 @@ RSpec.describe Html2rss::CLI do
 
       expect(Html2rss).to have_received(:feed).with(hash_excluding(:request))
     end
+
+    context 'with input option' do
+      it 'uses local_file strategy and sets local_file_path', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+        allow(Html2rss).to receive(:config_from_yaml_file).and_return({ channel: { url: 'https://example.com' } })
+
+        cli.invoke(:feed, ['example.yml'], { input: 'spec/fixtures/local_feed_test.html' })
+
+        expect(Html2rss).to have_received(:feed).with(
+          hash_including(
+            strategy: :local_file,
+            request: hash_including(local_file_path: File.expand_path('spec/fixtures/local_feed_test.html'))
+          )
+        )
+      end
+
+      it 'auto-detects base URL from HTML input if config url is missing' do # rubocop:disable RSpec/ExampleLength
+        allow(Html2rss).to receive(:config_from_yaml_file).and_return({ channel: {} })
+
+        cli.invoke(:feed, ['example.yml'], { input: 'spec/fixtures/local_feed_test.html' })
+
+        expect(Html2rss).to have_received(:feed).with(
+          hash_including(
+            channel: hash_including(url: 'https://example.com/blog')
+          )
+        )
+      end
+
+      it 'raises Thor::Error when input file does not exist' do
+        allow(Html2rss).to receive(:config_from_yaml_file).and_return({})
+
+        expect { cli.invoke(:feed, ['example.yml'], { input: 'nonexistent.html' }) }
+          .to raise_error(Thor::Error, /Input file does not exist/)
+      end
+    end
   end
 
   describe '#auto' do
@@ -108,7 +143,7 @@ RSpec.describe Html2rss::CLI do
 
       expect(Html2rss).to have_received(:auto_source)
         .with('https://example.com', strategy: :browserless, items_selector: nil, max_redirects: nil,
-                                     max_requests: nil)
+                                     max_requests: nil, local_file_path: nil)
     end
 
     it 'passes botasaurus strategy option to Html2rss.auto_source' do
@@ -116,7 +151,7 @@ RSpec.describe Html2rss::CLI do
 
       expect(Html2rss).to have_received(:auto_source)
         .with('https://example.com', strategy: :botasaurus, items_selector: nil, max_redirects: nil,
-                                     max_requests: nil)
+                                     max_requests: nil, local_file_path: nil)
     end
 
     it 'passes the rss format option to Html2rss.auto_source' do
@@ -124,7 +159,7 @@ RSpec.describe Html2rss::CLI do
 
       expect(Html2rss).to have_received(:auto_source)
         .with('https://example.com', strategy: :auto, items_selector: nil, max_redirects: nil,
-                                     max_requests: nil)
+                                     max_requests: nil, local_file_path: nil)
     end
 
     it 'passes the jsonfeed format option to Html2rss.auto_json_feed' do
@@ -132,7 +167,7 @@ RSpec.describe Html2rss::CLI do
 
       expect(Html2rss).to have_received(:auto_json_feed)
         .with('https://example.com', strategy: :auto, items_selector: nil, max_redirects: nil,
-                                     max_requests: nil)
+                                     max_requests: nil, local_file_path: nil)
     end
 
     it 'prints the jsonfeed output when requested' do
@@ -147,21 +182,23 @@ RSpec.describe Html2rss::CLI do
 
       expect(Html2rss).to have_received(:auto_source)
         .with('https://example.com', strategy: :auto, items_selector: '.item', max_redirects: nil,
-                                     max_requests: nil)
+                                     max_requests: nil, local_file_path: nil)
     end
 
     it 'passes the max_redirects option to Html2rss.auto_source' do
       cli.invoke(:auto, ['https://example.com'], { max_redirects: 8 })
 
       expect(Html2rss).to have_received(:auto_source)
-        .with('https://example.com', strategy: :auto, items_selector: nil, max_redirects: 8, max_requests: nil)
+        .with('https://example.com', strategy: :auto, items_selector: nil, max_redirects: 8, max_requests: nil,
+                                     local_file_path: nil)
     end
 
     it 'passes the max_requests option to Html2rss.auto_source' do
       cli.invoke(:auto, ['https://example.com'], { max_requests: 8 })
 
       expect(Html2rss).to have_received(:auto_source)
-        .with('https://example.com', strategy: :auto, items_selector: nil, max_redirects: nil, max_requests: 8)
+        .with('https://example.com', strategy: :auto, items_selector: nil, max_redirects: nil, max_requests: 8,
+                                     local_file_path: nil)
     end
 
     it 'passes auto strategy option to Html2rss.auto_source' do
@@ -169,7 +206,7 @@ RSpec.describe Html2rss::CLI do
 
       expect(Html2rss).to have_received(:auto_source)
         .with('https://example.com', strategy: :auto, items_selector: nil, max_redirects: nil,
-                                     max_requests: nil)
+                                     max_requests: nil, local_file_path: nil)
     end
 
     context 'when the redirect limit is hit' do
@@ -255,6 +292,49 @@ RSpec.describe Html2rss::CLI do
       it 'raises a CLI error with zero-items guidance' do
         expect { cli.auto('https://example.com') }
           .to raise_error(Thor::Error, /No feed items extracted after auto fallback/)
+      end
+    end
+
+    context 'with input option' do
+      it 'uses local_file strategy and extracts base URL', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+        cli.invoke(:auto, [], { input: 'spec/fixtures/local_feed_test.html' })
+
+        expect(Html2rss).to have_received(:auto_source).with(
+          'https://example.com/blog',
+          strategy: :local_file,
+          items_selector: nil,
+          max_redirects: nil,
+          max_requests: nil,
+          local_file_path: File.expand_path('spec/fixtures/local_feed_test.html')
+        )
+      end
+
+      it 'uses provided URL argument over auto-detection' do # rubocop:disable RSpec/ExampleLength
+        cli.invoke(:auto, ['https://custom-url.com'], { input: 'spec/fixtures/local_feed_test.html' })
+
+        expect(Html2rss).to have_received(:auto_source).with(
+          'https://custom-url.com',
+          strategy: :local_file,
+          items_selector: nil,
+          max_redirects: nil,
+          max_requests: nil,
+          local_file_path: File.expand_path('spec/fixtures/local_feed_test.html')
+        )
+      end
+
+      it 'raises Thor::Error when input file does not exist' do
+        expect { cli.invoke(:auto, [], { input: 'nonexistent.html' }) }
+          .to raise_error(Thor::Error, /Input file does not exist/)
+      end
+
+      it 'raises Thor::Error when no URL is provided and no canonical metadata is found' do # rubocop:disable RSpec/ExampleLength
+        Tempfile.create(%w[test .html]) do |temp|
+          temp.write('<html><body>no url metadata</body></html>')
+          temp.close
+
+          expect { cli.invoke(:auto, [], { input: temp.path }) }
+            .to raise_error(Thor::Error, /Could not auto-detect a base URL/)
+        end
       end
     end
   end

--- a/spec/lib/html2rss/request_service/local_file_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/local_file_strategy_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tempfile'
+
+RSpec.describe Html2rss::RequestService::LocalFileStrategy do
+  subject(:execute) { described_class.new(ctx).execute }
+
+  let(:file_path) { temp_file.path }
+  let(:temp_file) do
+    Tempfile.new(%w[test .html]).tap do |f|
+      f.write('<html><body><h1>Hello World</h1></body></html>')
+      f.close
+    end
+  end
+
+  after do
+    temp_file.unlink
+  end
+
+  context 'with a valid file path' do
+    let(:ctx) do
+      Html2rss::RequestService::Context.new(
+        url: 'https://example.com',
+        request: { local_file_path: file_path }
+      )
+    end
+
+    it 'reads the file content and returns a Response object', :aggregate_failures do
+      response = execute
+      expect(response.body).to eq('<html><body><h1>Hello World</h1></body></html>')
+      expect(response.status).to eq(200)
+      expect(response.headers['content-type']).to include('text/html')
+      expect(response.url.to_s).to eq('https://example.com/')
+    end
+  end
+
+  context 'with a missing file path' do
+    let(:ctx) do
+      Html2rss::RequestService::Context.new(
+        url: 'https://example.com',
+        request: { local_file_path: '/nonexistent/file.html' }
+      )
+    end
+
+    it 'raises Errno::ENOENT' do
+      expect { execute }.to raise_error(Errno::ENOENT)
+    end
+  end
+
+  context 'without local_file_path in request context' do
+    let(:ctx) do
+      Html2rss::RequestService::Context.new(
+        url: 'https://example.com',
+        request: {}
+      )
+    end
+
+    it 'raises ArgumentError' do
+      expect { execute }.to raise_error(ArgumentError, /Local file path is required/)
+    end
+  end
+end

--- a/spec/lib/html2rss/url_spec.rb
+++ b/spec/lib/html2rss/url_spec.rb
@@ -285,6 +285,38 @@ RSpec.describe Html2rss::Url do
     end
   end
 
+  describe '.extract_from_html' do
+    it 'extracts canonical link' do
+      html = '<html><head><link rel="canonical" href="https://example.com/canonical"></head></html>'
+      expect(described_class.extract_from_html(html).to_s).to eq('https://example.com/canonical')
+    end
+
+    it 'extracts og:url' do
+      html = '<html><head><meta property="og:url" content="https://example.com/og-url"></head></html>'
+      expect(described_class.extract_from_html(html).to_s).to eq('https://example.com/og-url')
+    end
+
+    it 'extracts twitter:url' do
+      html = '<html><head><meta name="twitter:url" content="https://example.com/twitter-url"></head></html>'
+      expect(described_class.extract_from_html(html).to_s).to eq('https://example.com/twitter-url')
+    end
+
+    it 'extracts base href' do
+      html = '<html><head><base href="https://example.com/base-href"></head></html>'
+      expect(described_class.extract_from_html(html).to_s).to eq('https://example.com/base-href')
+    end
+
+    it 'returns nil if no indicator matches' do
+      html = '<html><head></head><body>hello</body></html>'
+      expect(described_class.extract_from_html(html)).to be_nil
+    end
+
+    it 'returns nil on invalid URL extracted' do
+      html = '<html><head><link rel="canonical" href="not-a-url"></head></html>'
+      expect(described_class.extract_from_html(html)).to be_nil
+    end
+  end
+
   describe 'immutability' do
     let(:url) { described_class.from_relative('/path', 'https://example.com') }
 


### PR DESCRIPTION
## Description
This PR adds support for scraping and generating RSS/JSON feeds from local HTML files using a new `--input` CLI option. It introduces a stateless `LocalFileStrategy` that reads a file from the workspace, extracts base URL metadata, and processes the local HTML through the pipeline.

## Key Changes
- Added the `--input <path>` option to both `feed` and `auto` CLI commands.
- Implemented `Html2rss::RequestService::LocalFileStrategy` for reading local HTML files.
- Added URL base path extraction from canonical/og:url/twitter:url/base href HTML tags.
- Registered and documented `local_file_path` request configuration in validator and JSON schema.
- Added full test coverage for the local file strategy, CLI arguments, and integration runs.
