### PR TITLE
fix(request_service): implement remaining time budget across fallback strategies

### DIFF
--- a/lib/html2rss/feed_pipeline.rb
+++ b/lib/html2rss/feed_pipeline.rb
@@ -3,7 +3,7 @@
 module Html2rss
   ##
   # Builds feeds from validated config through request, extraction, and rendering stages.
-  class FeedPipeline
+  class FeedPipeline # rubocop:disable Metrics/ClassLength
     ##
     # @param raw_config [Hash{Symbol => Object}] user-provided feed config
     def initialize(raw_config)
@@ -77,11 +77,16 @@ module Html2rss
       auto_fallback_for(config).call
     end
 
+    # rubocop:disable Metrics/MethodLength
     def auto_fallback_for(config)
       AutoFallback.new(
         strategies: AutoFallback::CHAIN,
         budget: auto_pipeline_budget(config),
         session_for: lambda do |strategy:, budget:|
+          if budget.remaining_timeout_seconds && budget.remaining_timeout_seconds <= 0
+            raise RequestService::RequestTimedOut, 'Request timed out'
+          end
+
           request_session_for(config, strategy:, budget:)
         end,
         articles_for: lambda do |response:, request_session:|
@@ -89,10 +94,14 @@ module Html2rss
         end
       )
     end
+    # rubocop:enable Metrics/MethodLength
 
     def auto_pipeline_budget(config)
-      max_requests = RequestSession::RuntimePolicy.from_config(config).max_requests
-      RequestService::Budget.new(max_requests:)
+      policy = RequestSession::RuntimePolicy.from_config(config)
+      RequestService::Budget.new(
+        max_requests: policy.max_requests,
+        total_timeout_seconds: policy.total_timeout_seconds
+      )
     end
 
     def collect_articles(response:, config:, request_session:)

--- a/lib/html2rss/request_service/botasaurus_strategy.rb
+++ b/lib/html2rss/request_service/botasaurus_strategy.rb
@@ -16,9 +16,9 @@ module Html2rss
       # @raise [BotasaurusConnectionFailed] when Botasaurus cannot be reached or returns an invalid payload
       # @raise [RequestTimedOut] when the Botasaurus request exceeds configured timeout
       def execute
+        check_timeout!
         validate_request!
-        transport_response = client.post('/scrape', JSON.generate(contract.request_payload), content_type_header)
-        parsed_response = contract.parse_response(transport_response)
+        parsed_response = post_scrape_request
         raise_if_challenge_blocked!(parsed_response)
         raise_if_upstream_failed!(parsed_response)
         build_response(parsed_response)
@@ -29,6 +29,11 @@ module Html2rss
       end
 
       private
+
+      def post_scrape_request
+        transport_response = client.post('/scrape', JSON.generate(contract.request_payload), content_type_header)
+        contract.parse_response(transport_response)
+      end
 
       def validate_request!
         ctx.budget.consume!
@@ -76,7 +81,10 @@ module Html2rss
       end
 
       def request_options
-        { timeout: ctx.policy.total_timeout_seconds }
+        timeout = ctx.budget.remaining_timeout_seconds || ctx.policy.total_timeout_seconds
+        raise RequestTimedOut, 'Request timed out' if timeout <= 0
+
+        { timeout: timeout.to_i }
       end
 
       def content_type_header

--- a/lib/html2rss/request_service/browserless_strategy.rb
+++ b/lib/html2rss/request_service/browserless_strategy.rb
@@ -37,6 +37,7 @@ module Html2rss
       # @return [Response] normalized request response
       # @raise [RequestTimedOut] if the browser session exceeds the configured timeout
       def execute
+        check_timeout!
         validate_request!
         execute_browserless_request
       rescue Puppeteer::TimeoutError => error
@@ -71,7 +72,10 @@ module Html2rss
       end
 
       def protocol_timeout_ms
