### PR TITLE
feat(pagination): generalized multi-strategy pagination framework

### DIFF
--- a/lib/html2rss/feed_pipeline.rb
+++ b/lib/html2rss/feed_pipeline.rb
@@ -108,19 +108,24 @@ module Html2rss
     def selector_articles(response:, config:, request_session:) # rubocop:disable Metrics/MethodLength
       return [] unless (selectors = config.selectors)
 
-      page_responses = if (max_pages = selectors.dig(:items, :pagination, :max_pages))
-                         RequestSession::RelNextPager.new(
+      page_responses = if (pagination_config = selectors.dig(:items, :pagination))
+                         RequestSession::Pager.for(
+                           pagination_config,
                            session: request_session,
-                           initial_response: response,
-                           max_pages:
-                         ).to_a
+                           initial_response: response
+                         )
                        else
                          [response]
                        end
 
-      page_responses.flat_map do |page_response|
-        Selectors.new(page_response, selectors:, time_zone: config.time_zone).articles
+      articles = []
+      page_responses.each do |page_response|
+        page_articles = Selectors.new(page_response, selectors:, time_zone: config.time_zone).articles
+        break if page_articles.empty? && articles.any?
+
+        articles.concat(page_articles)
       end
+      articles
     end
 
     def auto_source_articles(response:, config:, request_session:)

--- a/lib/html2rss/feed_pipeline.rb
+++ b/lib/html2rss/feed_pipeline.rb
@@ -73,12 +73,8 @@ module Html2rss
       ).call
     end
 
-    def run_auto_pipeline(config)
-      auto_fallback_for(config).call
-    end
-
     # rubocop:disable Metrics/MethodLength
-    def auto_fallback_for(config)
+    def run_auto_pipeline(config)
       AutoFallback.new(
         strategies: AutoFallback::CHAIN,
         budget: auto_pipeline_budget(config),
@@ -92,7 +88,7 @@ module Html2rss
         articles_for: lambda do |response:, request_session:|
           deduplicated_articles(response:, config:, request_session:)
         end
-      )
+      ).call
     end
     # rubocop:enable Metrics/MethodLength
 

--- a/lib/html2rss/request_session/pager.rb
+++ b/lib/html2rss/request_session/pager.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require_relative 'pager/base'
+require_relative 'pager/rel_next'
+require_relative 'pager/custom_selector'
+require_relative 'pager/url_template'
+require_relative 'pager/offset'
+require_relative 'pager/json_cursor'
+
+module Html2rss
+  class RequestSession
+    ##
+    # Factory for building pagination strategy instances.
+    module Pager
+      STRATEGIES = {
+        rel_next: RelNext,
+        custom_selector: CustomSelector,
+        url_template: UrlTemplate,
+        offset: Offset,
+        json_cursor: JsonCursor
+      }.freeze
+
+      ##
+      # Returns a pager instance for the provided configuration.
+      #
+      # @param config [Hash, Integer, nil] pagination configuration
+      # @param session [RequestSession] request session used to execute follow-ups
+      # @param initial_response [RequestService::Response] initial page response
+      # @return [RequestSession::Pager::Base] pager strategy instance
+      def self.for(config, session:, initial_response:)
+        normalized_config = normalize_config(config)
+        strategy_name = normalized_config.fetch(:strategy, :rel_next).to_sym
+
+        klass = STRATEGIES.fetch(strategy_name) do
+          raise ArgumentError, "Unknown pagination strategy: #{strategy_name}"
+        end
+
+        klass.new(session:, initial_response:, config: normalized_config)
+      end
+
+      ##
+      # Normalizes integer, hash, or nil inputs into a strategy config hash.
+      #
+      # @param config [Hash, Integer, nil]
+      # @return [Hash]
+      def self.normalize_config(config)
+        case config
+        when Integer
+          { max_pages: config, strategy: :rel_next }
+        when Hash
+          normalized = config.transform_keys(&:to_sym)
+          normalized[:strategy] = (normalized[:strategy] || :rel_next).to_sym
+          normalized
+        else
+          { max_pages: Base::DEFAULT_MAX_PAGES, strategy: :rel_next }
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/request_session/pager.rb
+++ b/lib/html2rss/request_session/pager.rb
@@ -12,6 +12,8 @@ module Html2rss
     ##
     # Factory for building pagination strategy instances.
     module Pager
