### PR TITLE
feat(pagination): generalized multi-strategy pagination framework

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,5 +134,6 @@ Produce RSS 2.0 feeds from websites by scraping HTML or JSON. Adapt your strateg
 
 - Use `make quick` during implementation for the fast local feedback loop. It should stay focused on changed-file linting and targeted specs.
 - Treat `make ready` as the implementation quality gate before handoff or a potential PR merge. It must cover the repo's required merge checks.
+- When adding or modifying configuration options in `lib/html2rss/selectors/config.rb` or `lib/html2rss/config/validator.rb`, update `lib/html2rss/config/schema.rb` (`Html2rss::Config::Schema`) so the property is exported to the JSON schema, then run `make schema` to sync `schema/html2rss-config.schema.json`.
 - Treat YARD linting as a contract-integrity check for contributor-facing APIs and documentation syntax correctness. Keep validator scope high-signal; avoid baseline/todo suppression files as a long-term mechanism.
 - Run Ruby, Bundler, Rake, RuboCop, Reek, YARD, and RSpec commands through `mise exec -- ...` directly or via Make targets.

--- a/README.md
+++ b/README.md
@@ -13,181 +13,28 @@ Most people looking for a first working feed should start with `html2rss-web`, r
 Detailed usage guides, reference docs, and the feed directory live on the project website:
 
 - [Ruby gem documentation](https://html2rss.github.io/ruby-gem)
+- [Request strategies](https://html2rss.github.io/ruby-gem/reference/strategy) (`auto`, `faraday`, `botasaurus`, `browserless`)
+- [Selectors & pagination](https://html2rss.github.io/ruby-gem/reference/selectors#paginated-feeds)
 - [Web application](https://html2rss.github.io/web-application)
 - [Feed directory](https://html2rss.github.io/feed-directory)
 - [Contributing guide](https://html2rss.github.io/get-involved/contributing)
 - [GitHub Discussions](https://github.com/orgs/html2rss/discussions)
 - [Sponsor on GitHub](https://github.com/sponsors/gildesmarais)
 
-### 💻 Try in Browser
+Cloud development: [Open in GitHub Codespaces](https://github.com/codespaces/new?repo=html2rss/html2rss) (also covered in the [installation guide](https://html2rss.github.io/ruby-gem/installation)).
 
-You can develop html2rss directly in your browser using GitHub Codespaces:
+## Architecture
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?repo=html2rss/html2rss)
-
-The Codespace comes pre-configured with Ruby 3.4 (compatible with Ruby 4.0), all dependencies, and VS Code extensions ready to go!
-
-## 🤝 Contributing
-
-Please see the [contributing guide](https://html2rss.github.io/get-involved/contributing) for details on how to contribute.
-
-## 🏗️ Architecture
-
-### Core Components
-
-1. **Config** - Loads and validates configuration (YAML/hash)
-2. **RequestService** - Fetches pages using Faraday, Botasaurus, or Browserless
-3. **Selectors** - Extracts content via CSS selectors with extractors/post-processors
-4. **AutoSource** - Auto-detects content using Schema.org, JSON state blobs, semantic HTML, and structural patterns
-5. **RssBuilder** - Assembles Article objects and renders RSS 2.0
-
-### Data Flow
+1. **Config** — loads and validates configuration (YAML/hash); schema via `html2rss schema` / `schema/html2rss-config.schema.json`
+2. **RequestService** — fetches pages (`faraday`, `botasaurus`, or `browserless`)
+3. **Selectors** — extracts content via CSS selectors with extractors/post-processors
+4. **AutoSource** — auto-detects content (Schema.org, JSON state, semantic HTML, structural patterns)
+5. **RssBuilder** — assembles Article objects and renders RSS 2.0
 
 ```text
 Config -> Request -> Extraction -> Processing -> Building -> Output
 ```
 
-### Request Strategies
+## License
 
-- `auto` (default): pipeline fallback orchestration (`faraday` -> `botasaurus` -> `browserless`) based on extraction outcome and retry policy.
-- `faraday`: direct HTTP fetch.
-- `botasaurus`: delegates fetching to a Botasaurus scrape API. Requires `BOTASAURUS_SCRAPER_URL` (for example `http://localhost:4010`).
-- `browserless`: remote browser rendering via Browserless (`BROWSERLESS_IO_WEBSOCKET_URL` and token as needed).
-
-Auto fallback shares one request budget across all strategy attempts. For pagination-heavy or dynamic pages, increase `request.max_requests` (or `--max-requests`) when retries exhaust the budget.
-
-### Pagination Strategies
-
-Configure `selectors.items.pagination` to fetch items across multiple pages:
-
-- **`rel_next`** (default): Follows `<link rel="next">` or `<a rel="next">` tags.
-  ```yaml
-  selectors:
-    items:
-      selector: article
-      pagination: 5 # or { max_pages: 5 }
-  ```
-- **`custom_selector`**: Follows a custom CSS/XPath next-link selector.
-  ```yaml
-  selectors:
-    items:
-      selector: article
-      pagination:
-        strategy: custom_selector
-        selector: 'a.next-page'
-        max_pages: 5
-  ```
-- **`url_template`**: Increments a query parameter (`?page=N`) or path template (`/page/{page}/`).
-  ```yaml
-  selectors:
-    items:
-      selector: article
-      pagination:
-        strategy: url_template
-        param: page
-        max_pages: 5
-  ```
-- **`offset`**: Increments offset values (`?offset=N`).
-  ```yaml
-  selectors:
-    items:
-      selector: article
-      pagination:
-        strategy: offset
-        param: offset
-        increment: 20
-        max_pages: 5
-  ```
-- **`json_cursor`**: Digs next-page URLs or cursor tokens from JSON responses.
-  ```yaml
-  selectors:
-    items:
-      selector: items
-      pagination:
-        strategy: json_cursor
-        cursor_path: meta.next_cursor # or next_url_path: links.next
-        param: cursor
-        max_pages: 5
-  ```
-
-*Stop conditions*: Pagination stops automatically when `max_pages` or request budget is reached, a page yields 0 new items, an already visited URL is encountered, or a network error occurs.
-
-Auto fallback decisions are hidden at the default `LOG_LEVEL=warn`; run with `LOG_LEVEL=info` to include them in CLI output.
-
-Supported `request.botasaurus` options:
-
-- `navigation_mode` (`auto`, `get`, `google_get`, `google_get_bypass`; default `auto`)
-- `max_retries` (`0..3`; default `2`)
-- `wait_for_selector` (string)
-- `wait_timeout_seconds` (integer)
-- `block_images` (boolean)
-- `block_images_and_css` (boolean)
-- `wait_for_complete_page_load` (boolean)
-- `headless` (boolean, default `false`)
-- `proxy` (string)
-- `user_agent` (string)
-- `window_size` (two-item integer array, for example `[1920, 1080]`)
-- `lang` (string, for example `en-US`)
-
-Minimal YAML config example:
-
-```yaml
-channel:
-  url: https://example.com
-strategy: botasaurus
-auto_source: {}
-request:
-  botasaurus:
-    navigation_mode: auto
-    max_retries: 2
-    headless: false
-```
-
-Example request payload shape:
-
-```json
-{
-  "url": "https://example.com",
-  "navigation_mode": "auto",
-  "max_retries": 2,
-  "headless": false
-}
-```
-
-Example usage:
-
-```bash
-BOTASAURUS_SCRAPER_URL=http://localhost:4010 html2rss auto https://example.com --strategy botasaurus
-```
-
-Policy note: html2rss still enforces local request policy preflight and timeout budget. Botasaurus handles browser navigation/rendering internals, so some policy details are delegated to upstream execution.
-
-### Config schema workflow
-
-The config schema is generated from the runtime `dry-validation` contracts and exported for client-side tooling.
-
-- Ruby API: `Html2rss::Config.json_schema`
-- CLI: `html2rss schema`
-- CLI options:
-  - `html2rss schema --write tmp/html2rss-config.schema.json`
-  - `html2rss schema --no-pretty`
-- Runtime validation API: `Html2rss::Config.validate(config_hash)`
-- Runtime validation CLI: `html2rss validate config.yml`
-- Packaged JSON file: `schema/html2rss-config.schema.json`
-
-If you are an editor integration, automation script, or AI tool, prefer these stable discovery points:
-
-- call `html2rss schema` to read the current exported schema
-- read `schema/html2rss-config.schema.json` when working from the repository or installed gem
-- use `Html2rss::Config.schema_path` if you already have Ruby loaded
-- use `Html2rss::Config.validate` or `html2rss validate config.yml` when you need authoritative runtime validation of selector references
-
-Run `bundle exec rake config:schema` before committing to regenerate `schema/html2rss-config.schema.json` and keep the checked-in JSON Schema in sync with the validators. The exported schema covers client-side validation, while runtime validation remains authoritative for dynamic cross-field checks such as selector-key references.
-
-## 📄 License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## 💖 Sponsoring
-
-If you find `html2rss` useful, please consider [sponsoring the project](https://github.com/sponsors/gildesmarais).
+This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,62 @@ Config -> Request -> Extraction -> Processing -> Building -> Output
 
 Auto fallback shares one request budget across all strategy attempts. For pagination-heavy or dynamic pages, increase `request.max_requests` (or `--max-requests`) when retries exhaust the budget.
 
+### Pagination Strategies
+
+Configure `selectors.items.pagination` to fetch items across multiple pages:
+
+- **`rel_next`** (default): Follows `<link rel="next">` or `<a rel="next">` tags.
+  ```yaml
+  selectors:
+    items:
+      selector: article
+      pagination: 5 # or { max_pages: 5 }
+  ```
+- **`custom_selector`**: Follows a custom CSS/XPath next-link selector.
+  ```yaml
+  selectors:
+    items:
+      selector: article
+      pagination:
+        strategy: custom_selector
+        selector: 'a.next-page'
+        max_pages: 5
+  ```
+- **`url_template`**: Increments a query parameter (`?page=N`) or path template (`/page/{page}/`).
+  ```yaml
+  selectors:
+    items:
+      selector: article
+      pagination:
+        strategy: url_template
+        param: page
+        max_pages: 5
+  ```
+- **`offset`**: Increments offset values (`?offset=N`).
+  ```yaml
+  selectors:
+    items:
+      selector: article
+      pagination:
+        strategy: offset
+        param: offset
+        increment: 20
+        max_pages: 5
+  ```
+- **`json_cursor`**: Digs next-page URLs or cursor tokens from JSON responses.
+  ```yaml
+  selectors:
+    items:
+      selector: items
+      pagination:
+        strategy: json_cursor
+        cursor_path: meta.next_cursor # or next_url_path: links.next
+        param: cursor
+        max_pages: 5
+  ```
+
+*Stop conditions*: Pagination stops automatically when `max_pages` or request budget is reached, a page yields 0 new items, an already visited URL is encountered, or a network error occurs.
+
 Auto fallback decisions are hidden at the default `LOG_LEVEL=warn`; run with `LOG_LEVEL=info` to include them in CLI output.
 
 Supported `request.botasaurus` options:

--- a/lib/html2rss/config/schema.rb
+++ b/lib/html2rss/config/schema.rb
@@ -139,18 +139,22 @@ module Html2rss
         end
 
         # @return [Hash{Symbol => Object}] schema fragment for pagination object properties
+        # rubocop:disable Metrics/MethodLength -- property map mirrors runtime pager keys 1:1
         def pagination_properties
           {
             strategy: { type: 'string', enum: %w[rel_next custom_selector url_template offset json_cursor] },
             max_pages: { type: 'integer', exclusiveMinimum: 0 },
             selector: { type: 'string' },
             param: { type: 'string' },
-            start: { type: 'integer' },
+            start_page: { type: 'integer' },
+            step: { type: 'integer', exclusiveMinimum: 0 },
+            start_offset: { type: 'integer' },
             increment: { type: 'integer', exclusiveMinimum: 0 },
             cursor_path: { type: 'string' },
             next_url_path: { type: 'string' }
           }
         end
+        # rubocop:enable Metrics/MethodLength
 
         # @return [Hash{Symbol => Object}] schema fragment for auto_source configuration
         def auto_source

--- a/lib/html2rss/config/schema.rb
+++ b/lib/html2rss/config/schema.rb
@@ -121,6 +121,37 @@ module Html2rss
           }
         end
 
+        # @return [Hash{Symbol => Object}] schema fragment for pagination configuration
+        def pagination
+          {
+            description: 'Pagination configuration or maximum page count integer.',
+            oneOf: [{ type: 'integer', exclusiveMinimum: 0 }, pagination_object_schema]
+          }
+        end
+
+        # @return [Hash{Symbol => Object}] schema fragment for object-style pagination configuration
+        def pagination_object_schema
+          {
+            type: 'object',
+            properties: pagination_properties,
+            additionalProperties: true
+          }
+        end
+
+        # @return [Hash{Symbol => Object}] schema fragment for pagination object properties
+        def pagination_properties
+          {
+            strategy: { type: 'string', enum: %w[rel_next custom_selector url_template offset json_cursor] },
+            max_pages: { type: 'integer', exclusiveMinimum: 0 },
+            selector: { type: 'string' },
+            param: { type: 'string' },
+            start: { type: 'integer' },
+            increment: { type: 'integer', exclusiveMinimum: 0 },
+            cursor_path: { type: 'string' },
+            next_url_path: { type: 'string' }
+          }
+        end
+
         # @return [Hash{Symbol => Object}] schema fragment for auto_source configuration
         def auto_source
           schema = Html2rss::AutoSource::Config.json_schema(loose: true)
@@ -179,9 +210,11 @@ module Html2rss
 
         # @return [Hash{Symbol => Object}] schema fragment for `items` selector configuration
         def items_schema
-          Html2rss::Selectors::Config::Items.new.schema.json_schema(loose: true).merge(
+          schema = Html2rss::Selectors::Config::Items.new.schema.json_schema(loose: true).merge(
             description: 'Defines the items selector and optional enhancement settings.'
           )
+          schema[:properties][:pagination] = Components.pagination
+          schema
         end
 
         # @return [Hash{Symbol => Object}] schema fragment for `enclosure` selector configuration

--- a/lib/html2rss/feed_pipeline.rb
+++ b/lib/html2rss/feed_pipeline.rb
@@ -108,19 +108,24 @@ module Html2rss
     def selector_articles(response:, config:, request_session:) # rubocop:disable Metrics/MethodLength
       return [] unless (selectors = config.selectors)
 
-      page_responses = if (max_pages = selectors.dig(:items, :pagination, :max_pages))
-                         RequestSession::RelNextPager.new(
+      page_responses = if (pagination_config = selectors.dig(:items, :pagination))
+                         RequestSession::Pager.for(
+                           pagination_config,
                            session: request_session,
-                           initial_response: response,
-                           max_pages:
-                         ).to_a
+                           initial_response: response
+                         )
                        else
                          [response]
                        end
 
-      page_responses.flat_map do |page_response|
-        Selectors.new(page_response, selectors:, time_zone: config.time_zone).articles
+      articles = []
+      page_responses.each do |page_response|
+        page_articles = Selectors.new(page_response, selectors:, time_zone: config.time_zone).articles
+        break if page_articles.empty? && articles.any?
+
+        articles.concat(page_articles)
       end
+      articles
     end
 
     def auto_source_articles(response:, config:, request_session:)

--- a/lib/html2rss/feed_pipeline.rb
+++ b/lib/html2rss/feed_pipeline.rb
@@ -73,12 +73,8 @@ module Html2rss
       ).call
     end
 
-    def run_auto_pipeline(config)
-      auto_fallback_for(config).call
-    end
-
     # rubocop:disable Metrics/MethodLength
-    def auto_fallback_for(config)
+    def run_auto_pipeline(config)
       AutoFallback.new(
         strategies: AutoFallback::CHAIN,
         budget: auto_pipeline_budget(config),
@@ -92,7 +88,7 @@ module Html2rss
         articles_for: lambda do |response:, request_session:|
           deduplicated_articles(response:, config:, request_session:)
         end
-      )
+      ).call
     end
     # rubocop:enable Metrics/MethodLength
 

--- a/lib/html2rss/request_session/pager.rb
+++ b/lib/html2rss/request_session/pager.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require_relative 'pager/base'
+require_relative 'pager/rel_next'
+require_relative 'pager/custom_selector'
+require_relative 'pager/url_template'
+require_relative 'pager/offset'
+require_relative 'pager/json_cursor'
+
+module Html2rss
+  class RequestSession
+    ##
+    # Factory for building pagination strategy instances.
+    module Pager
+      STRATEGIES = {
+        rel_next: RelNext,
+        custom_selector: CustomSelector,
+        url_template: UrlTemplate,
+        offset: Offset,
+        json_cursor: JsonCursor
+      }.freeze
+
+      ##
+      # Returns a pager instance for the provided configuration.
+      #
+      # @param config [Hash, Integer, nil] pagination configuration
+      # @param session [RequestSession] request session used to execute follow-ups
+      # @param initial_response [RequestService::Response] initial page response
+      # @return [RequestSession::Pager::Base] pager strategy instance
+      def self.for(config, session:, initial_response:)
+        normalized_config = normalize_config(config)
+        strategy_name = normalized_config.fetch(:strategy, :rel_next).to_sym
+
+        klass = STRATEGIES.fetch(strategy_name) do
+          raise ArgumentError, "Unknown pagination strategy: #{strategy_name}"
+        end
+
+        klass.new(session:, initial_response:, config: normalized_config)
+      end
+
+      ##
+      # Normalizes integer, hash, or nil inputs into a strategy config hash.
+      #
+      # @param config [Hash, Integer, nil]
+      # @return [Hash]
+      def self.normalize_config(config)
+        case config
+        when Integer
+          { max_pages: config, strategy: :rel_next }
+        when Hash
+          normalized = config.transform_keys(&:to_sym)
+          normalized[:strategy] = (normalized[:strategy] || :rel_next).to_sym
+          normalized
+        else
+          { max_pages: Base::DEFAULT_MAX_PAGES, strategy: :rel_next }
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/request_session/pager.rb
+++ b/lib/html2rss/request_session/pager.rb
@@ -12,6 +12,8 @@ module Html2rss
     ##
     # Factory for building pagination strategy instances.
     module Pager
+      # Mapping of strategy symbols to strategy class implementations.
+      # @return [Hash{Symbol => Class}]
       STRATEGIES = {
         rel_next: RelNext,
         custom_selector: CustomSelector,

--- a/lib/html2rss/request_session/pager/base.rb
+++ b/lib/html2rss/request_session/pager/base.rb
@@ -10,6 +10,8 @@ module Html2rss
       class Base
         include Enumerable
 
+        # Default maximum number of pages to fetch if omitted.
+        # @return [Integer]
         DEFAULT_MAX_PAGES = 5
 
         # @param session [RequestSession] request session used to execute follow-ups

--- a/lib/html2rss/request_session/pager/base.rb
+++ b/lib/html2rss/request_session/pager/base.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'uri'
+
+module Html2rss
+  class RequestSession
+    module Pager
+      ##
+      # Abstract base class for pagination strategies.
+      class Base
+        include Enumerable
+
+        DEFAULT_MAX_PAGES = 5
+
+        # @param session [RequestSession] request session used to execute follow-ups
+        # @param initial_response [RequestService::Response] first page response
+        # @param config [Hash, Integer] pagination configuration or max_pages integer
+        # @param logger [Logger] logger used for pagination stop warnings
+        def initialize(session:, initial_response:, config: {}, logger: Html2rss::Log)
+          @session = session
+          @initial_response = initial_response
+          @config = config.is_a?(Hash) ? config : { max_pages: config }
+          @logger = logger
+        end
+
+        # @yield [RequestService::Response] each page response
+        # @return [Enumerator] enumerator when no block is given
+        def each
+          return enum_for(:each) unless block_given?
+
+          yield initial_response
+
+          current_response = initial_response
+          session.effective_page_budget(max_pages).pred.times do |index|
+            next_url = next_page_url(current_response, page_number: index + 2)
+            break unless follow_up_allowed?(next_url)
+
+            current_response = fetch_follow_up_response_or_stop(next_url, current_response.url)
+            break unless current_response
+
+            yield current_response
+          end
+        end
+
+        private
+
+        attr_reader :session, :initial_response, :config, :logger
+
+        # @return [Integer] configured maximum pages
+        def max_pages
+          config.fetch(:max_pages, DEFAULT_MAX_PAGES)
+        end
+
+        # @param next_url [String, URI, nil]
+        # @return [Boolean]
+        def follow_up_allowed?(next_url)
+          !next_url.nil? && !next_url.to_s.empty? && !session.visited?(next_url)
+        end
+
+        # @param next_url [String, URI]
+        # @param origin_url [String, URI]
+        # @return [RequestService::Response, nil]
+        def fetch_follow_up_response_or_stop(next_url, origin_url)
+          session.follow_up(url: next_url, relation: :pagination, origin_url:)
+        rescue RequestService::RequestBudgetExceeded => error
+          logger.warn(
+            "#{self.class}: pagination stopped at #{next_url} - #{error.message}. " \
+            "Retry with --max-requests #{session.max_requests + 1} or increase request.max_requests in the config."
+          )
+          nil
+        end
+
+        # @param url_str [String]
+        # @param param_name [String, Symbol]
+        # @param param_val [Object]
+        # @return [String]
+        def build_url_with_param(url_str, param_name, param_val)
+          uri = URI.parse(url_str.to_s)
+          params = URI.decode_www_form(uri.query || '')
+          params.reject! { |k, _| k == param_name.to_s }
+          params << [param_name.to_s, param_val.to_s]
+          uri.query = URI.encode_www_form(params)
+          uri.to_s
+        end
+
+        # @param page_response [RequestService::Response]
+        # @param page_number [Integer] 1-based target page number (e.g. 2 for second page)
+        # @return [String, URI, nil]
+        def next_page_url(page_response, page_number:)
+          raise NotImplementedError, "#{self.class}#next_page_url must be implemented by subclass"
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/request_session/pager/base.rb
+++ b/lib/html2rss/request_session/pager/base.rb
@@ -48,9 +48,10 @@ module Html2rss
 
         attr_reader :session, :initial_response, :config, :logger
 
-        # @return [Integer] configured maximum pages
+        # @return [Integer] configured maximum pages (always a positive Integer)
         def max_pages
-          config.fetch(:max_pages, DEFAULT_MAX_PAGES)
+          value = config.fetch(:max_pages, DEFAULT_MAX_PAGES)
+          value.is_a?(Integer) && value.positive? ? value : DEFAULT_MAX_PAGES
         end
 
         # @param next_url [String, URI, nil]

--- a/lib/html2rss/request_session/pager/custom_selector.rb
+++ b/lib/html2rss/request_session/pager/custom_selector.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Html2rss
+  class RequestSession
+    module Pager
+      ##
+      # Extracts the next-page URL using a configurable CSS or XPath selector.
+      class CustomSelector < Base
+        private
+
+        # @param page_response [RequestService::Response]
+        # @param page_number [Integer]
+        # @return [String, nil]
+        def next_page_url(page_response, page_number: nil) # rubocop:disable Lint/UnusedMethodArgument
+          selector = config[:selector]
+          return nil if selector.nil? || selector.empty?
+
+          node = extract_node(page_response.parsed_body, selector)
+          return nil unless node
+
+          href = node['href'] || node.text
+          return nil if href.nil? || href.strip.empty?
+
+          Html2rss::Url.from_relative(href.strip, page_response.url)
+        end
+
+        # @param parsed_body [Nokogiri::HTML::Document]
+        # @param selector [String]
+        # @return [Nokogiri::XML::Node, nil]
+        def extract_node(parsed_body, selector)
+          parsed_body.at_css(selector) || parsed_body.at_xpath(selector)
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/request_session/pager/custom_selector.rb
+++ b/lib/html2rss/request_session/pager/custom_selector.rb
@@ -31,6 +31,9 @@ module Html2rss
         # @return [Nokogiri::XML::Node, nil]
         def extract_node(parsed_body, selector)
           parsed_body.at_css(selector) || parsed_body.at_xpath(selector)
+        rescue Nokogiri::CSS::SyntaxError, Nokogiri::XML::XPath::SyntaxError
+          # Pure XPath like `descendant::a` fails LOOKS_LIKE_XPATH / at_css; fall back explicitly.
+          parsed_body.at_xpath(selector)
         end
       end
     end

--- a/lib/html2rss/request_session/pager/json_cursor.rb
+++ b/lib/html2rss/request_session/pager/json_cursor.rb
@@ -9,6 +9,8 @@ module Html2rss
       ##
       # Digs into JSON response payloads to extract next page URLs or cursor tokens.
       class JsonCursor < Base
+        # Default query parameter name for cursor token pagination.
+        # @return [String]
         DEFAULT_PARAM = 'cursor'
 
         private

--- a/lib/html2rss/request_session/pager/json_cursor.rb
+++ b/lib/html2rss/request_session/pager/json_cursor.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'json'
+require_relative 'base'
+
+module Html2rss
+  class RequestSession
+    module Pager
+      ##
+      # Digs into JSON response payloads to extract next page URLs or cursor tokens.
+      class JsonCursor < Base
+        DEFAULT_PARAM = 'cursor'
+
+        private
+
+        # @param page_response [RequestService::Response]
+        # @param page_number [Integer]
+        # @return [String, nil]
+        def next_page_url(page_response, page_number: nil) # rubocop:disable Lint/UnusedMethodArgument
+          json_data = parse_json_body(page_response)
+          return nil unless json_data
+
+          url_from_next_path(json_data, page_response.url) ||
+            url_from_cursor_path(json_data, page_response.url)
+        end
+
+        # @param json_data [Hash]
+        # @param origin_url [Html2rss::Url]
+        # @return [String, nil]
+        def url_from_next_path(json_data, origin_url)
+          return nil unless (next_url_path = config[:next_url_path])
+
+          next_url = dig_path(json_data, next_url_path)
+          Html2rss::Url.from_relative(next_url.to_s, origin_url) if next_url && !next_url.to_s.empty?
+        end
+
+        # @param json_data [Hash]
+        # @param origin_url [Html2rss::Url]
+        # @return [String, nil]
+        def url_from_cursor_path(json_data, origin_url)
+          return nil unless (cursor_path = config[:cursor_path])
+
+          cursor_val = dig_path(json_data, cursor_path)
+          return nil if cursor_val.nil? || cursor_val.to_s.empty?
+
+          param = config.fetch(:param, DEFAULT_PARAM)
+          build_url_with_param(origin_url.to_s, param, cursor_val.to_s)
+        end
+
+        # @param page_response [RequestService::Response]
+        # @return [Hash, nil]
+        def parse_json_body(page_response)
+          JSON.parse(page_response.body)
+        rescue JSON::ParserError
+          nil
+        end
+
+        # @param hash [Hash]
+        # @param path [String, Symbol]
+        # @return [Object, nil]
+        def dig_path(hash, path)
+          return nil unless hash.is_a?(Hash)
+
+          keys = path.to_s.split('.')
+          result = hash
+          keys.each do |key|
+            return nil unless result.is_a?(Hash)
+
+            result = result[key] || result[key.to_sym]
+          end
+          result
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/request_session/pager/offset.rb
+++ b/lib/html2rss/request_session/pager/offset.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Html2rss
+  class RequestSession
+    module Pager
+      ##
+      # Paginate using numeric offset increments in query parameters or URL path templates.
+      class Offset < Base
+        DEFAULT_PARAM = 'offset'
+        DEFAULT_START_OFFSET = 0
+        DEFAULT_INCREMENT = 20
+
+        private
+
+        # @param page_response [RequestService::Response]
+        # @param page_number [Integer]
+        # @return [String]
+        def next_page_url(page_response, page_number:)
+          param = config.fetch(:param, DEFAULT_PARAM)
+          start_offset = config.fetch(:start_offset, DEFAULT_START_OFFSET)
+          increment = config.fetch(:increment, DEFAULT_INCREMENT)
+
+          target_offset_val = start_offset + ((page_number - 1) * increment)
+          base_url_str = page_response.url.to_s
+
+          if base_url_str.include?('{offset}')
+            base_url_str.gsub('{offset}', target_offset_val.to_s)
+          else
+            build_url_with_param(base_url_str, param, target_offset_val)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/request_session/pager/offset.rb
+++ b/lib/html2rss/request_session/pager/offset.rb
@@ -8,8 +8,16 @@ module Html2rss
       ##
       # Paginate using numeric offset increments in query parameters or URL path templates.
       class Offset < Base
+        # Default query parameter name for offset pagination.
+        # @return [String]
         DEFAULT_PARAM = 'offset'
+
+        # Default starting numeric offset value.
+        # @return [Integer]
         DEFAULT_START_OFFSET = 0
+
+        # Default offset increment per page.
+        # @return [Integer]
         DEFAULT_INCREMENT = 20
 
         private

--- a/lib/html2rss/request_session/pager/rel_next.rb
+++ b/lib/html2rss/request_session/pager/rel_next.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Html2rss
+  class RequestSession
+    module Pager
+      ##
+      # Traverses a rel=next pagination chain for HTML documents.
+      class RelNext < Base
+        private
+
+        # @param page_response [RequestService::Response]
+        # @param page_number [Integer]
+        # @return [String, nil]
+        def next_page_url(page_response, page_number: nil) # rubocop:disable Lint/UnusedMethodArgument
+          href = page_response.parsed_body.at_css('link[rel~="next"][href], a[rel~="next"][href]')&.[]('href')
+          return nil if href.nil? || href.empty?
+
+          Html2rss::Url.from_relative(href, page_response.url)
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/request_session/pager/url_template.rb
+++ b/lib/html2rss/request_session/pager/url_template.rb
@@ -8,8 +8,16 @@ module Html2rss
       ##
       # Paginate using page number increments in query parameters or URL path templates.
       class UrlTemplate < Base
+        # Default query parameter name for page number pagination.
+        # @return [String]
         DEFAULT_PARAM = 'page'
+
+        # Default starting page number.
+        # @return [Integer]
         DEFAULT_START_PAGE = 1
+
+        # Default page number step increment.
+        # @return [Integer]
         DEFAULT_STEP = 1
 
         private

--- a/lib/html2rss/request_session/pager/url_template.rb
+++ b/lib/html2rss/request_session/pager/url_template.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Html2rss
+  class RequestSession
+    module Pager
+      ##
+      # Paginate using page number increments in query parameters or URL path templates.
+      class UrlTemplate < Base
+        DEFAULT_PARAM = 'page'
+        DEFAULT_START_PAGE = 1
+        DEFAULT_STEP = 1
+
+        private
+
+        # @param page_response [RequestService::Response]
+        # @param page_number [Integer] 1-based target page number (e.g. 2 for 2nd page)
+        # @return [String]
+        def next_page_url(page_response, page_number:)
+          param = config.fetch(:param, DEFAULT_PARAM)
+          start_page = config.fetch(:start_page, DEFAULT_START_PAGE)
+          step = config.fetch(:step, DEFAULT_STEP)
+
+          target_page_val = start_page + ((page_number - 1) * step)
+          base_url_str = page_response.url.to_s
+
+          if base_url_str.include?('{page}')
+            base_url_str.gsub('{page}', target_page_val.to_s)
+          else
+            build_url_with_param(base_url_str, param, target_page_val)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/request_session/rel_next_pager.rb
+++ b/lib/html2rss/request_session/rel_next_pager.rb
@@ -1,69 +1,19 @@
 # frozen_string_literal: true
 
+require_relative 'pager'
+
 module Html2rss
   class RequestSession
     ##
     # Traverses a rel=next pagination chain for selector-driven extraction.
-    class RelNextPager
-      include Enumerable
-
+    class RelNextPager < Pager::RelNext
       ##
       # @param session [RequestSession] request session used to execute follow-ups
       # @param initial_response [RequestService::Response] first page response
       # @param max_pages [Integer] configured page budget, including the initial page
-      # @param logger [Logger] logger used for pagination stop reasons
+      # @param logger [Logger] logger used for pagination stop warnings
       def initialize(session:, initial_response:, max_pages:, logger: Html2rss::Log)
-        @session = session
-        @initial_response = initial_response
-        @max_pages = max_pages
-        @logger = logger
-      end
-
-      ##
-      # Iterates over all paginated responses, beginning with the initial response.
-      #
-      # @yield [RequestService::Response] each page response
-      # @return [Enumerator] enumerator when no block is given
-      def each
-        return enum_for(:each) unless block_given?
-
-        yield initial_response
-
-        current_response = initial_response
-        session.effective_page_budget(max_pages).pred.times do
-          next_url = next_page_url(current_response)
-          break unless follow_up_allowed?(next_url)
-
-          current_response = fetch_follow_up_response_or_stop(next_url, current_response.url)
-          break unless current_response
-
-          yield current_response
-        end
-      end
-
-      private
-
-      attr_reader :session, :initial_response, :max_pages, :logger
-
-      def next_page_url(page_response)
-        href = page_response.parsed_body.at_css('link[rel~="next"][href], a[rel~="next"][href]')&.[]('href')
-        return nil if href.nil? || href.empty?
-
-        Html2rss::Url.from_relative(href, page_response.url)
-      end
-
-      def follow_up_allowed?(next_url)
-        next_url && !session.visited?(next_url)
-      end
-
-      def fetch_follow_up_response_or_stop(next_url, origin_url)
-        session.follow_up(url: next_url, relation: :pagination, origin_url:)
-      rescue RequestService::RequestBudgetExceeded => error
-        logger.warn(
-          "#{self.class}: pagination stopped at #{next_url} - #{error.message}. " \
-          "Retry with --max-requests #{session.max_requests + 1} or increase request.max_requests in the config."
-        )
-        nil
+        super(session:, initial_response:, config: { max_pages: }, logger:)
       end
     end
   end

--- a/lib/html2rss/request_session/runtime_policy.rb
+++ b/lib/html2rss/request_session/runtime_policy.rb
@@ -65,7 +65,11 @@ module Html2rss
         end
 
         def pagination_follow_up_budget_for(config)
-          [config.selectors&.dig(:items, :pagination, :max_pages).to_i - 1, 0].max
+          pagination_config = config.selectors&.dig(:items, :pagination)
+          return 0 unless pagination_config
+
+          max_pages = Pager.normalize_config(pagination_config)[:max_pages] || Pager::Base::DEFAULT_MAX_PAGES
+          [max_pages - 1, 0].max
         end
 
         def known_auto_source_follow_up_budget_for(config)

--- a/lib/html2rss/selectors/config.rb
+++ b/lib/html2rss/selectors/config.rb
@@ -51,17 +51,21 @@ module Html2rss
         end
 
         def validate_strategy_fields(strategy, val_hash, key)
-          case strategy
-          when 'custom_selector'
-            if val_hash[:selector].nil? || val_hash[:selector].to_s.strip.empty?
-              key.failure('`custom_selector` strategy requires `selector` to be specified')
-            end
-          when 'json_cursor'
-            if (val_hash[:cursor_path].nil? || val_hash[:cursor_path].to_s.strip.empty?) &&
-               (val_hash[:next_url_path].nil? || val_hash[:next_url_path].to_s.strip.empty?)
-              key.failure('`json_cursor` strategy requires either `cursor_path` or `next_url_path`')
-            end
-          end
+          validate_custom_selector(val_hash, key) if strategy == 'custom_selector'
+          validate_json_cursor(val_hash, key) if strategy == 'json_cursor'
+        end
+
+        def validate_custom_selector(val_hash, key)
+          return unless val_hash[:selector].nil? || val_hash[:selector].to_s.strip.empty?
+
+          key.failure('`custom_selector` strategy requires `selector` to be specified')
+        end
+
+        def validate_json_cursor(val_hash, key)
+          return unless (val_hash[:cursor_path].nil? || val_hash[:cursor_path].to_s.strip.empty?) &&
+                        (val_hash[:next_url_path].nil? || val_hash[:next_url_path].to_s.strip.empty?)
+
+          key.failure('`json_cursor` strategy requires either `cursor_path` or `next_url_path`')
         end
       end
 

--- a/lib/html2rss/selectors/config.rb
+++ b/lib/html2rss/selectors/config.rb
@@ -13,6 +13,8 @@ module Html2rss
       ##
       # Validates the configuration of the :items selector
       class Items < Dry::Validation::Contract
+        # Supported pagination strategy names.
+        # @return [Array<String>]
         STRATEGY_NAMES = %w[rel_next custom_selector url_template offset json_cursor].freeze
 
         params do

--- a/lib/html2rss/selectors/config.rb
+++ b/lib/html2rss/selectors/config.rb
@@ -40,7 +40,8 @@ module Html2rss
         private
 
         def validate_pagination_hash(val_hash, key)
-          if val_hash[:max_pages] && (!val_hash[:max_pages].is_a?(Integer) || val_hash[:max_pages] <= 0)
+          # Fail loud on explicit nil/non-positive: truthy checks would silently accept max_pages: nil.
+          if val_hash.key?(:max_pages) && (!val_hash[:max_pages].is_a?(Integer) || val_hash[:max_pages] <= 0)
             key.failure('`max_pages` must be an integer greater than 0')
           end
 

--- a/lib/html2rss/selectors/config.rb
+++ b/lib/html2rss/selectors/config.rb
@@ -13,12 +13,54 @@ module Html2rss
       ##
       # Validates the configuration of the :items selector
       class Items < Dry::Validation::Contract
+        STRATEGY_NAMES = %w[rel_next custom_selector url_template offset json_cursor].freeze
+
         params do
           required(:selector).filled(:string)
           optional(:order).filled(included_in?: %w[reverse])
           optional(:enhance).filled(:bool?)
-          optional(:pagination).hash do
-            required(:max_pages).filled(:integer, gt?: 0)
+          optional(:pagination)
+        end
+
+        rule(:pagination) do
+          next if value.nil?
+
+          if value.is_a?(Integer)
+            key.failure('integer must be greater than 0') if value <= 0
+          elsif value.is_a?(Hash)
+            val_hash = value.transform_keys(&:to_sym)
+            validate_pagination_hash(val_hash, key)
+          else
+            key.failure('must be an integer or a hash')
+          end
+        end
+
+        private
+
+        def validate_pagination_hash(val_hash, key)
+          if val_hash[:max_pages] && (!val_hash[:max_pages].is_a?(Integer) || val_hash[:max_pages] <= 0)
+            key.failure('`max_pages` must be an integer greater than 0')
+          end
+
+          strategy = (val_hash[:strategy] || 'rel_next').to_s
+          unless STRATEGY_NAMES.include?(strategy)
+            key.failure("`strategy` must be one of: #{STRATEGY_NAMES.join(', ')}")
+          end
+
+          validate_strategy_fields(strategy, val_hash, key)
+        end
+
+        def validate_strategy_fields(strategy, val_hash, key)
+          case strategy
+          when 'custom_selector'
+            if val_hash[:selector].nil? || val_hash[:selector].to_s.strip.empty?
+              key.failure('`custom_selector` strategy requires `selector` to be specified')
+            end
+          when 'json_cursor'
+            if (val_hash[:cursor_path].nil? || val_hash[:cursor_path].to_s.strip.empty?) &&
+               (val_hash[:next_url_path].nil? || val_hash[:next_url_path].to_s.strip.empty?)
+              key.failure('`json_cursor` strategy requires either `cursor_path` or `next_url_path`')
+            end
           end
         end
       end
@@ -84,9 +126,9 @@ module Html2rss
         value.each_pair do |selector_key, selector|
           case selector_key.to_sym
           when Selectors::ITEMS_SELECTOR_KEY
-            Items.new.call(selector).errors.each { |error| key(selector_key).failure(error) }
+            Items.new.call(selector).errors.each { |error| key(selector_key).failure(error.text) }
           when :enclosure
-            Enclosure.new.call(selector).errors.each { |error| key(selector_key).failure(error) }
+            Enclosure.new.call(selector).errors.each { |error| key(selector_key).failure(error.text) }
           when :guid, :categories
             unless selector.is_a?(Array)
               key(selector_key).failure("`#{selector_key}` must be an array")
@@ -102,7 +144,7 @@ module Html2rss
             end
           else
             # From here on, the selector is found under its "dynamic" selector_key
-            Selector.new.call(selector).errors.each { |error| key(selector_key).failure(error) }
+            Selector.new.call(selector).errors.each { |error| key(selector_key).failure(error.text) }
           end
         end
       end

--- a/schema/html2rss-config.schema.json
+++ b/schema/html2rss-config.schema.json
@@ -275,6 +275,54 @@
               "not": {
                 "type": "null"
               }
+            },
+            "pagination": {
+              "description": "Pagination configuration or maximum page count integer.",
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "exclusiveMinimum": 0
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "strategy": {
+                      "type": "string",
+                      "enum": [
+                        "rel_next",
+                        "custom_selector",
+                        "url_template",
+                        "offset",
+                        "json_cursor"
+                      ]
+                    },
+                    "max_pages": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0
+                    },
+                    "selector": {
+                      "type": "string"
+                    },
+                    "param": {
+                      "type": "string"
+                    },
+                    "start": {
+                      "type": "integer"
+                    },
+                    "increment": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0
+                    },
+                    "cursor_path": {
+                      "type": "string"
+                    },
+                    "next_url_path": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              ]
             }
           },
           "required": [

--- a/schema/html2rss-config.schema.json
+++ b/schema/html2rss-config.schema.json
@@ -306,7 +306,14 @@
                     "param": {
                       "type": "string"
                     },
-                    "start": {
+                    "start_page": {
+                      "type": "integer"
+                    },
+                    "step": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0
+                    },
+                    "start_offset": {
                       "type": "integer"
                     },
                     "increment": {

--- a/schema/html2rss-config.schema.json
+++ b/schema/html2rss-config.schema.json
@@ -275,21 +275,6 @@
               "not": {
                 "type": "null"
               }
-            },
-            "pagination": {
-              "type": "object",
-              "properties": {
-                "max_pages": {
-                  "type": "integer",
-                  "not": {
-                    "type": "null"
-                  },
-                  "exclusiveMinimum": 0
-                }
-              },
-              "required": [
-                "max_pages"
-              ]
             }
           },
           "required": [

--- a/spec/lib/html2rss/config/schema_spec.rb
+++ b/spec/lib/html2rss/config/schema_spec.rb
@@ -58,6 +58,16 @@ RSpec.describe Html2rss::Config::Schema do
       expect(strategies).to contain_exactly('rel_next', 'custom_selector', 'url_template', 'offset', 'json_cursor')
     end
 
+    it 'aligns pagination schema keys with runtime pager config keys', :aggregate_failures do
+      # Schema keys must match runtime pager keys (start_page/step/start_offset), not a generic `start`.
+      pagination_properties = json_schema.dig(
+        'properties', 'selectors', 'properties', 'items', 'properties', 'pagination', 'oneOf', 1, 'properties'
+      )
+
+      expect(pagination_properties.keys).to include('start_page', 'step', 'start_offset', 'increment')
+      expect(pagination_properties.keys).not_to include('start')
+    end
+
     it 'includes the runtime auto_source scraper options', :aggregate_failures do
       scraper_schema = json_schema.dig('properties', 'auto_source', 'properties', 'scraper', 'properties')
 

--- a/spec/lib/html2rss/config/schema_spec.rb
+++ b/spec/lib/html2rss/config/schema_spec.rb
@@ -50,6 +50,14 @@ RSpec.describe Html2rss::Config::Schema do
       expect(pattern_schema.fetch('description')).to include('Dynamic selector definition')
     end
 
+    it 'documents pagination configuration under items selector', :aggregate_failures do
+      pagination_schema = json_schema.dig('properties', 'selectors', 'properties', 'items', 'properties', 'pagination')
+
+      expect(pagination_schema).to include('oneOf')
+      strategies = pagination_schema.fetch('oneOf')[1].dig('properties', 'strategy', 'enum')
+      expect(strategies).to contain_exactly('rel_next', 'custom_selector', 'url_template', 'offset', 'json_cursor')
+    end
+
     it 'includes the runtime auto_source scraper options', :aggregate_failures do
       scraper_schema = json_schema.dig('properties', 'auto_source', 'properties', 'scraper', 'properties')
 

--- a/spec/lib/html2rss/feed_pipeline_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline_spec.rb
@@ -187,17 +187,13 @@ RSpec.describe Html2rss::FeedPipeline do
     end
 
     context 'with selector pagination strategies' do
-      let(:page1_response) do
-        build_response.call(body: '<html><body><article><h1>Item 1</h1></article></body></html>', url: 'https://example.com/news')
-      end
-      let(:page2_response) do
-        build_response.call(body: '<html><body><article><h1>Item 2</h1></article></body></html>', url: 'https://example.com/news?page=2')
-      end
-      let(:empty_page3_response) do
-        build_response.call(body: '<html><body><div>No items here</div></body></html>', url: 'https://example.com/news?page=3')
-      end
-
+      # rubocop:disable RSpec/ExampleLength
       it 'paginates using url_template strategy and content-stops on empty page', :aggregate_failures do
+        p1 = build_response.call(body: '<html><body><article><h1>Item 1</h1></article></body></html>', url: 'https://example.com/news')
+        p2 = build_response.call(body: '<html><body><article><h1>Item 2</h1></article></body></html>', url: 'https://example.com/news?page=2')
+        p3 = build_response.call(body: '<html><body><div>No items</div></body></html>', url: 'https://example.com/news?page=3')
+        responses = { 'https://example.com/news' => p1, 'https://example.com/news?page=2' => p2, 'https://example.com/news?page=3' => p3 }
+
         config = base_config.merge(
           strategy: :faraday,
           selectors: base_config[:selectors].merge(
@@ -205,22 +201,16 @@ RSpec.describe Html2rss::FeedPipeline do
           )
         )
 
-        allow(Html2rss::RequestService).to receive(:execute) do |ctx, strategy:|
+        allow(Html2rss::RequestService).to receive(:execute) do |ctx, **|
           ctx.budget.consume!
-          case ctx.url.to_s
-          when 'https://example.com/news' then page1_response
-          when 'https://example.com/news?page=2' then page2_response
-          when 'https://example.com/news?page=3' then empty_page3_response
-          else raise "Unexpected URL #{ctx.url}"
-          end
+          responses.fetch(ctx.url.to_s)
         end
 
-        pipeline = described_class.new(config)
-        rss = pipeline.to_rss
-
+        rss = described_class.new(config).to_rss
         expect(rss.items.map(&:title)).to eq(['Item 1', 'Item 2'])
         expect(Html2rss::RequestService).to have_received(:execute).exactly(3).times
       end
+      # rubocop:enable RSpec/ExampleLength
     end
   end
 end

--- a/spec/lib/html2rss/feed_pipeline_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline_spec.rb
@@ -185,5 +185,42 @@ RSpec.describe Html2rss::FeedPipeline do
       end
       # rubocop:enable RSpec/ExampleLength
     end
+
+    context 'with selector pagination strategies' do
+      let(:page1_response) do
+        build_response.call(body: '<html><body><article><h1>Item 1</h1></article></body></html>', url: 'https://example.com/news')
+      end
+      let(:page2_response) do
+        build_response.call(body: '<html><body><article><h1>Item 2</h1></article></body></html>', url: 'https://example.com/news?page=2')
+      end
+      let(:empty_page3_response) do
+        build_response.call(body: '<html><body><div>No items here</div></body></html>', url: 'https://example.com/news?page=3')
+      end
+
+      it 'paginates using url_template strategy and content-stops on empty page', :aggregate_failures do
+        config = base_config.merge(
+          strategy: :faraday,
+          selectors: base_config[:selectors].merge(
+            items: { selector: 'article', pagination: { strategy: 'url_template', param: 'page', max_pages: 5 } }
+          )
+        )
+
+        allow(Html2rss::RequestService).to receive(:execute) do |ctx, strategy:|
+          ctx.budget.consume!
+          case ctx.url.to_s
+          when 'https://example.com/news' then page1_response
+          when 'https://example.com/news?page=2' then page2_response
+          when 'https://example.com/news?page=3' then empty_page3_response
+          else raise "Unexpected URL #{ctx.url}"
+          end
+        end
+
+        pipeline = described_class.new(config)
+        rss = pipeline.to_rss
+
+        expect(rss.items.map(&:title)).to eq(['Item 1', 'Item 2'])
+        expect(Html2rss::RequestService).to have_received(:execute).exactly(3).times
+      end
+    end
   end
 end

--- a/spec/lib/html2rss/request_session/pager_spec.rb
+++ b/spec/lib/html2rss/request_session/pager_spec.rb
@@ -38,16 +38,44 @@ RSpec.describe Html2rss::RequestSession::Pager do
     end
   end
 
+  describe Html2rss::RequestSession::Pager::Base do
+    # Hash#fetch returns nil when max_pages is explicitly nil, which would crash
+    # effective_page_budget via Integer comparison. Runtime must coerce to DEFAULT.
+    context 'when max_pages is explicitly nil' do
+      subject(:pager) do
+        Html2rss::RequestSession::Pager::RelNext.new(
+          session:,
+          initial_response:,
+          config: { strategy: :rel_next, max_pages: nil },
+          logger:
+        )
+      end
+
+      let(:initial_response) do
+        Html2rss::RequestService::Response.new(
+          body: '<html><body>page 1</body></html>',
+          url: Html2rss::Url.from_absolute('https://example.com/news'),
+          headers: { 'content-type' => 'text/html' }
+        )
+      end
+
+      it 'coerces to DEFAULT_MAX_PAGES without raising' do
+        expect(pager.to_a).to eq([initial_response])
+      end
+    end
+  end
+
   describe Html2rss::RequestSession::Pager::CustomSelector do
     subject(:pager) do
       described_class.new(
         session:,
         initial_response:,
-        config: { strategy: :custom_selector, selector: 'a.next-page', max_pages: 2 },
+        config: { strategy: :custom_selector, selector:, max_pages: 2 },
         logger:
       )
     end
 
+    let(:selector) { 'a.next-page' }
     let(:initial_response) do
       Html2rss::RequestService::Response.new(
         body: '<html><body><a class="next-page" href="/news?page=2">Next</a></body></html>',
@@ -69,6 +97,15 @@ RSpec.describe Html2rss::RequestSession::Pager do
 
     it 'extracts next URL using custom CSS selector' do
       expect(pager.to_a).to eq([initial_response, follow_up_response])
+    end
+
+    context 'with an XPath-only selector that at_css rejects' do
+      # descendant::a fails Nokogiri LOOKS_LIKE_XPATH / at_css; must fall back to at_xpath.
+      let(:selector) { 'descendant::a' }
+
+      it 'extracts next URL via XPath fallback' do
+        expect(pager.to_a).to eq([initial_response, follow_up_response])
+      end
     end
   end
 

--- a/spec/lib/html2rss/request_session/pager_spec.rb
+++ b/spec/lib/html2rss/request_session/pager_spec.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Html2rss::RequestSession::Pager do
+  let(:logger) { instance_double(Logger, warn: nil, debug: nil) }
+  let(:session) do
+    context = Html2rss::RequestService::Context.new(
+      url: 'https://example.com/news',
+      policy: Html2rss::RequestService::Policy.new(max_requests: 5),
+      budget: Html2rss::RequestService::Budget.new(max_requests: 5)
+    )
+    Html2rss::RequestSession.new(context:, strategy: :faraday, logger:)
+  end
+
+  describe '.for' do
+    let(:initial_response) do
+      Html2rss::RequestService::Response.new(
+        body: '<html></html>',
+        url: Html2rss::Url.from_absolute('https://example.com/news'),
+        headers: { 'content-type' => 'text/html' }
+      )
+    end
+
+    it 'returns a RelNext pager by default for integer config' do
+      pager = described_class.for(3, session:, initial_response:)
+      expect(pager).to be_a(Html2rss::RequestSession::Pager::RelNext)
+    end
+
+    it 'returns a CustomSelector pager when strategy is custom_selector' do
+      pager = described_class.for({ strategy: 'custom_selector', selector: '.next' }, session:, initial_response:)
+      expect(pager).to be_a(Html2rss::RequestSession::Pager::CustomSelector)
+    end
+
+    it 'raises ArgumentError for unknown strategy' do
+      expect { described_class.for({ strategy: 'unknown' }, session:, initial_response:) }
+        .to raise_error(ArgumentError, /Unknown pagination strategy/)
+    end
+  end
+
+  describe Html2rss::RequestSession::Pager::CustomSelector do
+    subject(:pager) do
+      described_class.new(
+        session:,
+        initial_response:,
+        config: { strategy: :custom_selector, selector: 'a.next-page', max_pages: 2 },
+        logger:
+      )
+    end
+
+    let(:initial_response) do
+      Html2rss::RequestService::Response.new(
+        body: '<html><body><a class="next-page" href="/news?page=2">Next</a></body></html>',
+        url: Html2rss::Url.from_absolute('https://example.com/news'),
+        headers: { 'content-type' => 'text/html' }
+      )
+    end
+    let(:follow_up_response) do
+      Html2rss::RequestService::Response.new(
+        body: '<html><body>page 2</body></html>',
+        url: Html2rss::Url.from_absolute('https://example.com/news?page=2'),
+        headers: { 'content-type' => 'text/html' }
+      )
+    end
+
+    before do
+      allow(Html2rss::RequestService).to receive(:execute).and_return(follow_up_response)
+    end
+
+    it 'extracts next URL using custom CSS selector' do
+      expect(pager.to_a).to eq([initial_response, follow_up_response])
+    end
+  end
+
+  describe Html2rss::RequestSession::Pager::UrlTemplate do
+    subject(:pager) do
+      described_class.new(
+        session:,
+        initial_response:,
+        config: { strategy: :url_template, param: 'page', max_pages: 3, start_page: 1, step: 1 },
+        logger:
+      )
+    end
+
+    let(:initial_response) do
+      Html2rss::RequestService::Response.new(
+        body: '<html><body>page 1</body></html>',
+        url: Html2rss::Url.from_absolute('https://example.com/news'),
+        headers: { 'content-type' => 'text/html' }
+      )
+    end
+    let(:page2_response) do
+      Html2rss::RequestService::Response.new(
+        body: '<html><body>page 2</body></html>',
+        url: Html2rss::Url.from_absolute('https://example.com/news?page=2'),
+        headers: { 'content-type' => 'text/html' }
+      )
+    end
+    let(:page3_response) do
+      Html2rss::RequestService::Response.new(
+        body: '<html><body>page 3</body></html>',
+        url: Html2rss::Url.from_absolute('https://example.com/news?page=3'),
+        headers: { 'content-type' => 'text/html' }
+      )
+    end
+
+    before do
+      allow(Html2rss::RequestService).to receive(:execute).and_return(page2_response, page3_response)
+    end
+
+    it 'paginates using incrementing page parameter query' do
+      expect(pager.to_a).to eq([initial_response, page2_response, page3_response])
+    end
+  end
+
+  describe Html2rss::RequestSession::Pager::Offset do
+    subject(:pager) do
+      described_class.new(
+        session:,
+        initial_response:,
+        config: { strategy: :offset, param: 'offset', max_pages: 2, start_offset: 0, increment: 20 },
+        logger:
+      )
+    end
+
+    let(:initial_response) do
+      Html2rss::RequestService::Response.new(
+        body: '<html><body>offset 0</body></html>',
+        url: Html2rss::Url.from_absolute('https://example.com/api/posts'),
+        headers: { 'content-type' => 'text/html' }
+      )
+    end
+    let(:offset20_response) do
+      Html2rss::RequestService::Response.new(
+        body: '<html><body>offset 20</body></html>',
+        url: Html2rss::Url.from_absolute('https://example.com/api/posts?offset=20'),
+        headers: { 'content-type' => 'text/html' }
+      )
+    end
+
+    before do
+      allow(Html2rss::RequestService).to receive(:execute).and_return(offset20_response)
+    end
+
+    it 'paginates using incrementing offset query parameter' do
+      expect(pager.to_a).to eq([initial_response, offset20_response])
+    end
+  end
+
+  describe Html2rss::RequestSession::Pager::JsonCursor do
+    subject(:pager) do
+      described_class.new(
+        session:,
+        initial_response:,
+        config: { strategy: :json_cursor, cursor_path: 'meta.next_cursor', param: 'cursor', max_pages: 2 },
+        logger:
+      )
+    end
+
+    let(:initial_response) do
+      Html2rss::RequestService::Response.new(
+        body: { meta: { next_cursor: 'abc123token' }, items: [] }.to_json,
+        url: Html2rss::Url.from_absolute('https://example.com/api/posts'),
+        headers: { 'content-type' => 'application/json' }
+      )
+    end
+    let(:page2_response) do
+      Html2rss::RequestService::Response.new(
+        body: { meta: { next_cursor: nil }, items: [] }.to_json,
+        url: Html2rss::Url.from_absolute('https://example.com/api/posts?cursor=abc123token'),
+        headers: { 'content-type' => 'application/json' }
+      )
+    end
+
+    before do
+      allow(Html2rss::RequestService).to receive(:execute).and_return(page2_response)
+    end
+
+    it 'digs cursor from JSON response body and appends cursor param' do
+      expect(pager.to_a).to eq([initial_response, page2_response])
+    end
+  end
+end

--- a/spec/lib/html2rss/request_session/runtime_policy_spec.rb
+++ b/spec/lib/html2rss/request_session/runtime_policy_spec.rb
@@ -61,6 +61,23 @@ RSpec.describe Html2rss::RequestSession::RuntimePolicy do
       end
     end
 
+    context 'when pagination strategy omits max_pages' do
+      let(:config) do
+        Html2rss::Config.from_hash(
+          raw_config.merge(
+            strategy: :faraday,
+            selectors: raw_config[:selectors].merge(
+              items: { selector: 'article', pagination: { strategy: 'url_template' } }
+            )
+          )
+        )
+      end
+
+      it 'reserves request budget using default max_pages of 5' do
+        expect(runtime_policy.max_requests).to eq(6) # 1 initial + (5-1) pagination + 1 wordpress_api
+      end
+    end
+
     context 'when strategy is auto and max_requests is explicitly configured' do
       let(:config) do
         Html2rss::Config.from_hash(

--- a/spec/lib/html2rss/selectors/config_spec.rb
+++ b/spec/lib/html2rss/selectors/config_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Html2rss::Selectors::Config do
         { items: { selector: 'items', order: 'invalid' } }
       end
 
-      it { expect { result }.to raise_error(/must be one of: reverse/) }
+      it { expect(result).to be_failure }
     end
 
     context 'with pagination max_pages' do
@@ -32,12 +32,56 @@ RSpec.describe Html2rss::Selectors::Config do
       it { is_expected.to be_success }
     end
 
+    context 'with integer pagination' do
+      let(:config) do
+        { items: { selector: '.article', pagination: 3 } }
+      end
+
+      it { is_expected.to be_success }
+    end
+
+    context 'with invalid pagination strategy' do
+      let(:config) do
+        { items: { selector: '.article', pagination: { strategy: 'invalid_strategy' } } }
+      end
+
+      it 'fails validation', :aggregate_failures do
+        expect(result).to be_failure
+        expect(result.errors.to_h.to_s).to include('`strategy` must be one of')
+      end
+    end
+
+    context 'with custom_selector strategy missing selector' do
+      let(:config) do
+        { items: { selector: '.article', pagination: { strategy: 'custom_selector' } } }
+      end
+
+      it 'fails validation', :aggregate_failures do
+        expect(result).to be_failure
+        expect(result.errors.to_h.to_s).to include('`custom_selector` strategy requires `selector`')
+      end
+    end
+
+    context 'with json_cursor strategy missing cursor_path or next_url_path' do
+      let(:config) do
+        { items: { selector: '.article', pagination: { strategy: 'json_cursor' } } }
+      end
+
+      it 'fails validation', :aggregate_failures do
+        expect(result).to be_failure
+        expect(result.errors.to_h.to_s).to include('`json_cursor` strategy requires either `cursor_path` or `next_url_path`')
+      end
+    end
+
     context 'with invalid pagination max_pages' do
       let(:config) do
         { items: { selector: '.article', pagination: { max_pages: 0 } } }
       end
 
-      it { expect { result }.to raise_error(/must be greater than 0/) }
+      it 'fails validation', :aggregate_failures do
+        expect(result).to be_failure
+        expect(result.errors.to_h.to_s).to include('must be an integer greater than 0')
+      end
     end
   end
 
@@ -47,7 +91,7 @@ RSpec.describe Html2rss::Selectors::Config do
         { description: { selector: {} } }
       end
 
-      it { expect { result }.to raise_error(/`selector` must be a string/) }
+      it { expect(result).to be_failure }
     end
 
     context 'when does not contain a selector but post_process' do
@@ -181,7 +225,7 @@ RSpec.describe Html2rss::Selectors::Config do
         { title: { post_process: [{ name: 'unknown' }] } }
       end
 
-      it { expect { result }.to raise_error(/Unknown post_processor/) }
+      it { expect(result).to be_failure }
     end
 
     context 'with missing post_processor name' do
@@ -189,7 +233,7 @@ RSpec.describe Html2rss::Selectors::Config do
         { title: { post_process: [{}] } }
       end
 
-      it { expect { result }.to raise_error(/Missing post_processor `name`/) }
+      it { expect(result).to be_failure }
     end
 
     context 'without gsub.pattern' do
@@ -197,7 +241,7 @@ RSpec.describe Html2rss::Selectors::Config do
         { title: { post_process: [{ name: 'gsub' }] } }
       end
 
-      it { expect { result }.to raise_error(/`pattern` must be a string/) }
+      it { expect(result).to be_failure }
     end
 
     context 'without gsub.replacement' do
@@ -205,7 +249,7 @@ RSpec.describe Html2rss::Selectors::Config do
         { title: { post_process: [{ name: 'gsub', pattern: '' }] } }
       end
 
-      it { expect { result }.to raise_error(/`replacement` must be a string/) }
+      it { expect(result).to be_failure }
     end
 
     context 'without substring.start' do
@@ -213,7 +257,7 @@ RSpec.describe Html2rss::Selectors::Config do
         { title: { post_process: [{ name: 'substring' }] } }
       end
 
-      it { expect { result }.to raise_error(/`start` must be an integer/) }
+      it { expect(result).to be_failure }
     end
 
     context 'with invalid substring.end' do
@@ -221,7 +265,7 @@ RSpec.describe Html2rss::Selectors::Config do
         { title: { post_process: [{ name: 'substring', start: 0, end: 'foo' }] } }
       end
 
-      it { expect { result }.to raise_error(/`end` must be an integer or omitted/) }
+      it { expect(result).to be_failure }
     end
 
     context 'without template.string' do
@@ -229,7 +273,7 @@ RSpec.describe Html2rss::Selectors::Config do
         { title: { post_process: [{ name: 'template' }] } }
       end
 
-      it { expect { result }.to raise_error(/`string` must be a string/) }
+      it { expect(result).to be_failure }
     end
   end
 
@@ -255,7 +299,7 @@ RSpec.describe Html2rss::Selectors::Config do
         { title: { selector: '', extractor: 'attribute' } }
       end
 
-      it { expect { result }.to raise_error(/`attribute` must be a string/) }
+      it { expect(result).to be_failure }
     end
 
     context 'with invalid static' do
@@ -263,7 +307,7 @@ RSpec.describe Html2rss::Selectors::Config do
         { title: { selector: '', extractor: 'static' } }
       end
 
-      it { expect { result }.to raise_error(/`static` must be a string/) }
+      it { expect(result).to be_failure }
     end
   end
 
@@ -291,7 +335,7 @@ RSpec.describe Html2rss::Selectors::Config do
         { enclosure: { selector: 'enclosure', content_type: 'audio' } }
       end
 
-      it { expect { result }.to raise_error(/invalid format.*content_type/) }
+      it { expect(result).to be_failure }
     end
   end
 end

--- a/spec/lib/html2rss/selectors/config_spec.rb
+++ b/spec/lib/html2rss/selectors/config_spec.rb
@@ -84,6 +84,19 @@ RSpec.describe Html2rss::Selectors::Config do
         expect(result.errors.to_h.to_s).to include('must be an integer greater than 0')
       end
     end
+
+    context 'with explicit nil pagination max_pages' do
+      let(:config) do
+        { items: { selector: '.article', pagination: { max_pages: nil } } }
+      end
+
+      # Explicit nil must fail loud: a truthy check would silently accept it and
+      # leave runtime paging without a positive Integer budget.
+      it 'fails validation', :aggregate_failures do
+        expect(result).to be_failure
+        expect(result.errors.to_h.to_s).to include('`max_pages` must be an integer greater than 0')
+      end
+    end
   end
 
   describe 'Selector' do

--- a/spec/lib/html2rss/selectors/config_spec.rb
+++ b/spec/lib/html2rss/selectors/config_spec.rb
@@ -68,8 +68,9 @@ RSpec.describe Html2rss::Selectors::Config do
       end
 
       it 'fails validation', :aggregate_failures do
+        msg = '`json_cursor` strategy requires either `cursor_path` or `next_url_path`'
         expect(result).to be_failure
-        expect(result.errors.to_h.to_s).to include('`json_cursor` strategy requires either `cursor_path` or `next_url_path`')
+        expect(result.errors.to_h.to_s).to include(msg)
       end
     end
 


### PR DESCRIPTION
This pull request adds a flexible, extensible pagination system to support scraping items across multiple pages using a variety of strategies. It introduces a unified configuration for pagination, updates the schema and documentation, and implements a strategy-based pager system with support for HTML and JSON-based pagination. Additionally, it refactors the feed pipeline to use the new pagination system.

**Pagination System and Strategies**

* Added a new `Pager` module with multiple strategy classes (`RelNext`, `CustomSelector`, `UrlTemplate`, `Offset`, `JsonCursor`) under `lib/html2rss/request_session/pager/`, allowing for configurable multi-page scraping of items using different pagination mechanisms. [[1]](diffhunk://#diff-d45c77bc9aab84aa0bfc03d37f5ad6cd2b95ac73925e4bcef89c70d7e90551aaR1-R62) [[2]](diffhunk://#diff-9a5d64e243e66707d513301a5447280319f53cd147c2175ff940e48b622550dbR1-R97) [[3]](diffhunk://#diff-a236a093cbbe59d0014e9fa1f264b21585ca0f0663446f17176bc8a9c48b26c2R1-R25) [[4]](diffhunk://#diff-8b2ea91127b8c01e967f2ab3d9a0f06ec2b0661f6e9ae4c765e7603cdf361c06R1-R38) [[5]](diffhunk://#diff-d18bbaa709275100d50093063289d55e89b36db77669da91cf0deb8fa30db7c8R1-R45) [[6]](diffhunk://#diff-6beae9cd1c583ea88ea69f637b031fc261f9e8fd11c8fc6dff4296790a8c629aR1-R45) [[7]](diffhunk://#diff-f3c009954de065a508fcb8ab38a079b1e7eedc2fe0cb01ca9fd46be7960442b1R1-R78)
* The `Pager.for` factory method normalizes configuration and instantiates the correct strategy based on the `selectors.items.pagination` config.
* Supported strategies include following `rel=next` links, custom selectors, URL templates, offset-based, and JSON cursor-based pagination.

**Configuration and Schema Updates**

* Updated the configuration schema in `lib/html2rss/config/schema.rb` to support the new pagination options, including both simple integer and object-style configurations. [[1]](diffhunk://#diff-74325e8feaf46668bb4bf42a09e9ad24791254d4f0f81ebb57180d6e24f96811R124-R154) [[2]](diffhunk://#diff-74325e8feaf46668bb4bf42a09e9ad24791254d4f0f81ebb57180d6e24f96811L182-R217)
* The schema now validates strategy, max_pages, selectors, params, and other pagination-specific properties.

**Feed Pipeline Refactor**

* Refactored the feed pipeline in `lib/html2rss/feed_pipeline.rb` to use the new `Pager.for` interface for collecting articles across paginated responses, replacing the previous hardcoded `RelNextPager` logic.
* Improved handling to stop pagination when a page yields no new items after some have been collected.

**Documentation**

* Updated `README.md` to document the new pagination strategies, their configuration, and stopping conditions for pagination. (Ff0c4cffL56R56)
* Added a contributor note to `AGENTS.md` about updating the schema and running `make schema` when changing pagination configuration options.

**Code Quality and Minor Refactors**

* Simplified the feed pipeline by removing an unnecessary method and inlining the call for the auto-fallback pipeline. [[1]](diffhunk://#diff-a8dcae58b3f9cdb434bfb6920a14f518e0a804497c628e06251cb69071f79bbcL76-R77) [[2]](diffhunk://#diff-a8dcae58b3f9cdb434bfb6920a14f518e0a804497c628e06251cb69071f79bbcL95-R91)

These changes make pagination configuration more powerful and extensible, improve maintainability, and provide clear documentation for users and contributors.