-        ctx.policy.total_timeout_seconds * 1000
+        timeout = ctx.budget.remaining_timeout_seconds || ctx.policy.total_timeout_seconds
+        raise RequestTimedOut, 'Request timed out' if timeout <= 0
+
+        (timeout * 1000).to_i
       end
 
       def connect_with_timeout_support(&)

--- a/lib/html2rss/request_service/budget.rb
+++ b/lib/html2rss/request_service/budget.rb
@@ -6,13 +6,17 @@ module Html2rss
     # Tracks how many outbound requests a single feed build may still perform.
     class Budget
       ##
+      ##
       # @param max_requests [Integer] the maximum number of requests allowed
-      def initialize(max_requests:)
+      # @param total_timeout_seconds [Integer, nil] the total timeout for the feed build
+      def initialize(max_requests:, total_timeout_seconds: nil)
         unless max_requests.is_a?(Integer) && max_requests.positive?
           raise ArgumentError, 'max_requests must be positive'
         end
 
         @remaining = max_requests
+        @start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        @total_timeout_seconds = total_timeout_seconds
         @mutex = Mutex.new
       end
 
@@ -33,6 +37,16 @@ module Html2rss
       # @return [Integer] requests still available
       def remaining
         @mutex.synchronize { @remaining }
+      end
+
+      ##
+      # @return [Float, nil] the remaining timeout in seconds, or nil if not tracked
+      def remaining_timeout_seconds
+        return unless @total_timeout_seconds
+
+        elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - @start_time
+        remaining = @total_timeout_seconds - elapsed
+        [remaining, 0.0].max
       end
     end
   end

--- a/lib/html2rss/request_service/context.rb
+++ b/lib/html2rss/request_service/context.rb
@@ -77,7 +77,9 @@ module Html2rss
         raise ArgumentError, 'policy must not be nil' if @policy.nil?
 
         @origin_url = normalized_origin_url(request_options[:origin_url])
-        @budget = request_options.fetch(:budget) { Budget.new(max_requests: policy.max_requests) }
+        @budget = request_options.fetch(:budget) do
+          Budget.new(max_requests: policy.max_requests, total_timeout_seconds: policy.total_timeout_seconds)
+        end
         raise ArgumentError, 'budget must not be nil' if @budget.nil?
       end
 

--- a/lib/html2rss/request_service/faraday_strategy.rb
+++ b/lib/html2rss/request_service/faraday_strategy.rb
@@ -34,6 +34,7 @@ module Html2rss
       #   SSRF protection here is pre-connection only (DNS resolution via Policy).
       #   A DNS rebinding attack between resolution and connect cannot be caught at this layer.
       def execute
+        check_timeout!
         deadline = request_deadline
         response_guard, response = perform_request(deadline:)
         response_guard.inspect_body!(response.body)
@@ -45,7 +46,7 @@ module Html2rss
       private
 
       def request_deadline
-        monotonic_now + ctx.policy.total_timeout_seconds
+        monotonic_now + (ctx.budget.remaining_timeout_seconds || ctx.policy.total_timeout_seconds)
       end
 
       def perform_request(deadline:)

--- a/lib/html2rss/request_service/strategy.rb
+++ b/lib/html2rss/request_service/strategy.rb
@@ -23,6 +23,11 @@ module Html2rss
 
       # @return [Context] the context for the request
       attr_reader :ctx
+
+      def check_timeout!
+        remaining = ctx.budget.remaining_timeout_seconds
+        raise RequestTimedOut, 'Request timed out' if remaining && remaining <= 0
+      end
     end
   end
 end

--- a/spec/lib/html2rss/feed_pipeline_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline_spec.rb
@@ -167,6 +167,23 @@ RSpec.describe Html2rss::FeedPipeline do
           ).once
         end
       end