+      # Mapping of strategy symbols to strategy class implementations.
+      # @return [Hash{Symbol => Class}]
       STRATEGIES = {
         rel_next: RelNext,
         custom_selector: CustomSelector,

--- a/lib/html2rss/request_session/pager/base.rb
+++ b/lib/html2rss/request_session/pager/base.rb
@@ -10,6 +10,8 @@ module Html2rss
       class Base
         include Enumerable
 
+        # Default maximum number of pages to fetch if omitted.
+        # @return [Integer]
         DEFAULT_MAX_PAGES = 5
 
         # @param session [RequestSession] request session used to execute follow-ups

--- a/lib/html2rss/request_session/pager/base.rb
+++ b/lib/html2rss/request_session/pager/base.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'uri'
+
+module Html2rss
+  class RequestSession
+    module Pager
+      ##
+      # Abstract base class for pagination strategies.
+      class Base
+        include Enumerable
+
+        DEFAULT_MAX_PAGES = 5
+
+        # @param session [RequestSession] request session used to execute follow-ups
+        # @param initial_response [RequestService::Response] first page response
+        # @param config [Hash, Integer] pagination configuration or max_pages integer
+        # @param logger [Logger] logger used for pagination stop warnings
+        def initialize(session:, initial_response:, config: {}, logger: Html2rss::Log)
+          @session = session
+          @initial_response = initial_response
+          @config = config.is_a?(Hash) ? config : { max_pages: config }
+          @logger = logger
+        end
+
+        # @yield [RequestService::Response] each page response
+        # @return [Enumerator] enumerator when no block is given
+        def each
+          return enum_for(:each) unless block_given?
+
+          yield initial_response
+
+          current_response = initial_response
+          session.effective_page_budget(max_pages).pred.times do |index|
+            next_url = next_page_url(current_response, page_number: index + 2)
+            break unless follow_up_allowed?(next_url)
+
+            current_response = fetch_follow_up_response_or_stop(next_url, current_response.url)
+            break unless current_response
+
+            yield current_response
+          end
+        end
+
+        private
+
+        attr_reader :session, :initial_response, :config, :logger
+
+        # @return [Integer] configured maximum pages
+        def max_pages
+          config.fetch(:max_pages, DEFAULT_MAX_PAGES)
+        end
+
+        # @param next_url [String, URI, nil]
+        # @return [Boolean]
+        def follow_up_allowed?(next_url)
+          !next_url.nil? && !next_url.to_s.empty? && !session.visited?(next_url)
+        end
+
+        # @param next_url [String, URI]
+        # @param origin_url [String, URI]
+        # @return [RequestService::Response, nil]
+        def fetch_follow_up_response_or_stop(next_url, origin_url)
+          session.follow_up(url: next_url, relation: :pagination, origin_url:)
+        rescue RequestService::RequestBudgetExceeded => error
+          logger.warn(
+            "#{self.class}: pagination stopped at #{next_url} - #{error.message}. " \
+            "Retry with --max-requests #{session.max_requests + 1} or increase request.max_requests in the config."
+          )
+          nil
+        end
+
+        # @param url_str [String]
+        # @param param_name [String, Symbol]
+        # @param param_val [Object]
+        # @return [String]
+        def build_url_with_param(url_str, param_name, param_val)
+          uri = URI.parse(url_str.to_s)
+          params = URI.decode_www_form(uri.query || '')
+          params.reject! { |k, _| k == param_name.to_s }
+          params << [param_name.to_s, param_val.to_s]
+          uri.query = URI.encode_www_form(params)
+          uri.to_s
+        end
+
+        # @param page_response [RequestService::Response]
+        # @param page_number [Integer] 1-based target page number (e.g. 2 for second page)
+        # @return [String, URI, nil]
+        def next_page_url(page_response, page_number:)
+          raise NotImplementedError, "#{self.class}#next_page_url must be implemented by subclass"
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/request_session/pager/custom_selector.rb
+++ b/lib/html2rss/request_session/pager/custom_selector.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Html2rss
+  class RequestSession
+    module Pager
+      ##
+      # Extracts the next-page URL using a configurable CSS or XPath selector.
+      class CustomSelector < Base
+        private
+
+        # @param page_response [RequestService::Response]
+        # @param page_number [Integer]
+        # @return [String, nil]
+        def next_page_url(page_response, page_number: nil) # rubocop:disable Lint/UnusedMethodArgument
+          selector = config[:selector]
+          return nil if selector.nil? || selector.empty?
+
+          node = extract_node(page_response.parsed_body, selector)
+          return nil unless node
+
+          href = node['href'] || node.text
+          return nil if href.nil? || href.strip.empty?
+
+          Html2rss::Url.from_relative(href.strip, page_response.url)
+        end
+
+        # @param parsed_body [Nokogiri::HTML::Document]
+        # @param selector [String]
+        # @return [Nokogiri::XML::Node, nil]
+        def extract_node(parsed_body, selector)
+          parsed_body.at_css(selector) || parsed_body.at_xpath(selector)
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/request_session/pager/json_cursor.rb
+++ b/lib/html2rss/request_session/pager/json_cursor.rb
@@ -9,6 +9,8 @@ module Html2rss
       ##
       # Digs into JSON response payloads to extract next page URLs or cursor tokens.
       class JsonCursor < Base
+        # Default query parameter name for cursor token pagination.
+        # @return [String]
         DEFAULT_PARAM = 'cursor'
 
         private

--- a/lib/html2rss/request_session/pager/json_cursor.rb
+++ b/lib/html2rss/request_session/pager/json_cursor.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'json'
+require_relative 'base'
+
+module Html2rss
+  class RequestSession
+    module Pager
+      ##
+      # Digs into JSON response payloads to extract next page URLs or cursor tokens.
+      class JsonCursor < Base
+        DEFAULT_PARAM = 'cursor'
+
+        private
+
+        # @param page_response [RequestService::Response]
+        # @param page_number [Integer]
+        # @return [String, nil]
+        def next_page_url(page_response, page_number: nil) # rubocop:disable Lint/UnusedMethodArgument
+          json_data = parse_json_body(page_response)
+          return nil unless json_data
+
+          url_from_next_path(json_data, page_response.url) ||
+            url_from_cursor_path(json_data, page_response.url)
+        end
+
+        # @param json_data [Hash]
+        # @param origin_url [Html2rss::Url]
+        # @return [String, nil]
+        def url_from_next_path(json_data, origin_url)
+          return nil unless (next_url_path = config[:next_url_path])
+
+          next_url = dig_path(json_data, next_url_path)
+          Html2rss::Url.from_relative(next_url.to_s, origin_url) if next_url && !next_url.to_s.empty?
+        end
+
+        # @param json_data [Hash]
+        # @param origin_url [Html2rss::Url]
+        # @return [String, nil]
+        def url_from_cursor_path(json_data, origin_url)
+          return nil unless (cursor_path = config[:cursor_path])
+
+          cursor_val = dig_path(json_data, cursor_path)
+          return nil if cursor_val.nil? || cursor_val.to_s.empty?
+
+          param = config.fetch(:param, DEFAULT_PARAM)
+          build_url_with_param(origin_url.to_s, param, cursor_val.to_s)
+        end
+
+        # @param page_response [RequestService::Response]
+        # @return [Hash, nil]
+        def parse_json_body(page_response)
+          JSON.parse(page_response.body)
+        rescue JSON::ParserError
+          nil
+        end
+
+        # @param hash [Hash]
+        # @param path [String, Symbol]
+        # @return [Object, nil]
+        def dig_path(hash, path)
+          return nil unless hash.is_a?(Hash)
+
+          keys = path.to_s.split('.')
+          result = hash
+          keys.each do |key|
+            return nil unless result.is_a?(Hash)
+
+            result = result[key] || result[key.to_sym]
+          end
+          result
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/request_session/pager/offset.rb
+++ b/lib/html2rss/request_session/pager/offset.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Html2rss
+  class RequestSession
+    module Pager
+      ##
+      # Paginate using numeric offset increments in query parameters or URL path templates.
+      class Offset < Base
+        DEFAULT_PARAM = 'offset'
+        DEFAULT_START_OFFSET = 0
+        DEFAULT_INCREMENT = 20
+
+        private
+
+        # @param page_response [RequestService::Response]
+        # @param page_number [Integer]
+        # @return [String]
+        def next_page_url(page_response, page_number:)
+          param = config.fetch(:param, DEFAULT_PARAM)
+          start_offset = config.fetch(:start_offset, DEFAULT_START_OFFSET)
+          increment = config.fetch(:increment, DEFAULT_INCREMENT)
+
+          target_offset_val = start_offset + ((page_number - 1) * increment)
+          base_url_str = page_response.url.to_s
+
+          if base_url_str.include?('{offset}')
+            base_url_str.gsub('{offset}', target_offset_val.to_s)
+          else
+            build_url_with_param(base_url_str, param, target_offset_val)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/request_session/pager/offset.rb
+++ b/lib/html2rss/request_session/pager/offset.rb
@@ -8,8 +8,16 @@ module Html2rss
       ##
       # Paginate using numeric offset increments in query parameters or URL path templates.
       class Offset < Base
+        # Default query parameter name for offset pagination.
+        # @return [String]
         DEFAULT_PARAM = 'offset'
+
+        # Default starting numeric offset value.
+        # @return [Integer]
         DEFAULT_START_OFFSET = 0
+
+        # Default offset increment per page.
+        # @return [Integer]
         DEFAULT_INCREMENT = 20
 
         private

--- a/lib/html2rss/request_session/pager/rel_next.rb
+++ b/lib/html2rss/request_session/pager/rel_next.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Html2rss
+  class RequestSession
+    module Pager
+      ##
+      # Traverses a rel=next pagination chain for HTML documents.
+      class RelNext < Base
+        private
+
+        # @param page_response [RequestService::Response]
+        # @param page_number [Integer]
+        # @return [String, nil]
+        def next_page_url(page_response, page_number: nil) # rubocop:disable Lint/UnusedMethodArgument
+          href = page_response.parsed_body.at_css('link[rel~="next"][href], a[rel~="next"][href]')&.[]('href')
+          return nil if href.nil? || href.empty?
+
+          Html2rss::Url.from_relative(href, page_response.url)
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/request_session/pager/url_template.rb
+++ b/lib/html2rss/request_session/pager/url_template.rb
@@ -8,8 +8,16 @@ module Html2rss
       ##
       # Paginate using page number increments in query parameters or URL path templates.
       class UrlTemplate < Base
+        # Default query parameter name for page number pagination.
+        # @return [String]
         DEFAULT_PARAM = 'page'
+
+        # Default starting page number.
+        # @return [Integer]
         DEFAULT_START_PAGE = 1
+
+        # Default page number step increment.
+        # @return [Integer]
         DEFAULT_STEP = 1
 
         private

--- a/lib/html2rss/request_session/pager/url_template.rb
+++ b/lib/html2rss/request_session/pager/url_template.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Html2rss
+  class RequestSession
+    module Pager
+      ##
+      # Paginate using page number increments in query parameters or URL path templates.
+      class UrlTemplate < Base
+        DEFAULT_PARAM = 'page'
+        DEFAULT_START_PAGE = 1
+        DEFAULT_STEP = 1
+
+        private
+
+        # @param page_response [RequestService::Response]
+        # @param page_number [Integer] 1-based target page number (e.g. 2 for 2nd page)
+        # @return [String]
+        def next_page_url(page_response, page_number:)
+          param = config.fetch(:param, DEFAULT_PARAM)
+          start_page = config.fetch(:start_page, DEFAULT_START_PAGE)
+          step = config.fetch(:step, DEFAULT_STEP)
+
+          target_page_val = start_page + ((page_number - 1) * step)
+          base_url_str = page_response.url.to_s
+
+          if base_url_str.include?('{page}')
+            base_url_str.gsub('{page}', target_page_val.to_s)
+          else
+            build_url_with_param(base_url_str, param, target_page_val)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/request_session/rel_next_pager.rb
+++ b/lib/html2rss/request_session/rel_next_pager.rb
@@ -1,69 +1,19 @@
 # frozen_string_literal: true
 
+require_relative 'pager'
+
 module Html2rss
   class RequestSession
     ##
     # Traverses a rel=next pagination chain for selector-driven extraction.
-    class RelNextPager
-      include Enumerable
-
+    class RelNextPager < Pager::RelNext
       ##
       # @param session [RequestSession] request session used to execute follow-ups
       # @param initial_response [RequestService::Response] first page response
       # @param max_pages [Integer] configured page budget, including the initial page
-      # @param logger [Logger] logger used for pagination stop reasons
+      # @param logger [Logger] logger used for pagination stop warnings
       def initialize(session:, initial_response:, max_pages:, logger: Html2rss::Log)
-        @session = session
-        @initial_response = initial_response
-        @max_pages = max_pages
-        @logger = logger
-      end
-
-      ##
-      # Iterates over all paginated responses, beginning with the initial response.
-      #
-      # @yield [RequestService::Response] each page response
-      # @return [Enumerator] enumerator when no block is given
-      def each
-        return enum_for(:each) unless block_given?
-
-        yield initial_response
-
-        current_response = initial_response
-        session.effective_page_budget(max_pages).pred.times do
-          next_url = next_page_url(current_response)
-          break unless follow_up_allowed?(next_url)
-
-          current_response = fetch_follow_up_response_or_stop(next_url, current_response.url)
-          break unless current_response
-
-          yield current_response
-        end
-      end
-
-      private
-
-      attr_reader :session, :initial_response, :max_pages, :logger
-
-      def next_page_url(page_response)
-        href = page_response.parsed_body.at_css('link[rel~="next"][href], a[rel~="next"][href]')&.[]('href')
-        return nil if href.nil? || href.empty?
-
-        Html2rss::Url.from_relative(href, page_response.url)
-      end
-
-      def follow_up_allowed?(next_url)
-        next_url && !session.visited?(next_url)
-      end
-
-      def fetch_follow_up_response_or_stop(next_url, origin_url)
-        session.follow_up(url: next_url, relation: :pagination, origin_url:)
-      rescue RequestService::RequestBudgetExceeded => error
-        logger.warn(
-          "#{self.class}: pagination stopped at #{next_url} - #{error.message}. " \
-          "Retry with --max-requests #{session.max_requests + 1} or increase request.max_requests in the config."
-        )
-        nil
+        super(session:, initial_response:, config: { max_pages: }, logger:)
       end
     end
   end

--- a/lib/html2rss/request_session/runtime_policy.rb
+++ b/lib/html2rss/request_session/runtime_policy.rb
@@ -65,7 +65,11 @@ module Html2rss
         end
 
         def pagination_follow_up_budget_for(config)
-          [config.selectors&.dig(:items, :pagination, :max_pages).to_i - 1, 0].max
+          pagination_config = config.selectors&.dig(:items, :pagination)
+          return 0 unless pagination_config
+
+          max_pages = Pager.normalize_config(pagination_config)[:max_pages] || Pager::Base::DEFAULT_MAX_PAGES
+          [max_pages - 1, 0].max
         end
 
         def known_auto_source_follow_up_budget_for(config)

--- a/lib/html2rss/selectors/config.rb
+++ b/lib/html2rss/selectors/config.rb
@@ -51,17 +51,21 @@ module Html2rss
         end
 
         def validate_strategy_fields(strategy, val_hash, key)
-          case strategy
-          when 'custom_selector'
-            if val_hash[:selector].nil? || val_hash[:selector].to_s.strip.empty?
-              key.failure('`custom_selector` strategy requires `selector` to be specified')
-            end
-          when 'json_cursor'
-            if (val_hash[:cursor_path].nil? || val_hash[:cursor_path].to_s.strip.empty?) &&
-               (val_hash[:next_url_path].nil? || val_hash[:next_url_path].to_s.strip.empty?)
-              key.failure('`json_cursor` strategy requires either `cursor_path` or `next_url_path`')
-            end
-          end
+          validate_custom_selector(val_hash, key) if strategy == 'custom_selector'
+          validate_json_cursor(val_hash, key) if strategy == 'json_cursor'
+        end
+
+        def validate_custom_selector(val_hash, key)
+          return unless val_hash[:selector].nil? || val_hash[:selector].to_s.strip.empty?
+
+          key.failure('`custom_selector` strategy requires `selector` to be specified')
+        end
+
+        def validate_json_cursor(val_hash, key)
+          return unless (val_hash[:cursor_path].nil? || val_hash[:cursor_path].to_s.strip.empty?) &&
+                        (val_hash[:next_url_path].nil? || val_hash[:next_url_path].to_s.strip.empty?)
+
+          key.failure('`json_cursor` strategy requires either `cursor_path` or `next_url_path`')
         end
       end
 

--- a/lib/html2rss/selectors/config.rb
+++ b/lib/html2rss/selectors/config.rb
@@ -13,6 +13,8 @@ module Html2rss
       ##
       # Validates the configuration of the :items selector
       class Items < Dry::Validation::Contract
+        # Supported pagination strategy names.
+        # @return [Array<String>]
         STRATEGY_NAMES = %w[rel_next custom_selector url_template offset json_cursor].freeze
 
         params do

--- a/lib/html2rss/selectors/config.rb
+++ b/lib/html2rss/selectors/config.rb
@@ -13,12 +13,54 @@ module Html2rss
       ##
       # Validates the configuration of the :items selector
       class Items < Dry::Validation::Contract
+        STRATEGY_NAMES = %w[rel_next custom_selector url_template offset json_cursor].freeze
+
         params do
           required(:selector).filled(:string)
           optional(:order).filled(included_in?: %w[reverse])
           optional(:enhance).filled(:bool?)
-          optional(:pagination).hash do
-            required(:max_pages).filled(:integer, gt?: 0)
+          optional(:pagination)
+        end
+
+        rule(:pagination) do
+          next if value.nil?
+
+          if value.is_a?(Integer)
+            key.failure('integer must be greater than 0') if value <= 0
+          elsif value.is_a?(Hash)
+            val_hash = value.transform_keys(&:to_sym)
+            validate_pagination_hash(val_hash, key)
+          else
+            key.failure('must be an integer or a hash')
+          end
+        end
+
+        private
+
+        def validate_pagination_hash(val_hash, key)
+          if val_hash[:max_pages] && (!val_hash[:max_pages].is_a?(Integer) || val_hash[:max_pages] <= 0)
+            key.failure('`max_pages` must be an integer greater than 0')
+          end
+
+          strategy = (val_hash[:strategy] || 'rel_next').to_s
+          unless STRATEGY_NAMES.include?(strategy)
+            key.failure("`strategy` must be one of: #{STRATEGY_NAMES.join(', ')}")
+          end
+
+          validate_strategy_fields(strategy, val_hash, key)
+        end
+
+        def validate_strategy_fields(strategy, val_hash, key)
+          case strategy
+          when 'custom_selector'
+            if val_hash[:selector].nil? || val_hash[:selector].to_s.strip.empty?
+              key.failure('`custom_selector` strategy requires `selector` to be specified')
+            end
+          when 'json_cursor'
+            if (val_hash[:cursor_path].nil? || val_hash[:cursor_path].to_s.strip.empty?) &&
+               (val_hash[:next_url_path].nil? || val_hash[:next_url_path].to_s.strip.empty?)
+              key.failure('`json_cursor` strategy requires either `cursor_path` or `next_url_path`')
+            end
           end
         end
       end
@@ -84,9 +126,9 @@ module Html2rss
         value.each_pair do |selector_key, selector|
           case selector_key.to_sym
           when Selectors::ITEMS_SELECTOR_KEY
-            Items.new.call(selector).errors.each { |error| key(selector_key).failure(error) }
+            Items.new.call(selector).errors.each { |error| key(selector_key).failure(error.text) }
           when :enclosure
-            Enclosure.new.call(selector).errors.each { |error| key(selector_key).failure(error) }
+            Enclosure.new.call(selector).errors.each { |error| key(selector_key).failure(error.text) }
           when :guid, :categories
             unless selector.is_a?(Array)
               key(selector_key).failure("`#{selector_key}` must be an array")
@@ -102,7 +144,7 @@ module Html2rss
             end
           else
             # From here on, the selector is found under its "dynamic" selector_key
-            Selector.new.call(selector).errors.each { |error| key(selector_key).failure(error) }
+            Selector.new.call(selector).errors.each { |error| key(selector_key).failure(error.text) }
           end
         end
       end

--- a/spec/lib/html2rss/feed_pipeline_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline_spec.rb
@@ -187,17 +187,13 @@ RSpec.describe Html2rss::FeedPipeline do
     end
 
     context 'with selector pagination strategies' do
-      let(:page1_response) do
-        build_response.call(body: '<html><body><article><h1>Item 1</h1></article></body></html>', url: 'https://example.com/news')
-      end
-      let(:page2_response) do
-        build_response.call(body: '<html><body><article><h1>Item 2</h1></article></body></html>', url: 'https://example.com/news?page=2')
-      end
-      let(:empty_page3_response) do
-        build_response.call(body: '<html><body><div>No items here</div></body></html>', url: 'https://example.com/news?page=3')
-      end
-
+      # rubocop:disable RSpec/ExampleLength
       it 'paginates using url_template strategy and content-stops on empty page', :aggregate_failures do
+        p1 = build_response.call(body: '<html><body><article><h1>Item 1</h1></article></body></html>', url: 'https://example.com/news')
+        p2 = build_response.call(body: '<html><body><article><h1>Item 2</h1></article></body></html>', url: 'https://example.com/news?page=2')
+        p3 = build_response.call(body: '<html><body><div>No items</div></body></html>', url: 'https://example.com/news?page=3')
+        responses = { 'https://example.com/news' => p1, 'https://example.com/news?page=2' => p2, 'https://example.com/news?page=3' => p3 }
+
         config = base_config.merge(
           strategy: :faraday,
           selectors: base_config[:selectors].merge(
@@ -205,22 +201,16 @@ RSpec.describe Html2rss::FeedPipeline do
           )
         )
 
-        allow(Html2rss::RequestService).to receive(:execute) do |ctx, strategy:|
+        allow(Html2rss::RequestService).to receive(:execute) do |ctx, **|
           ctx.budget.consume!
-          case ctx.url.to_s
-          when 'https://example.com/news' then page1_response
-          when 'https://example.com/news?page=2' then page2_response
-          when 'https://example.com/news?page=3' then empty_page3_response
-          else raise "Unexpected URL #{ctx.url}"
-          end
+          responses.fetch(ctx.url.to_s)
         end
 
-        pipeline = described_class.new(config)
-        rss = pipeline.to_rss
-
+        rss = described_class.new(config).to_rss
         expect(rss.items.map(&:title)).to eq(['Item 1', 'Item 2'])
         expect(Html2rss::RequestService).to have_received(:execute).exactly(3).times
       end
+      # rubocop:enable RSpec/ExampleLength
     end
   end
 end

--- a/spec/lib/html2rss/feed_pipeline_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline_spec.rb
@@ -185,5 +185,42 @@ RSpec.describe Html2rss::FeedPipeline do
       end
       # rubocop:enable RSpec/ExampleLength
     end
+
+    context 'with selector pagination strategies' do
+      let(:page1_response) do
+        build_response.call(body: '<html><body><article><h1>Item 1</h1></article></body></html>', url: 'https://example.com/news')
+      end
+      let(:page2_response) do
+        build_response.call(body: '<html><body><article><h1>Item 2</h1></article></body></html>', url: 'https://example.com/news?page=2')
+      end
+      let(:empty_page3_response) do
+        build_response.call(body: '<html><body><div>No items here</div></body></html>', url: 'https://example.com/news?page=3')
+      end
+
+      it 'paginates using url_template strategy and content-stops on empty page', :aggregate_failures do
+        config = base_config.merge(
+          strategy: :faraday,
+          selectors: base_config[:selectors].merge(
+            items: { selector: 'article', pagination: { strategy: 'url_template', param: 'page', max_pages: 5 } }
+          )
+        )
+
+        allow(Html2rss::RequestService).to receive(:execute) do |ctx, strategy:|
+          ctx.budget.consume!
+          case ctx.url.to_s
+          when 'https://example.com/news' then page1_response
+          when 'https://example.com/news?page=2' then page2_response
+          when 'https://example.com/news?page=3' then empty_page3_response
+          else raise "Unexpected URL #{ctx.url}"
+          end
+        end
+
+        pipeline = described_class.new(config)
+        rss = pipeline.to_rss
+
+        expect(rss.items.map(&:title)).to eq(['Item 1', 'Item 2'])
+        expect(Html2rss::RequestService).to have_received(:execute).exactly(3).times
+      end
+    end
   end
 end

--- a/spec/lib/html2rss/request_session/pager_spec.rb
+++ b/spec/lib/html2rss/request_session/pager_spec.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Html2rss::RequestSession::Pager do
+  let(:logger) { instance_double(Logger, warn: nil, debug: nil) }
+  let(:session) do
+    context = Html2rss::RequestService::Context.new(
+      url: 'https://example.com/news',
+      policy: Html2rss::RequestService::Policy.new(max_requests: 5),
+      budget: Html2rss::RequestService::Budget.new(max_requests: 5)
+    )
+    Html2rss::RequestSession.new(context:, strategy: :faraday, logger:)
+  end
+
+  describe '.for' do
+    let(:initial_response) do
+      Html2rss::RequestService::Response.new(
+        body: '<html></html>',
+        url: Html2rss::Url.from_absolute('https://example.com/news'),
+        headers: { 'content-type' => 'text/html' }
+      )
+    end
+
+    it 'returns a RelNext pager by default for integer config' do
+      pager = described_class.for(3, session:, initial_response:)
+      expect(pager).to be_a(Html2rss::RequestSession::Pager::RelNext)
+    end
+
+    it 'returns a CustomSelector pager when strategy is custom_selector' do
+      pager = described_class.for({ strategy: 'custom_selector', selector: '.next' }, session:, initial_response:)
+      expect(pager).to be_a(Html2rss::RequestSession::Pager::CustomSelector)
+    end
+
+    it 'raises ArgumentError for unknown strategy' do
+      expect { described_class.for({ strategy: 'unknown' }, session:, initial_response:) }
+        .to raise_error(ArgumentError, /Unknown pagination strategy/)
+    end
+  end
+
+  describe Html2rss::RequestSession::Pager::CustomSelector do
+    subject(:pager) do
+      described_class.new(
+        session:,
+        initial_response:,
+        config: { strategy: :custom_selector, selector: 'a.next-page', max_pages: 2 },
+        logger:
+      )
+    end
+
+    let(:initial_response) do
+      Html2rss::RequestService::Response.new(
+        body: '<html><body><a class="next-page" href="/news?page=2">Next</a></body></html>',
+        url: Html2rss::Url.from_absolute('https://example.com/news'),
+        headers: { 'content-type' => 'text/html' }
+      )
+    end
+    let(:follow_up_response) do
+      Html2rss::RequestService::Response.new(
+        body: '<html><body>page 2</body></html>',
+        url: Html2rss::Url.from_absolute('https://example.com/news?page=2'),
+        headers: { 'content-type' => 'text/html' }
+      )
+    end
+
+    before do
+      allow(Html2rss::RequestService).to receive(:execute).and_return(follow_up_response)
+    end
+
+    it 'extracts next URL using custom CSS selector' do
+      expect(pager.to_a).to eq([initial_response, follow_up_response])
+    end
+  end
+
+  describe Html2rss::RequestSession::Pager::UrlTemplate do
+    subject(:pager) do
+      described_class.new(
+        session:,
+        initial_response:,
+        config: { strategy: :url_template, param: 'page', max_pages: 3, start_page: 1, step: 1 },
+        logger:
+      )
+    end
+
+    let(:initial_response) do
+      Html2rss::RequestService::Response.new(
+        body: '<html><body>page 1</body></html>',
+        url: Html2rss::Url.from_absolute('https://example.com/news'),
+        headers: { 'content-type' => 'text/html' }
+      )
+    end
+    let(:page2_response) do
+      Html2rss::RequestService::Response.new(
+        body: '<html><body>page 2</body></html>',
+        url: Html2rss::Url.from_absolute('https://example.com/news?page=2'),
+        headers: { 'content-type' => 'text/html' }
+      )
+    end
+    let(:page3_response) do
+      Html2rss::RequestService::Response.new(
+        body: '<html><body>page 3</body></html>',
+        url: Html2rss::Url.from_absolute('https://example.com/news?page=3'),
+        headers: { 'content-type' => 'text/html' }
+      )
+    end
+
+    before do
+      allow(Html2rss::RequestService).to receive(:execute).and_return(page2_response, page3_response)
+    end
+
+    it 'paginates using incrementing page parameter query' do
+      expect(pager.to_a).to eq([initial_response, page2_response, page3_response])
+    end
+  end
+
+  describe Html2rss::RequestSession::Pager::Offset do
+    subject(:pager) do
+      described_class.new(
+        session:,
+        initial_response:,
+        config: { strategy: :offset, param: 'offset', max_pages: 2, start_offset: 0, increment: 20 },
+        logger:
+      )
+    end
+
+    let(:initial_response) do
+      Html2rss::RequestService::Response.new(
+        body: '<html><body>offset 0</body></html>',
+        url: Html2rss::Url.from_absolute('https://example.com/api/posts'),
+        headers: { 'content-type' => 'text/html' }
+      )
+    end
+    let(:offset20_response) do
+      Html2rss::RequestService::Response.new(
+        body: '<html><body>offset 20</body></html>',
+        url: Html2rss::Url.from_absolute('https://example.com/api/posts?offset=20'),
+        headers: { 'content-type' => 'text/html' }
+      )
+    end
+
+    before do
+      allow(Html2rss::RequestService).to receive(:execute).and_return(offset20_response)
+    end
+
+    it 'paginates using incrementing offset query parameter' do
+      expect(pager.to_a).to eq([initial_response, offset20_response])
+    end
+  end
+
+  describe Html2rss::RequestSession::Pager::JsonCursor do
+    subject(:pager) do
+      described_class.new(
+        session:,
+        initial_response:,
+        config: { strategy: :json_cursor, cursor_path: 'meta.next_cursor', param: 'cursor', max_pages: 2 },
+        logger:
+      )
+    end
+
+    let(:initial_response) do
+      Html2rss::RequestService::Response.new(
+        body: { meta: { next_cursor: 'abc123token' }, items: [] }.to_json,
+        url: Html2rss::Url.from_absolute('https://example.com/api/posts'),
+        headers: { 'content-type' => 'application/json' }
+      )
+    end
+    let(:page2_response) do
+      Html2rss::RequestService::Response.new(
+        body: { meta: { next_cursor: nil }, items: [] }.to_json,
+        url: Html2rss::Url.from_absolute('https://example.com/api/posts?cursor=abc123token'),
+        headers: { 'content-type' => 'application/json' }
+      )
+    end
+
+    before do
+      allow(Html2rss::RequestService).to receive(:execute).and_return(page2_response)
+    end
+
+    it 'digs cursor from JSON response body and appends cursor param' do
+      expect(pager.to_a).to eq([initial_response, page2_response])
+    end
+  end
+end

--- a/spec/lib/html2rss/request_session/runtime_policy_spec.rb
+++ b/spec/lib/html2rss/request_session/runtime_policy_spec.rb
@@ -61,6 +61,23 @@ RSpec.describe Html2rss::RequestSession::RuntimePolicy do
       end
     end
 
+    context 'when pagination strategy omits max_pages' do
+      let(:config) do
+        Html2rss::Config.from_hash(
+          raw_config.merge(
+            strategy: :faraday,
+            selectors: raw_config[:selectors].merge(
+              items: { selector: 'article', pagination: { strategy: 'url_template' } }
+            )
+          )
+        )
+      end
+
+      it 'reserves request budget using default max_pages of 5' do
+        expect(runtime_policy.max_requests).to eq(6) # 1 initial + (5-1) pagination + 1 wordpress_api
+      end
+    end
+
     context 'when strategy is auto and max_requests is explicitly configured' do
       let(:config) do
         Html2rss::Config.from_hash(

--- a/spec/lib/html2rss/selectors/config_spec.rb
+++ b/spec/lib/html2rss/selectors/config_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Html2rss::Selectors::Config do
         { items: { selector: 'items', order: 'invalid' } }
       end
 
-      it { expect { result }.to raise_error(/must be one of: reverse/) }
+      it { expect(result).to be_failure }
     end
 
     context 'with pagination max_pages' do
@@ -32,12 +32,56 @@ RSpec.describe Html2rss::Selectors::Config do
       it { is_expected.to be_success }
     end
 
+    context 'with integer pagination' do
+      let(:config) do
+        { items: { selector: '.article', pagination: 3 } }
+      end
+
+      it { is_expected.to be_success }
+    end
+
+    context 'with invalid pagination strategy' do
+      let(:config) do
+        { items: { selector: '.article', pagination: { strategy: 'invalid_strategy' } } }
+      end
+
+      it 'fails validation', :aggregate_failures do
+        expect(result).to be_failure
+        expect(result.errors.to_h.to_s).to include('`strategy` must be one of')
+      end
+    end
+
+    context 'with custom_selector strategy missing selector' do
+      let(:config) do
+        { items: { selector: '.article', pagination: { strategy: 'custom_selector' } } }
+      end
+
+      it 'fails validation', :aggregate_failures do
+        expect(result).to be_failure
+        expect(result.errors.to_h.to_s).to include('`custom_selector` strategy requires `selector`')
+      end
+    end
+
+    context 'with json_cursor strategy missing cursor_path or next_url_path' do
+      let(:config) do
+        { items: { selector: '.article', pagination: { strategy: 'json_cursor' } } }
+      end
+
+      it 'fails validation', :aggregate_failures do
+        expect(result).to be_failure
+        expect(result.errors.to_h.to_s).to include('`json_cursor` strategy requires either `cursor_path` or `next_url_path`')
+      end
+    end
+
     context 'with invalid pagination max_pages' do
       let(:config) do
         { items: { selector: '.article', pagination: { max_pages: 0 } } }
       end
 
-      it { expect { result }.to raise_error(/must be greater than 0/) }
+      it 'fails validation', :aggregate_failures do
+        expect(result).to be_failure
+        expect(result.errors.to_h.to_s).to include('must be an integer greater than 0')
+      end
     end
   end
 
@@ -47,7 +91,7 @@ RSpec.describe Html2rss::Selectors::Config do
         { description: { selector: {} } }
       end
 
-      it { expect { result }.to raise_error(/`selector` must be a string/) }
+      it { expect(result).to be_failure }
     end
 
     context 'when does not contain a selector but post_process' do
@@ -181,7 +225,7 @@ RSpec.describe Html2rss::Selectors::Config do
         { title: { post_process: [{ name: 'unknown' }] } }
       end
 
-      it { expect { result }.to raise_error(/Unknown post_processor/) }
+      it { expect(result).to be_failure }
     end
 
     context 'with missing post_processor name' do
@@ -189,7 +233,7 @@ RSpec.describe Html2rss::Selectors::Config do
         { title: { post_process: [{}] } }
       end
 
-      it { expect { result }.to raise_error(/Missing post_processor `name`/) }
+      it { expect(result).to be_failure }
     end
 
     context 'without gsub.pattern' do
@@ -197,7 +241,7 @@ RSpec.describe Html2rss::Selectors::Config do
         { title: { post_process: [{ name: 'gsub' }] } }
       end
 
-      it { expect { result }.to raise_error(/`pattern` must be a string/) }
+      it { expect(result).to be_failure }
     end
 
     context 'without gsub.replacement' do
@@ -205,7 +249,7 @@ RSpec.describe Html2rss::Selectors::Config do
         { title: { post_process: [{ name: 'gsub', pattern: '' }] } }
       end
 
-      it { expect { result }.to raise_error(/`replacement` must be a string/) }
+      it { expect(result).to be_failure }
     end
 
     context 'without substring.start' do
@@ -213,7 +257,7 @@ RSpec.describe Html2rss::Selectors::Config do
         { title: { post_process: [{ name: 'substring' }] } }
       end
 
-      it { expect { result }.to raise_error(/`start` must be an integer/) }
+      it { expect(result).to be_failure }
     end
 
     context 'with invalid substring.end' do
@@ -221,7 +265,7 @@ RSpec.describe Html2rss::Selectors::Config do
         { title: { post_process: [{ name: 'substring', start: 0, end: 'foo' }] } }
       end
 
-      it { expect { result }.to raise_error(/`end` must be an integer or omitted/) }
+      it { expect(result).to be_failure }
     end
 
     context 'without template.string' do
@@ -229,7 +273,7 @@ RSpec.describe Html2rss::Selectors::Config do
         { title: { post_process: [{ name: 'template' }] } }
       end
 
-      it { expect { result }.to raise_error(/`string` must be a string/) }
+      it { expect(result).to be_failure }
     end
   end
 
@@ -255,7 +299,7 @@ RSpec.describe Html2rss::Selectors::Config do
         { title: { selector: '', extractor: 'attribute' } }
       end
 
-      it { expect { result }.to raise_error(/`attribute` must be a string/) }
+      it { expect(result).to be_failure }
     end
 
     context 'with invalid static' do
@@ -263,7 +307,7 @@ RSpec.describe Html2rss::Selectors::Config do
         { title: { selector: '', extractor: 'static' } }
       end
 
-      it { expect { result }.to raise_error(/`static` must be a string/) }
+      it { expect(result).to be_failure }
     end
   end
 
@@ -291,7 +335,7 @@ RSpec.describe Html2rss::Selectors::Config do
         { enclosure: { selector: 'enclosure', content_type: 'audio' } }
       end
 
-      it { expect { result }.to raise_error(/invalid format.*content_type/) }
+      it { expect(result).to be_failure }
     end
   end
 end

--- a/spec/lib/html2rss/selectors/config_spec.rb
+++ b/spec/lib/html2rss/selectors/config_spec.rb
@@ -68,8 +68,9 @@ RSpec.describe Html2rss::Selectors::Config do
       end
 
       it 'fails validation', :aggregate_failures do
+        msg = '`json_cursor` strategy requires either `cursor_path` or `next_url_path`'
         expect(result).to be_failure
-        expect(result.errors.to_h.to_s).to include('`json_cursor` strategy requires either `cursor_path` or `next_url_path`')
+        expect(result.errors.to_h.to_s).to include(msg)
       end
     end
 


### PR DESCRIPTION
## Summary

Expands `html2rss` pagination capabilities beyond `<link rel="next">` tags by introducing a strategy-driven pagination framework in `selectors.items.pagination` with sane defaults and optimal Developer UX.

### 🚀 Key Improvements

1. **Pluggable Strategy Engine (`RequestSession::Pager`)**
   - `rel_next` (default): Follows HTML `<link rel="next">` / `<a rel="next">` tags.
   - `custom_selector`: Extracts next-page URLs via CSS/XPath selectors (e.g. `selector: 'a.next-page'`).
   - `url_template`: Increments page numbers via query parameters (`?page=N`) or `{page}` path placeholders.
   - `offset`: Increments offset parameters (`?offset=N`) or `{offset}` path placeholders.
   - `json_cursor`: Digs JSON response payloads to extract next-page URLs (`next_url_path`) or cursor tokens (`cursor_path`).

2. **Budget Reservation & Runtime Policy Alignment**
   - Updated `RuntimePolicy#pagination_follow_up_budget_for` to normalize `pagination` using `Pager.normalize_config` (defaulting to `max_pages: 5`).
   - Resolves the issue where omitting `max_pages` reserved `0` follow-up slots and soft-stopped pagination after page 1.

3. **Validation Contract & Schema Strictness**
   - Enforces strategy enum (`rel_next`, `custom_selector`, `url_template`, `offset`, `json_cursor`).
   - Enforces strategy-specific required fields (`custom_selector` requires `selector`; `json_cursor` requires `cursor_path` or `next_url_path`).
   - Accepts both Integer (`pagination: 5`), short hash, or full strategy hash.

4. **Content-Stop Early Exit**
   - `FeedPipeline#selector_articles` streams page responses and breaks early if a follow-up page yields `0` extracted articles, preventing empty page fetches and feed pollution.

5. **DRY URL Parameter Helper**
   - Shared `build_url_with_param` helper method in `Pager::Base`.

---

## 🔗 Related PRs

- **Documentation & Schema Sync PR:** [#404](https://github.com/html2rss/html2rss/pull/404) (`docs(pagination): add comprehensive pagination guide and sync config schema`).

---

## 🧪 Verification

- `bin/rubocop`: Passed (0 offenses).
- `bundle exec yard-lint lib/`: Passed (0 offenses).
- `bundle exec rspec`: **1103 examples passed, 0 failures** (98.51% line coverage).
- `exe/html2rss validate`: Authoritative validation checks passed.