+
+      # rubocop:disable RSpec/ExampleLength
+      it 'halts fallback chain immediately if the time budget is exhausted', :aggregate_failures do
+        t = 0.0
+        allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { t }
+        allow(Html2rss::RequestService).to receive(:execute).and_call_original
+        allow(Html2rss::RequestService).to receive(:execute).with(anything, strategy: :faraday) do
+          t += 1.5 # advance time to exceed the 1s budget
+          raise Html2rss::RequestService::RequestTimedOut, 'timed out'
+        end
+
+        pipeline = described_class.new(base_config.merge(strategy: :auto, request: { total_timeout_seconds: 1 }))
+        expect { pipeline.to_rss }.to raise_error(Html2rss::RequestService::RequestTimedOut)
+        expect(Html2rss::RequestService).to have_received(:execute).with(anything, strategy: :faraday).once
+        expect(Html2rss::RequestService).not_to have_received(:execute).with(anything, strategy: :botasaurus)
+      end
+      # rubocop:enable RSpec/ExampleLength
     end
   end
 end

--- a/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
       validate_request!: nil
     )
   end
-  let(:budget) { instance_double(Html2rss::RequestService::Budget, consume!: nil) }
+  let(:budget) { instance_double(Html2rss::RequestService::Budget, consume!: nil, remaining_timeout_seconds: nil) }
   let(:request_config) { {} }
   let(:ctx) { Html2rss::RequestService::Context.new(url: 'https://example.com', request: request_config, policy:, budget:) }
   let(:connection) { instance_double(Faraday::Connection) }

--- a/spec/lib/html2rss/request_service/browserless_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/browserless_strategy_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Html2rss::RequestService::BrowserlessStrategy do
       validate_request!: nil
     )
   end
-  let(:budget) { instance_double(Html2rss::RequestService::Budget, consume!: nil) }
+  let(:budget) { instance_double(Html2rss::RequestService::Budget, consume!: nil, remaining_timeout_seconds: nil) }
   let(:ctx) { Html2rss::RequestService::Context.new(url: 'https://example.com', policy:, budget:) }
 
   describe '#execute' do # rubocop:disable RSpec/MultipleMemoizedHelpers

--- a/spec/lib/html2rss/request_service/budget_spec.rb
+++ b/spec/lib/html2rss/request_service/budget_spec.rb
@@ -19,4 +19,16 @@ RSpec.describe Html2rss::RequestService::Budget do
       end.to raise_error(Html2rss::RequestService::RequestBudgetExceeded, 'Request budget exhausted')
     end
   end
+
+  describe '#remaining_timeout_seconds' do
+    it 'returns nil when total_timeout_seconds is not provided' do
+      budget = described_class.new(max_requests: 2)
+      expect(budget.remaining_timeout_seconds).to be_nil
+    end
+
+    it 'returns the remaining time' do
+      budget = described_class.new(max_requests: 2, total_timeout_seconds: 10)
+      expect(budget.remaining_timeout_seconds).to be_within(0.5).of(10)
+    end
+  end
 end

--- a/spec/lib/html2rss/request_service/faraday_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/faraday_strategy_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Html2rss::RequestService::FaradayStrategy do # rubocop:disable RS
       validate_redirect!: nil
     )
   end
-  let(:budget) { instance_double(Html2rss::RequestService::Budget, consume!: nil) }
+  let(:budget) { instance_double(Html2rss::RequestService::Budget, consume!: nil, remaining_timeout_seconds: nil) }
   let(:ctx) do
     Html2rss::RequestService::Context.new(
       url: 'https://example.com',

--- a/spec/lib/html2rss/request_service/puppet_commander_spec.rb
+++ b/spec/lib/html2rss/request_service/puppet_commander_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Html2rss::RequestService::PuppetCommander do
       validate_remote_ip!: nil
     )
   end
-  let(:budget) { instance_double(Html2rss::RequestService::Budget, consume!: nil) }
+  let(:budget) { instance_double(Html2rss::RequestService::Budget, consume!: nil, remaining_timeout_seconds: nil) }
   let(:ctx) do
     instance_double(
       Html2rss::RequestService::Context,


### PR DESCRIPTION
Resolves request timeout errors in production under auto strategy fallback and multi-page pagination by introducing a dynamic remaining timeout budget tracked by a shared Budget instance.