### PR TITLE
refactor: deepen ownership seams (selectors, request, :auto plan)

### DIFF
--- a/lib/html2rss/auto_source/scraper/link_heuristics.rb
+++ b/lib/html2rss/auto_source/scraper/link_heuristics.rb
@@ -442,22 +442,11 @@ module Html2rss
           end
         end
 
-        # Token pattern for content-like class/id markers on containers.
-        CONTENT_TOKEN_REGEXP = begin
-          words = PathClassifier::SEGMENT_SETS.fetch(:content)
-          /(?:^|\s|[-_])(#{Regexp.union(words.to_a).source})(?:\s|[-_]|$)/i
-        end.freeze
-
-        # Token pattern for junk/utility class/id markers on containers.
-        JUNK_TOKEN_REGEXP = begin
-          words = PathClassifier::SEGMENT_SETS.fetch(:utility)
-          /(?:^|\s|[-_])(#{Regexp.union(words.to_a).source})(?:\s|[-_]|$)/i
-        end.freeze
-
         # @param base_url [String, Html2rss::Url] page URL used to resolve relative hrefs
         def initialize(base_url)
           @base_url = base_url
           @text_classifier = TextClassifier.new
+          @container_assessor = ContainerAssessor.new(text_classifier: @text_classifier)
         end
 
         # Builds normalized destination facts for an anchor element or href string.
@@ -510,50 +499,19 @@ module Html2rss
         end
 
         ##
-        # @param tokens [String, #to_s] combined class/id token string
-        # @return [Boolean] true when tokens look content-like
-        def content_tokens?(tokens) = tokens.to_s.match?(CONTENT_TOKEN_REGEXP)
-
-        ##
-        # @param tokens [String, #to_s] combined class/id token string
-        # @return [Boolean] true when tokens look like utility chrome
-        def junk_tokens?(tokens) = tokens.to_s.match?(JUNK_TOKEN_REGEXP)
-
-        ##
         # Observes a container and builds ranking signals, including hard-junk.
         #
-        # Owns DOM observation for container assessment so SemanticHtml only
-        # orchestrates candidates and extraction.
+        # Delegates DOM observation to ContainerAssessor so SemanticHtml only
+        # orchestrates candidates and extraction, while ContainerSignals keeps
+        # scoring policy.
         #
         # @param container [Nokogiri::XML::Node] semantic container node
         # @param selected_anchor [Nokogiri::XML::Node, nil] primary anchor for the container
         # @param destination_facts [DestinationFacts, nil] route facts for the selected anchor
         # @return [ContainerSignals] observation + scoring signals for the container
-        # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         def assess_container(container, selected_anchor, destination_facts:)
-          title = entry_title(container, selected_anchor)
-          tokens = container_tokens(container)
-
-          ContainerSignals.new(
-            title_word_count: word_count(title),
-            path_length: destination_facts&.url&.path.to_s.length,
-            content_path: destination_facts&.content_path,
-            publish_marker: publish_marker?(container),
-            descriptive_context: descriptive_context?(visible_text(container), title),
-            article_container: container.name == 'article',
-            content_tokens: content_tokens?(tokens),
-            junk_tokens: junk_tokens?(tokens),
-            utility_prefix_title: utility_prefix_text?(title),
-            recommended_title: recommended_text?(title),
-            utility_path: destination_facts&.utility_path,
-            strong_post_suffix: destination_facts&.strong_post_suffix,
-            shallow: destination_facts&.shallow,
-            high_confidence_junk_path: destination_facts&.high_confidence_junk_path,
-            high_confidence_utility_destination: destination_facts&.high_confidence_utility_destination,
-            selected_anchor_present: !selected_anchor.nil?
-          )
+          @container_assessor.call(container, selected_anchor, destination_facts:)
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
         private
 
@@ -573,41 +531,6 @@ module Html2rss
             url = Html2rss::Url.from_relative(href, @base_url)
             DestinationFacts.build(url)
           end
-        end
-
-        def publish_marker?(container)
-          (@publish_markers ||= {}.compare_by_identity)[container] ||=
-            !!container.at_css('time, [datetime], [itemprop="datePublished"], [itemprop="dateModified"]')
-        end
-
-        def descriptive_context?(container_text, title)
-          snippet = container_text.to_s.sub(/\A#{Regexp.escape(title.to_s)}/i, '')
-          snippet.length > 30 && word_count(snippet) >= 8
-        end
-
-        def heading_for(container)
-          (@headings ||= {}.compare_by_identity)[container] ||=
-            container.at_css(HtmlNavigator::HEADING_TAGS.join(','))
-        end
-
-        def visible_text(node)
-          return '' unless node
-
-          (@visible_texts ||= {}.compare_by_identity)[node] ||= HtmlNavigator.extract_visible_text(node).to_s.strip
-        end
-
-        def entry_title(container, selected_anchor) = visible_text(heading_for(container) || selected_anchor)
-
-        def word_count(text)
-          (@word_counts ||= {})[text] ||= begin
-            count = 0
-            text.to_s.scan(/\p{Alnum}+/) { count += 1 }
-            count
-          end
-        end
-
-        def container_tokens(container)
-          (@container_tokens ||= {}.compare_by_identity)[container] ||= "#{container['class']} #{container['id']}"
         end
       end
     end

--- a/lib/html2rss/auto_source/scraper/link_heuristics/container_assessor.rb
+++ b/lib/html2rss/auto_source/scraper/link_heuristics/container_assessor.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+module Html2rss
+  class AutoSource
+    module Scraper
+      class LinkHeuristics
+        ##
+        # Turns container DOM observations into ContainerSignals inputs.
+        #
+        # Owns publish markers, headings, visible text, and class/id tokens so
+        # LinkHeuristics can keep eligibility policy and ContainerSignals can
+        # keep scoring without re-reading the DOM.
+        class ContainerAssessor
+          # Token pattern for content-like class/id markers on containers.
+          CONTENT_TOKEN_REGEXP = begin
+            words = PathClassifier::SEGMENT_SETS.fetch(:content)
+            /(?:^|\s|[-_])(#{Regexp.union(words.to_a).source})(?:\s|[-_]|$)/i
+          end.freeze
+
+          # Token pattern for junk/utility class/id markers on containers.
+          JUNK_TOKEN_REGEXP = begin
+            words = PathClassifier::SEGMENT_SETS.fetch(:utility)
+            /(?:^|\s|[-_])(#{Regexp.union(words.to_a).source})(?:\s|[-_]|$)/i
+          end.freeze
+
+          # @param text_classifier [TextClassifier] shared utility/recommended text policy
+          def initialize(text_classifier:)
+            @text_classifier = text_classifier
+          end
+
+          ##
+          # Observes a container and builds ranking signals, including hard-junk.
+          #
+          # @param container [Nokogiri::XML::Node] semantic container node
+          # @param selected_anchor [Nokogiri::XML::Node, nil] primary anchor for the container
+          # @param destination_facts [DestinationFacts, nil] route facts for the selected anchor
+          # @return [ContainerSignals] observation + scoring signals for the container
+          # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+          def call(container, selected_anchor, destination_facts:)
+            title = entry_title(container, selected_anchor)
+            tokens = container_tokens(container)
+
+            ContainerSignals.new(
+              title_word_count: word_count(title),
+              path_length: destination_facts&.url&.path.to_s.length,
+              content_path: destination_facts&.content_path,
+              publish_marker: publish_marker?(container),
+              descriptive_context: descriptive_context?(visible_text(container), title),
+              article_container: container.name == 'article',
+              content_tokens: content_tokens?(tokens),
+              junk_tokens: junk_tokens?(tokens),
+              utility_prefix_title: @text_classifier.utility_prefix?(title),
+              recommended_title: @text_classifier.recommended?(title),
+              utility_path: destination_facts&.utility_path,
+              strong_post_suffix: destination_facts&.strong_post_suffix,
+              shallow: destination_facts&.shallow,
+              high_confidence_junk_path: destination_facts&.high_confidence_junk_path,
+              high_confidence_utility_destination: destination_facts&.high_confidence_utility_destination,
+              selected_anchor_present: !selected_anchor.nil?
+            )
+          end
+          # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+          private
+
+          def publish_marker?(container)
+            (@publish_markers ||= {}.compare_by_identity)[container] ||=
+              !!container.at_css('time, [datetime], [itemprop="datePublished"], [itemprop="dateModified"]')
+          end
+
+          def descriptive_context?(container_text, title)
+            snippet = container_text.to_s.sub(/\A#{Regexp.escape(title.to_s)}/i, '')
+            snippet.length > 30 && word_count(snippet) >= 8
+          end
+
+          def heading_for(container)
+            (@headings ||= {}.compare_by_identity)[container] ||=
+              container.at_css(HtmlNavigator::HEADING_TAGS.join(','))
+          end
+
+          def visible_text(node)
+            return '' unless node
+
+            (@visible_texts ||= {}.compare_by_identity)[node] ||= HtmlNavigator.extract_visible_text(node).to_s.strip
+          end
+
+          def entry_title(container, selected_anchor) = visible_text(heading_for(container) || selected_anchor)
+
+          def word_count(text)
+            (@word_counts ||= {})[text] ||= begin
+              count = 0
+              text.to_s.scan(/\p{Alnum}+/) { count += 1 }
+              count
+            end
+          end
+
+          def container_tokens(container)
+            (@container_tokens ||= {}.compare_by_identity)[container] ||= "#{container['class']} #{container['id']}"
+          end
+
+          def content_tokens?(tokens) = tokens.to_s.match?(CONTENT_TOKEN_REGEXP)
+
+          def junk_tokens?(tokens) = tokens.to_s.match?(JUNK_TOKEN_REGEXP)
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/auto_source/scraper/wordpress_api/page_scope.rb
+++ b/lib/html2rss/auto_source/scraper/wordpress_api/page_scope.rb
@@ -99,7 +99,7 @@ module Html2rss
             def date_scope
               return unless date_archive?
 
-              range = date_archive_range
+              range = DateArchiveRange.from_segments(scoped_path_segments)
               return unknown_archive_scope unless range
 
               PageScope.new(query: range, fetchable: true, reason: :archive)
@@ -195,45 +195,7 @@ module Html2rss
             end
 
             def date_archive_path?
-              !date_archive_segments.nil?
-            end
-
-            def date_archive_range
-              components = date_archive_components
-              return unless components
-
-              start_date = Date.new(*components.fetch(:start_date_parts))
-              {
-                'after' => iso8601_start(start_date),
-                'before' => iso8601_start(next_archive_boundary(start_date, components.fetch(:precision)))
-              }
-            rescue Date::Error
-              nil
-            end
-
-            def date_archive_components
-              segments = date_archive_segments
-              return unless segments
-
-              year = segments.fetch(0).to_i
-              month = parse_archive_segment(segments[1], 1, 12)
-              day = parse_archive_segment(segments[2], 1, 31)
-
-              {
-                start_date_parts: [year, month || 1, day || 1],
-                precision: archive_precision(month:, day:)
-              }
-            end
-
-            def date_archive_segments
-              year_index = scoped_path_segments.find_index { _1.match?(/\A\d{4}\z/) }
-              return unless year_index
-
-              segments = scoped_path_segments.drop(year_index)
-              return unless segments.length.between?(1, 3)
-              return unless archive_segment_shape?(segments)
-
-              segments
+              DateArchiveRange.path?(scoped_path_segments)
             end
 
             def paginated_path?
@@ -253,46 +215,8 @@ module Html2rss
               parse_positive_integer(path_segments[-1])
             end
 
-            def archive_segment_shape?(segments)
-              month = segments[1]
-              day = segments[2]
-              return false if day && month.nil?
-              return false unless month.nil? || month.match?(/\A\d+\z/)
-              return false unless day.nil? || day.match?(/\A\d+\z/)
-
-              true
-            end
-
             def same_origin_url?(left, right)
               [left.scheme, left.host, left.port] == [right.scheme, right.host, right.port]
-            end
-
-            def archive_precision(month:, day:)
-              return :day if day
-              return :month if month
-
-              :year
-            end
-
-            def next_archive_boundary(start_date, precision)
-              {
-                year: start_date.next_year,
-                month: start_date.next_month,
-                day: start_date.next_day
-              }.fetch(precision)
-            end
-
-            def iso8601_start(date)
-              date.strftime('%Y-%m-%dT00:00:00Z')
-            end
-
-            def parse_archive_segment(value, minimum, maximum)
-              return nil unless value&.match?(/\A\d+\z/)
-
-              number = value.to_i
-              return nil if number < minimum || number > maximum
-
-              number
             end
 
             def parse_positive_integer(value)

--- a/lib/html2rss/auto_source/scraper/wordpress_api/page_scope/date_archive_range.rb
+++ b/lib/html2rss/auto_source/scraper/wordpress_api/page_scope/date_archive_range.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'date'
+
+module Html2rss
+  class AutoSource
+    module Scraper
+      class WordpressApi
+        class PageScope
+          ##
+          # Maps scoped archive path segments to WordPress REST +after+/+before+ bounds.
+          #
+          # Owns date-path shape detection and calendar range math only. Body-class
+          # taxonomy/author signals and pagination stay on {Resolver}.
+          class DateArchiveRange
+            ##
+            # @param segments [Array<String>] path segments with pagination already stripped
+            # @return [Hash{String => String}, nil] +after+/+before+ ISO8601 bounds, or +nil+
+            def self.from_segments(segments)
+              components = components_from(segments)
+              return unless components
+
+              start_date = Date.new(*components.fetch(:start_date_parts))
+              {
+                'after' => iso8601_start(start_date),
+                'before' => iso8601_start(next_archive_boundary(start_date, components.fetch(:precision)))
+              }
+            rescue Date::Error
+              nil
+            end
+
+            ##
+            # @param segments [Array<String>] path segments with pagination already stripped
+            # @return [Boolean] whether segments match a year[/month[/day]] archive shape
+            def self.path?(segments)
+              !date_segments_from(segments).nil?
+            end
+
+            class << self
+              private
+
+              def components_from(segments)
+                date_segments = date_segments_from(segments)
+                return unless date_segments
+
+                year = date_segments.fetch(0).to_i
+                month = parse_archive_segment(date_segments[1], 1, 12)
+                day = parse_archive_segment(date_segments[2], 1, 31)
+
+                {
+                  start_date_parts: [year, month || 1, day || 1],
+                  precision: archive_precision(month:, day:)
+                }
+              end
+
+              def date_segments_from(segments)
+                year_index = segments.find_index { _1.match?(/\A\d{4}\z/) }
+                return unless year_index
+
+                date_segments = segments.drop(year_index)
+                return unless date_segments.length.between?(1, 3)
+                return unless archive_segment_shape?(date_segments)
+
+                date_segments
+              end
+
+              def archive_segment_shape?(segments)
+                month = segments[1]
+                day = segments[2]
+                return false if day && month.nil?
+                return false unless month.nil? || month.match?(/\A\d+\z/)
+                return false unless day.nil? || day.match?(/\A\d+\z/)
+
+                true
+              end
+
+              def archive_precision(month:, day:)
+                return :day if day
+                return :month if month
+
+                :year
+              end
+
+              def next_archive_boundary(start_date, precision)
+                {
+                  year: start_date.next_year,
+                  month: start_date.next_month,
+                  day: start_date.next_day
+                }.fetch(precision)
+              end
+
+              def iso8601_start(date)
+                date.strftime('%Y-%m-%dT00:00:00Z')
+              end
+
+              def parse_archive_segment(value, minimum, maximum)
+                return nil unless value&.match?(/\A\d+\z/)
+
+                number = value.to_i
+                return nil if number < minimum || number > maximum
+
+                number
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/cli.rb
+++ b/lib/html2rss/cli.rb
@@ -9,14 +9,15 @@ module Html2rss
   # The Html2rss command line interface.
   class CLI < Thor # rubocop:disable Metrics/ClassLength
     check_unknown_options!
-    # Ordered fallback chain attempted by auto strategy.
+    # Ordered fallback chain attempted by the feed-level :auto plan.
     #
     # @return [Array<Symbol>]
     AUTO_FALLBACK_CHAIN = Html2rss::FeedPipeline::AutoFallback::CHAIN.freeze
-    # Supported CLI strategy option values.
+    # Supported CLI strategy plan option values (:auto plus concrete strategies).
     #
     # @return [Array<String>]
-    STRATEGY_OPTION_ENUM = (['auto'] + Html2rss::RequestService.strategy_names).uniq.freeze
+    STRATEGY_OPTION_ENUM = Html2rss::FeedPipeline::StrategyPlan.accepted_names.map(&:to_s).freeze
+
     # User-facing strategy help text that reflects the current fallback chain.
     #
     # @return [String]

--- a/lib/html2rss/config/class_methods.rb
+++ b/lib/html2rss/config/class_methods.rb
@@ -139,7 +139,7 @@ module Html2rss
         }
       end
 
-      # @return [Symbol] the default strategy for feed orchestration
+      # @return [Symbol] the default feed-level strategy plan (+:auto+ or concrete)
       def default_strategy_name
         Html2rss.configuration.default_strategy || :auto
       end

--- a/lib/html2rss/config/validator.rb
+++ b/lib/html2rss/config/validator.rb
@@ -13,8 +13,8 @@ module Html2rss
       STYLESHEET_TYPES = RssBuilder::Stylesheet::TYPES
       # Optional language/region format (`en` or `en-US`).
       LANGUAGE_FORMAT_REGEX = /\A[a-z]{2}(-[A-Z]{2})?\z/
-      # Baseline strategy enum exported in static schema artifacts.
-      BASE_STRATEGY_OPTIONS = ([:auto] + Html2rss::RequestService.strategy_names.map(&:to_sym)).uniq.freeze
+      # Baseline strategy-plan enum (:auto plus concrete RequestService strategies).
+      BASE_STRATEGY_OPTIONS = Html2rss::FeedPipeline::StrategyPlan.accepted_names.freeze
 
       # Contract for the top-level `channel` section.
       ChannelConfig = Dry::Schema.Params do
@@ -111,7 +111,7 @@ module Html2rss
 
       rule(:strategy) do
         next if value.nil?
-        next if value == :auto || Html2rss::RequestService.strategy_registered?(value)
+        next if Html2rss::FeedPipeline::StrategyPlan.valid?(value)
 
         key.failure("must be one of: #{BASE_STRATEGY_OPTIONS.join(', ')}")
       end

--- a/lib/html2rss/configuration.rb
+++ b/lib/html2rss/configuration.rb
@@ -93,11 +93,13 @@ module Html2rss
     end
 
     ##
-    # Sets the default strategy.
+    # Sets the default feed-level strategy plan (+:auto+ or a concrete transport strategy).
     #
-    # @param strategy [Symbol, String, nil] the strategy name
-    # @return [Symbol, nil] the normalized strategy name
-    # @raise [ArgumentError] if the strategy is not registered
+    # +:auto+ is not a {RequestService} adapter — it is resolved by {FeedPipeline::StrategyPlan}.
+    #
+    # @param strategy [Symbol, String, nil] the strategy plan name
+    # @return [Symbol, nil] the normalized strategy plan name
+    # @raise [ArgumentError] if the strategy plan is unknown
     def default_strategy=(strategy)
       if strategy.nil?
         @default_strategy = nil
@@ -107,7 +109,7 @@ module Html2rss
         end
 
         normalized = strategy.to_sym
-        raise ArgumentError, "unknown strategy: #{strategy}" unless RequestService.strategy_registered?(normalized)
+        raise ArgumentError, "unknown strategy: #{strategy}" unless FeedPipeline::StrategyPlan.valid?(normalized)
 
         @default_strategy = normalized
       end

--- a/lib/html2rss/feed_pipeline.rb
+++ b/lib/html2rss/feed_pipeline.rb
@@ -42,10 +42,11 @@ module Html2rss
     end
 
     def pipeline_state_for(config)
-      if config.strategy == :auto
+      plan = StrategyPlan.resolve(config.strategy)
+      if plan.is_a?(StrategyPlan::Auto)
         run_auto_pipeline(config)
       else
-        run_pipeline_for_strategy(config, strategy: config.strategy, budget: pipeline_budget(config))
+        run_pipeline_for_strategy(config, strategy: plan.strategy, budget: pipeline_budget(config))
       end
     end
 

--- a/lib/html2rss/feed_pipeline/auto_fallback.rb
+++ b/lib/html2rss/feed_pipeline/auto_fallback.rb
@@ -2,9 +2,11 @@
 
 module Html2rss
   class FeedPipeline
-    # Retries feed extraction across concrete request strategies for :auto mode.
+    # Retries feed extraction across concrete request strategies for the :auto plan.
+    #
+    # Owned by {FeedPipeline}; invoked only after {StrategyPlan} resolves +:auto+.
     class AutoFallback
-      # Ordered list of concrete request strategies attempted by auto mode.
+      # Ordered list of concrete request strategies attempted by the :auto plan.
       CHAIN = %i[faraday botasaurus browserless].freeze
 
       # Error classes that should abort auto fallback immediately.

--- a/lib/html2rss/feed_pipeline/strategy_plan.rb
+++ b/lib/html2rss/feed_pipeline/strategy_plan.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Html2rss
+  class FeedPipeline
+    ##
+    # Feed-level request plan: +:auto+ (fallback chain) or a concrete transport strategy.
+    #
+    # {RequestService} executes concrete adapters only. +:auto+ is resolved here before
+    # any session or adapter call — plan vs transport locality.
+    class StrategyPlan
+      # Feed-level auto plan: try {AutoFallback::CHAIN} until items are extracted.
+      Auto = Data.define
+
+      # Concrete transport strategy name for {RequestService}.
+      Concrete = Data.define(:strategy)
+
+      # Symbol used in config / configure for the auto plan.
+      AUTO_NAME = :auto
+
+      class << self
+        ##
+        # @param name [Symbol, String] config or configure strategy value
+        # @return [Auto, Concrete] resolved feed-level plan
+        # @raise [ArgumentError] when +name+ is neither +:auto+ nor a registered strategy
+        def resolve(name)
+          normalized = name.to_sym
+          return Auto.new if normalized == AUTO_NAME
+
+          unless RequestService.strategy_registered?(normalized)
+            raise ArgumentError, "unknown strategy plan: #{name.inspect}"
+          end
+
+          Concrete.new(strategy: normalized)
+        end
+
+        ##
+        # @param name [Symbol, String, nil] candidate plan name
+        # @return [Boolean] whether +name+ is a valid feed-level strategy plan
+        def valid?(name)
+          return false unless name.is_a?(Symbol) || name.is_a?(String)
+
+          resolve(name)
+          true
+        rescue ArgumentError
+          false
+        end
+
+        ##
+        # @return [Array<Symbol>] accepted plan names (+:auto+ plus registered strategies)
+        def accepted_names
+          [AUTO_NAME, *RequestService.strategy_names.map(&:to_sym)].uniq
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/request_service.rb
+++ b/lib/html2rss/request_service.rb
@@ -6,7 +6,10 @@ require 'forwardable'
 module Html2rss
   ##
   # Requests website URLs to retrieve their HTML for further processing.
-  # Provides strategies, e.g. integrating Browserless.io.
+  # Provides concrete transport strategies (e.g. Faraday, Browserless).
+  #
+  # Feed-level +:auto+ is not registered here — {FeedPipeline::StrategyPlan} resolves
+  # it to a concrete strategy (or {FeedPipeline::AutoFallback} chain) before execute.
   class RequestService
     include Singleton
 

--- a/lib/html2rss/request_service/network_guard.rb
+++ b/lib/html2rss/request_service/network_guard.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require 'ipaddr'
+require 'resolv'
+require 'socket'
+
+module Html2rss
+  class RequestService
+    ##
+    # Enforces public-network reachability for request targets and remote IPs.
+    #
+    # Owns DNS resolution, host denylist, and blocked IP ranges. Callers go through
+    # {Policy} so SSRF/origin rules stay single-homed on the public façade.
+    class NetworkGuard
+      # Hostnames treated as local/private surfaces.
+      LOCAL_HOSTS = %w[localhost localhost.localdomain metadata.google.internal].to_set.freeze
+      # IP ranges blocked when private networks are disabled.
+      BLOCKED_IP_RANGES = [
+        IPAddr.new('0.0.0.0/8'),
+        IPAddr.new('10.0.0.0/8'),
+        IPAddr.new('127.0.0.0/8'),
+        IPAddr.new('169.254.0.0/16'),
+        IPAddr.new('172.16.0.0/12'),
+        IPAddr.new('192.168.0.0/16'),
+        IPAddr.new('224.0.0.0/4'),
+        IPAddr.new('::/128'),
+        IPAddr.new('::1/128'),
+        IPAddr.new('fe80::/10'),
+        IPAddr.new('fc00::/7'),
+        IPAddr.new('ff00::/8')
+      ].freeze
+
+      ##
+      # @param allow_private_networks [Boolean] whether private network targets are allowed
+      # @param resolver [#each_address, #getaddrinfo] DNS resolver used for hostname classification
+      def initialize(allow_private_networks:, resolver: Socket)
+        @allow_private_networks = allow_private_networks ? true : false
+        @resolver = resolver
+        freeze
+      end
+
+      ##
+      # Rejects URLs whose host is denylisted or resolves to a blocked address.
+      #
+      # @param url [Html2rss::Url] destination URL
+      # @return [void]
+      # @raise [PrivateNetworkDenied] if the target resolves to a private address
+      def enforce_public_network!(url)
+        host = url.host
+        return if allow_private_networks?
+        return unless blocked_host?(host) || resolved_ip_addresses(host).any? { |address| blocked_ip?(address) }
+
+        raise PrivateNetworkDenied, "Private network target denied for #{url}"
+      end
+
+      ##
+      # Validates the resolved remote IP for a completed request.
+      #
+      # @param ip [String, nil] remote IP address reported by the client
+      # @param url [Html2rss::Url] URL associated with the response
+      # @return [void]
+      # @raise [PrivateNetworkDenied] if the response came from a blocked address
+      def validate_remote_ip!(ip:, url:)
+        return if allow_private_networks?
+        return if ip.nil? || ip.empty?
+
+        parsed_ip = parse_ip(ip)
+        raise PrivateNetworkDenied, "Remote IP could not be validated for #{url}" unless parsed_ip
+        return unless blocked_ip?(parsed_ip)
+
+        raise PrivateNetworkDenied, "Private network target denied for #{url}"
+      end
+
+      private
+
+      attr_reader :resolver
+
+      def allow_private_networks?
+        @allow_private_networks
+      end
+
+      def blocked_host?(host)
+        LOCAL_HOSTS.include?(host.to_s.downcase)
+      end
+
+      def resolved_ip_addresses(host)
+        literal = parse_ip(host)
+        return [literal] if literal
+
+        if resolver.respond_to?(:each_address)
+          addresses_from_each_address(host)
+        else
+          addresses_from_getaddrinfo(host)
+        end
+      rescue Resolv::ResolvError, SocketError, SystemCallError
+        []
+      end
+
+      def addresses_from_each_address(host)
+        [].tap do |addresses|
+          resolver.each_address(host) do |address|
+            parsed = parse_ip(address)
+            addresses << parsed if parsed
+          end
+        end
+      end
+
+      def addresses_from_getaddrinfo(host)
+        resolver.getaddrinfo(host, nil).filter_map do |entry|
+          parse_ip(entry[3])
+        end
+      end
+
+      def parse_ip(value)
+        IPAddr.new(value)
+      rescue IPAddr::AddressFamilyError, IPAddr::InvalidAddressError
+        nil
+      end
+
+      def blocked_ip?(address)
+        BLOCKED_IP_RANGES.any? { |range| range.include?(address) }
+      end
+    end
+  end
+end

--- a/lib/html2rss/request_service/policy.rb
+++ b/lib/html2rss/request_service/policy.rb
@@ -1,32 +1,16 @@
 # frozen_string_literal: true
 
-require 'ipaddr'
-require 'resolv'
 require 'socket'
 
 module Html2rss
   class RequestService
     ##
     # Describes the runtime request envelope for a single feed build.
-    class Policy # rubocop:disable Metrics/ClassLength
+    #
+    # Public façade for request limits, same-origin/follow-up rules, and
+    # network reachability. DNS/host/IP enforcement lives on {NetworkGuard}.
+    class Policy
       MAX_REQUESTS_CEILING = 10
-      # Hostnames treated as local/private surfaces.
-      LOCAL_HOSTS = %w[localhost localhost.localdomain metadata.google.internal].to_set.freeze
-      # IP ranges blocked when private networks are disabled.
-      BLOCKED_IP_RANGES = [
-        IPAddr.new('0.0.0.0/8'),
-        IPAddr.new('10.0.0.0/8'),
-        IPAddr.new('127.0.0.0/8'),
-        IPAddr.new('169.254.0.0/16'),
-        IPAddr.new('172.16.0.0/12'),
-        IPAddr.new('192.168.0.0/16'),
-        IPAddr.new('224.0.0.0/4'),
-        IPAddr.new('::/128'),
-        IPAddr.new('::1/128'),
-        IPAddr.new('fe80::/10'),
-        IPAddr.new('fc00::/7'),
-        IPAddr.new('ff00::/8')
-      ].freeze
 
       # Default policy values used when request controls are not explicitly set.
       DEFAULTS = {
@@ -71,7 +55,7 @@ module Html2rss
         @max_requests = [validate_positive_integer!(:max_requests, max_requests), MAX_REQUESTS_CEILING].min
         @allow_private_networks = allow_private_networks ? true : false
         @allow_cross_origin_followups = allow_cross_origin_followups ? true : false
-        @resolver = resolver
+        @network_guard = NetworkGuard.new(allow_private_networks: @allow_private_networks, resolver:)
         freeze
       end
 
@@ -116,7 +100,7 @@ module Html2rss
       # @raise [PrivateNetworkDenied] if the target resolves to a private address
       def validate_request!(url:, origin_url:, relation:)
         enforce_same_origin!(url, origin_url, relation)
-        enforce_public_network!(url)
+        network_guard.enforce_public_network!(url)
       end
 
       ##
@@ -144,19 +128,12 @@ module Html2rss
       # @return [void]
       # @raise [PrivateNetworkDenied] if the response came from a blocked address
       def validate_remote_ip!(ip:, url:)
-        return if allow_private_networks?
-        return if ip.nil? || ip.empty?
-
-        parsed_ip = parse_ip(ip)
-        raise PrivateNetworkDenied, "Remote IP could not be validated for #{url}" unless parsed_ip
-        return unless blocked_ip?(parsed_ip)
-
-        raise PrivateNetworkDenied, "Private network target denied for #{url}"
+        network_guard.validate_remote_ip!(ip:, url:)
       end
 
       private
 
-      attr_reader :resolver
+      attr_reader :network_guard
 
       def validate_positive_integer!(name, value)
         raise ArgumentError, "#{name} must be positive" unless value.is_a?(Integer) && value.positive?
@@ -193,56 +170,6 @@ module Html2rss
         return url.port if url.port
 
         url.scheme == 'https' ? 443 : 80
-      end
-
-      def enforce_public_network!(url)
-        host = url.host
-        return if allow_private_networks?
-        return unless blocked_host?(host) || resolved_ip_addresses(host).any? { |address| blocked_ip?(address) }
-
-        raise PrivateNetworkDenied, "Private network target denied for #{url}"
-      end
-
-      def blocked_host?(host)
-        LOCAL_HOSTS.include?(host.to_s.downcase)
-      end
-
-      def resolved_ip_addresses(host)
-        literal = parse_ip(host)
-        return [literal] if literal
-
-        if resolver.respond_to?(:each_address)
-          addresses_from_each_address(host)
-        else
-          addresses_from_getaddrinfo(host)
-        end
-      rescue Resolv::ResolvError, SocketError, SystemCallError
-        []
-      end
-
-      def addresses_from_each_address(host)
-        [].tap do |addresses|
-          resolver.each_address(host) do |address|
-            parsed = parse_ip(address)
-            addresses << parsed if parsed
-          end
-        end
-      end
-
-      def addresses_from_getaddrinfo(host)
-        resolver.getaddrinfo(host, nil).filter_map do |entry|
-          parse_ip(entry[3])
-        end
-      end
-
-      def parse_ip(value)
-        IPAddr.new(value)
-      rescue IPAddr::AddressFamilyError, IPAddr::InvalidAddressError
-        nil
-      end
-
-      def blocked_ip?(address)
-        BLOCKED_IP_RANGES.any? { |range| range.include?(address) }
       end
     end
 

--- a/lib/html2rss/request_service/policy.rb
+++ b/lib/html2rss/request_service/policy.rb
@@ -10,6 +10,7 @@ module Html2rss
     # Public façade for request limits, same-origin/follow-up rules, and
     # network reachability. DNS/host/IP enforcement lives on {NetworkGuard}.
     class Policy
+      # Hard ceiling for configured max_requests during a feed build.
       MAX_REQUESTS_CEILING = 10
 
       # Default policy values used when request controls are not explicitly set.

--- a/lib/html2rss/request_service/puppet_commander.rb
+++ b/lib/html2rss/request_service/puppet_commander.rb
@@ -23,6 +23,7 @@ module Html2rss
         @browser = browser
         @skip_request_resources = skip_request_resources
         @referer = referer
+        @navigation_guards = NavigationGuards.new(ctx:, skip_request_resources:)
       end
 
       ##
@@ -33,9 +34,9 @@ module Html2rss
         page = new_page
         navigation_response = navigate_to_destination(page, ctx.url)
         perform_preload(page)
-        raise_navigation_error_if_any
-        final_navigation_response = latest_navigation_response || navigation_response
-        validate_navigation_response!(final_navigation_response)
+        navigation_guards.raise_deferred_error!
+        final_navigation_response = navigation_guards.latest_navigation_response || navigation_response
+        navigation_guards.validate_final!(final_navigation_response)
         build_response(page, final_navigation_response)
       ensure
         page&.close
@@ -46,9 +47,8 @@ module Html2rss
       # @see https://yusukeiwaki.github.io/puppeteer-ruby-docs/Puppeteer/Page.html
       def new_page
         page = browser.new_page
-        @main_frame = page.main_frame if page.respond_to?(:main_frame)
         configure_page(page)
-        configure_navigation_guards(page)
+        navigation_guards.install!(page)
         page
       end
 
@@ -62,28 +62,16 @@ module Html2rss
       end
 
       ##
-      # @param page [Puppeteer::Page]
-      # @return [void]
-      def configure_navigation_guards(page)
-        page.request_interception = true
-        page.on('request') do |request|
-          handle_request(request)
-        end
-        page.on('response') { |response| handle_response(response) }
-      end
-
-      ##
       # @param page [Puppeteer::Page] browser page
       # @param url [Html2rss::Url] target URL
       # @return [Puppeteer::HTTPResponse, nil] the navigation response if one was produced
       def navigate_to_destination(page, url)
-        @navigation_error = nil
-        @latest_navigation_response = nil
+        navigation_guards.begin_navigation!
         page.goto(url, wait_until: 'networkidle0', referer:, timeout: navigation_timeout_ms).tap do
-          raise_navigation_error_if_any
+          navigation_guards.raise_deferred_error!
         end
       rescue StandardError
-        raise_navigation_error_if_any
+        navigation_guards.raise_deferred_error!
 
         raise
       end
@@ -95,15 +83,7 @@ module Html2rss
 
       private
 
-      attr_reader :ctx, :browser, :skip_request_resources, :referer, :latest_navigation_response, :main_frame
-
-      ##
-      # Re-raises a deferred navigation error when one was captured.
-      #
-      # @raise [Html2rss::Error] when a navigation request or response validation failed
-      def raise_navigation_error_if_any
-        raise @navigation_error if @navigation_error
-      end
+      attr_reader :ctx, :browser, :skip_request_resources, :referer, :navigation_guards
 
       def navigation_timeout_ms
         timeout = ctx.budget.remaining_timeout_seconds || ctx.policy.total_timeout_seconds
@@ -116,40 +96,6 @@ module Html2rss
         ctx.headers.reject { |key, _| BROWSER_UNSAFE_HEADERS.include?(key.to_s.downcase) }
       end
 
-      def handle_request(request)
-        validate_request!(request)
-
-        skip_request_resources.member?(request.resource_type) ? request.abort : request.continue
-      rescue Html2rss::Error => error
-        store_navigation_error(error, navigation_request: request.navigation_request?)
-        request.abort
-      end
-
-      def handle_response(response)
-        @latest_navigation_response = response if main_frame_navigation_response?(response)
-        validate_response!(response)
-      rescue Html2rss::Error => error
-        store_navigation_error(error, navigation_request: response.request.navigation_request?)
-      end
-
-      def validate_request!(request)
-        validate_navigation_redirect_chain!(request)
-        validate_navigation_target!(request)
-      end
-
-      def main_frame_navigation_response?(response)
-        request = response.request
-        return false unless request.navigation_request?
-        return true unless request.respond_to?(:frame)
-
-        frame = request.frame
-        return true if frame.nil?
-        return frame == main_frame unless main_frame.nil?
-        return true unless frame.respond_to?(:parent_frame)
-
-        frame.parent_frame.nil?
-      end
-
       def build_response(page, navigation_response)
         Response.new(
           body: body(page),
@@ -159,46 +105,9 @@ module Html2rss
         )
       end
 
-      def validate_navigation_response!(navigation_response)
-        final_url = response_url(navigation_response, ctx.url)
-        ctx.policy.validate_remote_ip!(ip: remote_ip(navigation_response), url: final_url)
-      end
-
-      def validate_response!(response)
-        validate_navigation_response!(response)
-      end
-
       def response_url(navigation_response, fallback_url)
         raw_url = navigation_response&.url || fallback_url.to_s
         Html2rss::Url.from_absolute(raw_url)
-      end
-
-      def remote_ip(navigation_response)
-        navigation_response.remote_address&.ip
-      end
-
-      def request_chain(request)
-        (request.redirect_chain + [request]).map { |entry| request_url(entry) }
-      end
-
-      def request_url(request)
-        Html2rss::Url.from_absolute(request.url)
-      end
-
-      def validate_navigation_redirect_chain!(request)
-        request_chain(request).each_cons(2) do |from_url, to_url|
-          ctx.policy.validate_redirect!(from_url:, to_url:, origin_url: ctx.origin_url, relation: ctx.relation)
-        end
-      end
-
-      def validate_navigation_target!(request)
-        ctx.policy.validate_request!(url: request_url(request), origin_url: ctx.origin_url, relation: ctx.relation)
-      end
-
-      def store_navigation_error(error, navigation_request:)
-        return unless navigation_request
-
-        @navigation_error = error if @navigation_error.nil?
       end
 
       def perform_preload(page)

--- a/lib/html2rss/request_service/puppet_commander.rb
+++ b/lib/html2rss/request_service/puppet_commander.rb
@@ -5,6 +5,7 @@ module Html2rss
     ##
     # Commands the Puppeteer Browser to the website and builds the Response.
     class PuppetCommander
+      # Request header names that must not be forwarded to the browser session.
       BROWSER_UNSAFE_HEADERS = %w[
         host connection content-length transfer-encoding
         sec-fetch-dest sec-fetch-mode sec-fetch-site sec-fetch-user

--- a/lib/html2rss/request_service/puppet_commander.rb
+++ b/lib/html2rss/request_service/puppet_commander.rb
@@ -4,7 +4,7 @@ module Html2rss
   class RequestService
     ##
     # Commands the Puppeteer Browser to the website and builds the Response.
-    class PuppetCommander # rubocop:disable Metrics/ClassLength
+    class PuppetCommander
       BROWSER_UNSAFE_HEADERS = %w[
         host connection content-length transfer-encoding
         sec-fetch-dest sec-fetch-mode sec-fetch-site sec-fetch-user
@@ -21,9 +21,9 @@ module Html2rss
                      referer: [ctx.url.scheme, ctx.url.host].join('://'))
         @ctx = ctx
         @browser = browser
-        @skip_request_resources = skip_request_resources
         @referer = referer
         @navigation_guards = NavigationGuards.new(ctx:, skip_request_resources:)
+        @preload_runner = PreloadRunner.new(ctx:)
       end
 
       ##
@@ -33,7 +33,7 @@ module Html2rss
       def call
         page = new_page
         navigation_response = navigate_to_destination(page, ctx.url)
-        perform_preload(page)
+        preload_runner.call(page)
         navigation_guards.raise_deferred_error!
         final_navigation_response = navigation_guards.latest_navigation_response || navigation_response
         navigation_guards.validate_final!(final_navigation_response)
@@ -83,7 +83,7 @@ module Html2rss
 
       private
 
-      attr_reader :ctx, :browser, :skip_request_resources, :referer, :navigation_guards
+      attr_reader :ctx, :browser, :referer, :navigation_guards, :preload_runner
 
       def navigation_timeout_ms
         timeout = ctx.budget.remaining_timeout_seconds || ctx.policy.total_timeout_seconds
@@ -108,65 +108,6 @@ module Html2rss
       def response_url(navigation_response, fallback_url)
         raw_url = navigation_response&.url || fallback_url.to_s
         Html2rss::Url.from_absolute(raw_url)
-      end
-
-      def perform_preload(page)
-        preload_config = ctx.browserless_preload
-        return unless preload_config
-
-        wait_after(page, preload_config[:wait_after_ms])
-        click_selectors(page, preload_config[:click_selectors]) if preload_config[:click_selectors]
-        scroll_down(page, preload_config[:scroll_down]) if preload_config[:scroll_down]
-        wait_after(page, preload_config[:wait_after_ms])
-      end
-
-      def wait_after(page, timeout_ms)
-        return unless timeout_ms
-
-        ctx.budget.consume_interaction!
-        page.wait_for_timeout(timeout_ms)
-      end
-
-      def click_selectors(page, selectors)
-        selectors.each { |selector_config| click_selector(page, selector_config) }
-      end
-
-      def scroll_down(page, config)
-        iterations = config.fetch(:iterations, 1)
-        wait_after_ms = config[:wait_after_ms]
-        previous_height = nil
-
-        iterations.times do
-          updated_height = perform_scroll_iteration(page, wait_after_ms, previous_height)
-          break unless updated_height
-
-          previous_height = updated_height
-        end
-      end
-
-      def click_selector(page, config)
-        selector = config.fetch(:selector)
-        max_clicks = config.fetch(:max_clicks, 1)
-        wait_after_ms = config[:wait_after_ms]
-
-        max_clicks.times do
-          break unless (element = page.query_selector(selector))
-
-          ctx.budget.consume_interaction!
-          element.click
-          wait_after(page, wait_after_ms)
-        end
-      end
-
-      def perform_scroll_iteration(page, wait_after_ms, previous_height)
-        ctx.budget.consume_interaction!
-        page.evaluate('() => window.scrollTo(0, document.body.scrollHeight)')
-        wait_after(page, wait_after_ms)
-
-        current_height = page.evaluate('() => document.body.scrollHeight')
-        return if previous_height && current_height <= previous_height
-
-        current_height
       end
     end
   end

--- a/lib/html2rss/request_service/puppet_commander/navigation_guards.rb
+++ b/lib/html2rss/request_service/puppet_commander/navigation_guards.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+module Html2rss
+  class RequestService
+    class PuppetCommander
+      ##
+      # Owns Puppeteer request interception, deferred navigation errors, main-frame
+      # filtering, and redirect-chain validation via {Policy}.
+      #
+      # Does not re-own Policy rules — only calls +validate_*!+ on +ctx.policy+.
+      class NavigationGuards
+        ##
+        # @param ctx [Context] request context providing policy and origin
+        # @param skip_request_resources [Set<String>] resource types to abort
+        def initialize(ctx:, skip_request_resources:)
+          @ctx = ctx
+          @skip_request_resources = skip_request_resources
+          @navigation_error = nil
+          @latest_navigation_response = nil
+          @main_frame = nil
+        end
+
+        ##
+        # Captures the main frame and wires request/response interceptors.
+        #
+        # @param page [Puppeteer::Page] browser page
+        # @return [void]
+        def install!(page)
+          @main_frame = page.main_frame if page.respond_to?(:main_frame)
+          page.request_interception = true
+          page.on('request') { |request| handle_request(request) }
+          page.on('response') { |response| handle_response(response) }
+        end
+
+        ##
+        # Clears deferred error and latest navigation response before goto.
+        #
+        # @return [void]
+        def begin_navigation!
+          @navigation_error = nil
+          @latest_navigation_response = nil
+        end
+
+        ##
+        # Re-raises a deferred navigation error when one was captured.
+        #
+        # @return [void]
+        # @raise [Html2rss::Error] when a navigation request or response validation failed
+        def raise_deferred_error!
+          raise @navigation_error if @navigation_error
+        end
+
+        ##
+        # @return [Puppeteer::HTTPResponse, nil] latest main-frame navigation response
+        attr_reader :latest_navigation_response
+
+        ##
+        # Validates the remote IP of a navigation response via Policy.
+        #
+        # @param navigation_response [Puppeteer::HTTPResponse, nil]
+        # @return [void]
+        def validate_final!(navigation_response)
+          final_url = response_url(navigation_response, ctx.url)
+          ctx.policy.validate_remote_ip!(ip: remote_ip(navigation_response), url: final_url)
+        end
+
+        private
+
+        attr_reader :ctx, :skip_request_resources, :main_frame
+
+        def handle_request(request)
+          validate_request!(request)
+
+          skip_request_resources.member?(request.resource_type) ? request.abort : request.continue
+        rescue Html2rss::Error => error
+          store_navigation_error(error, navigation_request: request.navigation_request?)
+          request.abort
+        end
+
+        def handle_response(response)
+          @latest_navigation_response = response if main_frame_navigation_response?(response)
+          validate_final!(response)
+        rescue Html2rss::Error => error
+          store_navigation_error(error, navigation_request: response.request.navigation_request?)
+        end
+
+        def validate_request!(request)
+          validate_navigation_redirect_chain!(request)
+          validate_navigation_target!(request)
+        end
+
+        def main_frame_navigation_response?(response)
+          request = response.request
+          return false unless request.navigation_request?
+          return true unless request.respond_to?(:frame)
+
+          frame = request.frame
+          return true if frame.nil?
+          return frame == main_frame unless main_frame.nil?
+          return true unless frame.respond_to?(:parent_frame)
+
+          frame.parent_frame.nil?
+        end
+
+        def response_url(navigation_response, fallback_url)
+          raw_url = navigation_response&.url || fallback_url.to_s
+          Html2rss::Url.from_absolute(raw_url)
+        end
+
+        def remote_ip(navigation_response)
+          navigation_response.remote_address&.ip
+        end
+
+        def request_chain(request)
+          (request.redirect_chain + [request]).map { |entry| request_url(entry) }
+        end
+
+        def request_url(request)
+          Html2rss::Url.from_absolute(request.url)
+        end
+
+        def validate_navigation_redirect_chain!(request)
+          request_chain(request).each_cons(2) do |from_url, to_url|
+            ctx.policy.validate_redirect!(from_url:, to_url:, origin_url: ctx.origin_url, relation: ctx.relation)
+          end
+        end
+
+        def validate_navigation_target!(request)
+          ctx.policy.validate_request!(url: request_url(request), origin_url: ctx.origin_url, relation: ctx.relation)
+        end
+
+        def store_navigation_error(error, navigation_request:)
+          return unless navigation_request
+
+          @navigation_error = error if @navigation_error.nil?
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/request_service/puppet_commander/preload_runner.rb
+++ b/lib/html2rss/request_service/puppet_commander/preload_runner.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module Html2rss
+  class RequestService
+    class PuppetCommander
+      ##
+      # Runs Browserless preload choreography: wait, click, and scroll against
+      # the interaction budget on {Context#budget}.
+      class PreloadRunner
+        ##
+        # @param ctx [Context] request context providing preload config and budget
+        def initialize(ctx:)
+          @ctx = ctx
+        end
+
+        ##
+        # Executes configured preload actions on the page, if any.
+        #
+        # @param page [Puppeteer::Page] browser page after initial navigation
+        # @return [void]
+        def call(page)
+          preload_config = ctx.browserless_preload
+          return unless preload_config
+
+          wait_after(page, preload_config[:wait_after_ms])
+          click_selectors(page, preload_config[:click_selectors]) if preload_config[:click_selectors]
+          scroll_down(page, preload_config[:scroll_down]) if preload_config[:scroll_down]
+          wait_after(page, preload_config[:wait_after_ms])
+        end
+
+        private
+
+        attr_reader :ctx
+
+        def wait_after(page, timeout_ms)
+          return unless timeout_ms
+
+          ctx.budget.consume_interaction!
+          page.wait_for_timeout(timeout_ms)
+        end
+
+        def click_selectors(page, selectors)
+          selectors.each { |selector_config| click_selector(page, selector_config) }
+        end
+
+        def scroll_down(page, config)
+          iterations = config.fetch(:iterations, 1)
+          wait_after_ms = config[:wait_after_ms]
+          previous_height = nil
+
+          iterations.times do
+            updated_height = perform_scroll_iteration(page, wait_after_ms, previous_height)
+            break unless updated_height
+
+            previous_height = updated_height
+          end
+        end
+
+        def click_selector(page, config)
+          selector = config.fetch(:selector)
+          max_clicks = config.fetch(:max_clicks, 1)
+          wait_after_ms = config[:wait_after_ms]
+
+          max_clicks.times do
+            break unless (element = page.query_selector(selector))
+
+            ctx.budget.consume_interaction!
+            element.click
+            wait_after(page, wait_after_ms)
+          end
+        end
+
+        def perform_scroll_iteration(page, wait_after_ms, previous_height)
+          ctx.budget.consume_interaction!
+          page.evaluate('() => window.scrollTo(0, document.body.scrollHeight)')
+          wait_after(page, wait_after_ms)
+
+          current_height = page.evaluate('() => document.body.scrollHeight')
+          return if previous_height && current_height <= previous_height
+
+          current_height
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/request_session/runtime_policy.rb
+++ b/lib/html2rss/request_session/runtime_policy.rb
@@ -59,7 +59,8 @@ module Html2rss
         end
 
         def auto_strategy_fallback_budget_for(config)
-          return 0 unless config.strategy == :auto
+          plan = FeedPipeline::StrategyPlan.resolve(config.strategy)
+          return 0 unless plan.is_a?(FeedPipeline::StrategyPlan::Auto)
 
           [FeedPipeline::AutoFallback::CHAIN.size - 1, 0].max
         end

--- a/lib/html2rss/selectors.rb
+++ b/lib/html2rss/selectors.rb
@@ -134,12 +134,23 @@ module Html2rss
     # @return [Object, Array<Object>] The selected value(s).
     # @raise [InvalidSelectorName] If the attribute name is invalid or not defined.
     def select(name, item, base_url: @url)
+      select_in_scope(name, item_scope_for(item, base_url))
+    end
+
+    ##
+    # Selects the value for a given attribute within an existing {ItemScope}.
+    # Used by {ItemScope#select} so nested selects reuse one scope per extraction pass.
+    #
+    # @param name [Symbol, String] Name of the attribute.
+    # @param scope [ItemScope] Per-item extraction scope.
+    # @return [Object, Array<Object>] The selected value(s).
+    # @raise [InvalidSelectorName] If the attribute name is invalid or not defined.
+    def select_in_scope(name, scope)
       name = name.to_sym
 
       raise InvalidSelectorName, "Attribute selector '#{name}' is reserved for items." if name == ITEMS_SELECTOR_KEY
 
       selector_key, config = selector_config_for(name)
-      scope = item_scope_for(item, base_url)
 
       if SPECIAL_ATTRIBUTES.member?(selector_key)
         select_special(selector_key, scope:, config:)

--- a/lib/html2rss/selectors.rb
+++ b/lib/html2rss/selectors.rb
@@ -18,7 +18,9 @@ module Html2rss
     include Enumerable
 
     # A context instance passed to item extractors and post-processors.
-    Context = Struct.new('Context', :options, :item, :config, :scraper, keyword_init: true)
+    # When built via {ItemScope#context_for}, +item_scope+ carries the per-item
+    # extraction base_url for nested selects (e.g. Template).
+    Context = Struct.new('Context', :options, :item, :config, :scraper, :item_scope, keyword_init: true)
 
     # Default selectors options merged into user configuration.
     DEFAULT_CONFIG = { items: { enhance: true } }.freeze
@@ -92,7 +94,8 @@ module Html2rss
     # @param page_response [RequestService::Response] response used for selector extraction context
     # @return [Hash] Hash of attributes for the article.
     def extract_article(item, page_response = response)
-      @rss_item_attributes.to_h { |key| [key, select(key, item, base_url: page_response.url)] }.compact
+      scope = item_scope_for(item, page_response.url)
+      @rss_item_attributes.to_h { |key| [key, scope.select(key)] }.compact
     end
 
     ##
@@ -136,17 +139,28 @@ module Html2rss
       raise InvalidSelectorName, "Attribute selector '#{name}' is reserved for items." if name == ITEMS_SELECTOR_KEY
 
       selector_key, config = selector_config_for(name)
+      scope = item_scope_for(item, base_url)
 
       if SPECIAL_ATTRIBUTES.member?(selector_key)
-        select_special(selector_key, item:, config:, base_url:)
+        select_special(selector_key, scope:, config:)
       else
-        select_regular(selector_key, item:, config:, base_url:)
+        select_regular(selector_key, scope:, config:)
       end
     end
 
     private
 
     attr_reader :response
+
+    def item_scope_for(item, base_url)
+      ItemScope.new(
+        item:,
+        base_url:,
+        scraper: self,
+        channel: channel_context(base_url),
+        post_process_config: channel_post_process_context(base_url)
+      )
+    end
 
     def prepare_selectors!
       validate_url_and_link_exclusivity!
@@ -192,64 +206,58 @@ module Html2rss
                                             end
     end
 
-    def select_special(name, item:, config:, base_url:)
+    def select_special(name, scope:, config:)
       case name
       when :enclosure
-        enclosure(item:, config:, base_url:)
+        enclosure(scope:, config:)
       when :guid
-        Array(config).map { |selector_name| select(selector_name, item, base_url:) }
+        Array(config).map { |selector_name| scope.select(selector_name) }
       when :categories
-        select_categories(category_selectors: config, item:, base_url:)
+        select_categories(category_selectors: config, scope:)
       end
     end
 
-    def select_regular(_name, item:, config:, base_url:)
+    def select_regular(_name, scope:, config:)
       @merged_configs ||= {}
-      merged_config = @merged_configs[[config.object_id, base_url]] ||=
-        config.merge(channel: channel_context(base_url)).freeze
-      value = Extractors.get(merged_config, item)
+      merged_config = @merged_configs[[config.object_id, scope.base_url]] ||=
+        config.merge(channel: scope.channel).freeze
+      value = Extractors.get(merged_config, scope.item)
 
       if value && (post_process_steps = config[:post_process])
         steps = post_process_steps.is_a?(Array) ? post_process_steps : [post_process_steps]
-        value = post_process(item, value, steps, base_url:)
+        value = post_process(scope, value, steps)
       end
 
       value
     end
 
-    def post_process(item, value, post_process_steps, base_url:)
-      pp_context = channel_post_process_context(base_url)
+    def post_process(scope, value, post_process_steps)
       post_process_steps.each do |options|
-        context = Context.new(config: pp_context,
-                              item:, scraper: self, options:)
-
-        value = PostProcessors.get(options[:name], value, context)
+        value = PostProcessors.get(options[:name], value, scope.context_for(options:))
       end
 
       value
     end
 
-    def select_categories(category_selectors:, item:, base_url:)
+    def select_categories(category_selectors:, scope:)
       Array(category_selectors).flat_map do |selector_name|
-        extract_category_values(selector_name, item:, base_url:)
+        extract_category_values(selector_name, scope:)
       end
     end
 
-    def extract_category_values(selector_name, item:, base_url:)
+    def extract_category_values(selector_name, scope:)
       selector_key, config = selector_config_for(selector_name, allow_nil: true)
       return [] unless config
 
-      nodes = extract_nodes(item:, config:)
-      unless node_set_with_multiple_elements?(nodes)
-        return Array(select_regular(selector_key, item:, config:, base_url:))
-      end
+      nodes = extract_nodes(item: scope.item, config:)
+      return Array(select_regular(selector_key, scope:, config:)) unless node_set_with_multiple_elements?(nodes)
 
-      Array(nodes).flat_map { |node| extract_categories_from_node(node, item:, config:, base_url:) }
+      Array(nodes).flat_map { |node| extract_categories_from_node(node, scope:, config:) }
     end
 
-    def extract_categories_from_node(node, item:, config:, base_url:)
-      values = Extractors.get(category_node_options(config, base_url:), node)
-      values = apply_post_process_steps(item:, value: values, post_process_steps: config[:post_process], base_url:)
+    def extract_categories_from_node(node, scope:, config:)
+      values = Extractors.get(category_node_options(config, scope:), node)
+      values = apply_post_process_steps(scope:, value: values, post_process_steps: config[:post_process])
 
       Array(values).filter_map { |category| extract_category_text(category) }
     end
@@ -270,19 +278,19 @@ module Html2rss
       nodes.is_a?(Nokogiri::XML::NodeSet) && nodes.length > 1
     end
 
-    def category_node_options(selector_config, base_url:)
+    def category_node_options(selector_config, scope:)
       @category_node_configs ||= {}
-      @category_node_configs[[selector_config.object_id, base_url]] ||= selector_config.merge(
-        channel: channel_context(base_url),
+      @category_node_configs[[selector_config.object_id, scope.base_url]] ||= selector_config.merge(
+        channel: scope.channel,
         selector: nil
       ).freeze
     end
 
-    def apply_post_process_steps(item:, value:, post_process_steps:, base_url:)
+    def apply_post_process_steps(scope:, value:, post_process_steps:)
       return value unless value && post_process_steps
 
       steps = post_process_steps.is_a?(Array) ? post_process_steps : [post_process_steps]
-      post_process(item, value, steps, base_url:)
+      post_process(scope, value, steps)
     end
 
     def selector_config_for(name, allow_nil: false)
@@ -311,8 +319,8 @@ module Html2rss
     end
 
     # @return [Hash] enclosure details.
-    def enclosure(item:, config:, base_url:)
-      url = Url.from_relative(select_regular(:enclosure, item:, config:, base_url:), base_url)
+    def enclosure(scope:, config:)
+      url = Url.from_relative(select_regular(:enclosure, scope:, config:), scope.base_url)
 
       { url:, type: config[:content_type] }
     end

--- a/lib/html2rss/selectors/item_scope.rb
+++ b/lib/html2rss/selectors/item_scope.rb
@@ -13,12 +13,13 @@ module Html2rss
       #
       # @param name [Symbol, String]
       # @return [Object, Array<Object>]
-      def select(name) = scraper.select(name, item, base_url:)
+      def select(name) = scraper.select_in_scope(name, self)
 
       ##
       # Builds a post-processor {Context} carrying this scope for nested selects.
       #
       # @param options [Hash] post-processor options from the selector config
+      # @option options [String] :name post-processor name
       # @return [Context]
       def context_for(options:)
         Context.new(options:, item:, config: post_process_config, scraper:, item_scope: self)

--- a/lib/html2rss/selectors/item_scope.rb
+++ b/lib/html2rss/selectors/item_scope.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Html2rss
+  class Selectors
+    ##
+    # Per-item extraction scope: owns the article node and page +base_url+ for one
+    # extraction pass. Channel hashes are injected (and cached) by {Selectors}.
+    #
+    # Distinct from {Context}, which is the post-processor invocation bag (+options+).
+    ItemScope = Data.define(:item, :base_url, :scraper, :channel, :post_process_config) do
+      ##
+      # Selects an attribute using this scope's item and base_url.
+      #
+      # @param name [Symbol, String]
+      # @return [Object, Array<Object>]
+      def select(name) = scraper.select(name, item, base_url:)
+
+      ##
+      # Builds a post-processor {Context} carrying this scope for nested selects.
+      #
+      # @param options [Hash] post-processor options from the selector config
+      # @return [Context]
+      def context_for(options:)
+        Context.new(options:, item:, config: post_process_config, scraper:, item_scope: self)
+      end
+    end
+  end
+end

--- a/lib/html2rss/selectors/post_processors/template.rb
+++ b/lib/html2rss/selectors/post_processors/template.rb
@@ -69,7 +69,13 @@ module Html2rss
         # @return [String]
         def item_value(key)
           key = key.to_sym
-          key == :self ? value : @scraper.select(key, @item)
+          return value if key == :self
+
+          if (scope = @context.item_scope)
+            scope.select(key)
+          else
+            @scraper.select(key, @item)
+          end
         end
       end
     end

--- a/lib/html2rss/selectors/post_processors/template.rb
+++ b/lib/html2rss/selectors/post_processors/template.rb
@@ -42,6 +42,10 @@ module Html2rss
 
           string = context[:options]&.dig(:string).to_s
           raise InvalidType, 'The `string` template is absent.' if string.empty?
+
+          return if context.item_scope
+
+          raise MissingOption, 'The post-processor context is missing `item_scope`.', [], cause: nil
         end
 
         ##
@@ -51,8 +55,6 @@ module Html2rss
           super
 
           @options = context[:options] || {}
-          @scraper = context[:scraper]
-          @item = context[:item]
           @string = @options[:string].to_s
           @getter = ->(key) { item_value(key) }
         end
@@ -71,11 +73,7 @@ module Html2rss
           key = key.to_sym
           return value if key == :self
 
-          if (scope = @context.item_scope)
-            scope.select(key)
-          else
-            @scraper.select(key, @item)
-          end
+          @context.item_scope.select(key)
         end
       end
     end

--- a/spec/lib/html2rss/auto_source/scraper/wordpress_api/page_scope_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper/wordpress_api/page_scope_spec.rb
@@ -7,6 +7,35 @@ RSpec.describe Html2rss::AutoSource::Scraper::WordpressApi::PageScope do
   let(:html) { '<html><body></body></html>' }
   let(:parsed_body) { Nokogiri::HTML(html) }
 
+  describe Html2rss::AutoSource::Scraper::WordpressApi::PageScope::DateArchiveRange do
+    describe '.from_segments' do
+      it 'maps year/month/day segments to exclusive after/before bounds' do
+        expect(described_class.from_segments(%w[2024 02 29])).to eq(
+          'after' => '2024-02-29T00:00:00Z',
+          'before' => '2024-03-01T00:00:00Z'
+        )
+      end
+
+      it 'returns nil for calendar-invalid date segments' do
+        expect(described_class.from_segments(%w[2023 02 29])).to be_nil
+      end
+
+      it 'returns nil when segments are not a date archive path' do
+        expect(described_class.from_segments(%w[category news])).to be_nil
+      end
+    end
+
+    describe '.path?' do
+      it 'is true for shape-valid date segments even when the calendar date is invalid' do
+        expect(described_class.path?(%w[2023 02 29])).to be(true)
+      end
+
+      it 'is false for non-date archive segments' do
+        expect(described_class.path?(%w[category news])).to be(false)
+      end
+    end
+  end
+
   describe '.from' do
     context 'when the page URL is a yearly archive' do
       let(:url) { Html2rss::Url.from_absolute('https://example.com/2024/') }

--- a/spec/lib/html2rss/configuration_spec.rb
+++ b/spec/lib/html2rss/configuration_spec.rb
@@ -92,9 +92,14 @@ RSpec.describe Html2rss::Configuration do
   describe '#default_strategy=' do
     subject(:config) { described_class.new }
 
-    it 'accepts a registered strategy' do
+    it 'accepts a registered concrete strategy' do
       config.default_strategy = :faraday
       expect(config.default_strategy).to eq(:faraday)
+    end
+
+    it 'accepts the feed-level :auto plan' do
+      config.default_strategy = :auto
+      expect(config.default_strategy).to eq(:auto)
     end
 
     it 'accepts string and normalizes to symbol' do
@@ -324,6 +329,14 @@ RSpec.describe Html2rss::Configuration do
       it 'uses global default strategy when strategy in config is default_strategy_name', :aggregate_failures do
         expect(Html2rss::Config.default_strategy_name).to eq(:faraday)
         expect(Html2rss::Config.default_config[:strategy]).to eq(:faraday)
+      end
+
+      it 'allows configure to set the feed-level :auto plan', :aggregate_failures do
+        Html2rss.configure { |config| config.default_strategy = :auto }
+
+        expect(Html2rss.configuration.default_strategy).to eq(:auto)
+        expect(Html2rss::Config.default_strategy_name).to eq(:auto)
+        expect(Html2rss::Config.default_config[:strategy]).to eq(:auto)
       end
 
       it 'uses global stylesheets in default_config' do

--- a/spec/lib/html2rss/feed_pipeline/strategy_plan_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline/strategy_plan_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Html2rss::FeedPipeline::StrategyPlan do
+  describe '.resolve' do
+    it 'resolves :auto to the Auto plan' do
+      expect(described_class.resolve(:auto)).to eq(described_class::Auto.new)
+    end
+
+    it 'resolves a registered strategy to Concrete', :aggregate_failures do
+      plan = described_class.resolve(:faraday)
+
+      expect(plan).to be_a(described_class::Concrete)
+      expect(plan.strategy).to eq(:faraday)
+    end
+
+    it 'accepts string names' do
+      expect(described_class.resolve('browserless')).to eq(described_class::Concrete.new(strategy: :browserless))
+    end
+
+    it 'raises ArgumentError for an unknown plan' do
+      expect { described_class.resolve(:unknown) }.to raise_error(ArgumentError, /unknown strategy plan/)
+    end
+  end
+
+  describe '.valid?' do
+    it 'accepts :auto and registered strategies', :aggregate_failures do
+      expect(described_class.valid?(:auto)).to be true
+      expect(described_class.valid?(:faraday)).to be true
+      expect(described_class.valid?('botasaurus')).to be true
+    end
+
+    it 'rejects unknown names and non-names', :aggregate_failures do
+      expect(described_class.valid?(:unknown)).to be false
+      expect(described_class.valid?(nil)).to be false
+      expect(described_class.valid?(123)).to be false
+    end
+  end
+
+  describe '.accepted_names' do
+    it 'lists :auto ahead of concrete transport strategies' do
+      expect(described_class.accepted_names).to eq(
+        [:auto, *Html2rss::RequestService.strategy_names.map(&:to_sym)].uniq
+      )
+    end
+  end
+end

--- a/spec/lib/html2rss/selectors/post_processors/template_spec.rb
+++ b/spec/lib/html2rss/selectors/post_processors/template_spec.rb
@@ -28,4 +28,22 @@ RSpec.describe Html2rss::Selectors::PostProcessors::Template do
 
     it { is_expected.to eq 'Hi! My name is Slim Shady! ' }
   end
+
+  context 'when Context carries an ItemScope' do
+    subject(:rendered) { described_class.new('Hi', context).get }
+
+    let(:item_scope) { instance_double(Html2rss::Selectors::ItemScope) }
+    let(:context) { Html2rss::Selectors::Context.new(options:, item:, scraper:, item_scope:) }
+    let(:options) { { string: '%{name}' } } # rubocop:disable Style/FormatStringToken
+
+    before do
+      allow(item_scope).to receive(:select).with(:name).and_return('Scoped')
+    end
+
+    it 'routes nested selects through the ItemScope', :aggregate_failures do
+      expect(rendered).to eq('Scoped')
+      expect(item_scope).to have_received(:select).with(:name)
+      expect(scraper).not_to have_received(:select)
+    end
+  end
 end

--- a/spec/lib/html2rss/selectors/post_processors/template_spec.rb
+++ b/spec/lib/html2rss/selectors/post_processors/template_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe Html2rss::Selectors::PostProcessors::Template do
   subject { described_class.new('Hi', context).get }
 
   let(:item) { Object.new }
-  let(:scraper) { instance_double(Html2rss::Selectors) }
-  let(:context) { Html2rss::Selectors::Context.new(options:, item:, scraper:) }
+  let(:item_scope) { instance_double(Html2rss::Selectors::ItemScope) }
+  let(:context) { Html2rss::Selectors::Context.new(options:, item:, item_scope:) }
 
   before do
-    allow(scraper).to receive(:select).with(:name, item).and_return('My name')
-    allow(scraper).to receive(:select).with(:author, item).and_return('Slim Shady')
-    allow(scraper).to receive(:select).with(:returns_nil, item).and_return(nil)
+    allow(item_scope).to receive(:select).with(:name).and_return('My name')
+    allow(item_scope).to receive(:select).with(:author).and_return('Slim Shady')
+    allow(item_scope).to receive(:select).with(:returns_nil).and_return(nil)
   end
 
   it { expect(described_class).to be < Html2rss::Selectors::PostProcessors::Base }
@@ -18,8 +18,19 @@ RSpec.describe Html2rss::Selectors::PostProcessors::Template do
   context 'when the string is empty' do
     it 'raises an error' do
       expect do
-        described_class.new('', Html2rss::Selectors::Context.new(options: {}))
+        described_class.new('', Html2rss::Selectors::Context.new(options: {}, item_scope:))
       end.to raise_error(Html2rss::Selectors::PostProcessors::InvalidType, 'The `string` template is absent.')
+    end
+  end
+
+  context 'when item_scope is missing' do
+    it 'raises MissingOption' do
+      expect do
+        # rubocop:disable Style/FormatStringToken -- template post-processor uses %{key}
+        described_class.new('Hi', Html2rss::Selectors::Context.new(options: { string: '%{name}' }))
+        # rubocop:enable Style/FormatStringToken
+      end.to raise_error(Html2rss::Selectors::PostProcessors::MissingOption,
+                         'The post-processor context is missing `item_scope`.')
     end
   end
 
@@ -29,21 +40,12 @@ RSpec.describe Html2rss::Selectors::PostProcessors::Template do
     it { is_expected.to eq 'Hi! My name is Slim Shady! ' }
   end
 
-  context 'when Context carries an ItemScope' do
-    subject(:rendered) { described_class.new('Hi', context).get }
-
-    let(:item_scope) { instance_double(Html2rss::Selectors::ItemScope) }
-    let(:context) { Html2rss::Selectors::Context.new(options:, item:, scraper:, item_scope:) }
+  context 'when routing nested selects through ItemScope' do
     let(:options) { { string: '%{name}' } } # rubocop:disable Style/FormatStringToken
 
-    before do
-      allow(item_scope).to receive(:select).with(:name).and_return('Scoped')
-    end
-
-    it 'routes nested selects through the ItemScope', :aggregate_failures do
-      expect(rendered).to eq('Scoped')
+    it 'renders via scope.select', :aggregate_failures do
+      expect(subject).to eq('My name')
       expect(item_scope).to have_received(:select).with(:name)
-      expect(scraper).not_to have_received(:select)
     end
   end
 end

--- a/spec/lib/html2rss/selectors_spec.rb
+++ b/spec/lib/html2rss/selectors_spec.rb
@@ -197,5 +197,33 @@ RSpec.describe Html2rss::Selectors do
         expect { value }.to raise_error(described_class::InvalidSelectorName, "Selector for 'unknown' is not defined.")
       end
     end
+
+    context 'when a template nested select resolves relative urls' do
+      subject(:value) do
+        instance.select(:title, item, base_url: 'https://other.example/section/').to_s
+      end
+
+      let(:selectors) do
+        {
+          items: { selector: 'article' },
+          path: { selector: 'a', extractor: 'href' },
+          title: {
+            selector: 'h1',
+            # rubocop:disable Style/FormatStringToken -- template post-processor uses %{key}
+            post_process: { name: 'template', string: '%{path}' }
+            # rubocop:enable Style/FormatStringToken
+          }
+        }
+      end
+      let(:body) do
+        <<~HTML
+          <html><body><article><h1>Title</h1><a href="/item">x</a></article></body></html>
+        HTML
+      end
+
+      it 'honors the per-call base_url for nested template selects' do
+        expect(value).to eq('https://other.example/item')
+      end
+    end
   end
 end


### PR DESCRIPTION
## What changed

- **Selectors / ItemScope** — one per-item extraction scope owns item + page `base_url`; Template nested selects route only through that scope (`select_in_scope`), and missing `item_scope` raises loudly.
- **RequestService::NetworkGuard** — DNS/host/IP SSRF rules leave Policy as a thin façade.
- **PuppetCommander::NavigationGuards** — intercept wiring, deferred nav errors, resource abort/continue, redirect validation.
- **PuppetCommander::PreloadRunner** — wait/click/scroll preload and interaction-budget consumption.
- **WordpressApi::DateArchiveRange** — date-path → REST after/before bounds; PageScope keeps taxonomy/pagination.
- **LinkHeuristics::ContainerAssessor** — DOM observation → `ContainerSignals`; scoring stays on heuristics policy.
- **FeedPipeline::StrategyPlan** — resolve config/configure `:auto` | concrete; RequestService stays concrete-adapter-only; `configure { default_strategy :auto }` is legal.

## Why

Architecture deepen (Reek ownership triage, Phases 1–7): cut dual-owned seams so each module has one job. Residual fix after Phase 1: Template still fell back to `scraper.select` (wrong `base_url` / silent missing scope), and yard-lint constants left bare by the extracts.

### Root cause (tip fix)

Phase 1 left a fallback path and undocumented constants; Phase 7 closed the `:auto` dual-ownership bug where Config defaulted to `:auto` but `Configuration#default_strategy=` rejected it.

## Risk

- Template post-processors that build Context without `item_scope` now raise `MissingOption` (intentional fail-loud).
- Strategy plan resolution is a new choke point — unknown plan names fail at resolve/configure rather than at RequestService execute.
- Low behavioral risk for concrete strategies and AutoFallback chain order (unchanged).

## Review map

1. `lib/html2rss/selectors/item_scope.rb` + `lib/html2rss/selectors.rb` — per-item scope contract; start here for Phase 1.
2. `lib/html2rss/selectors/post_processors/template.rb` — nested select must use scope only.
3. `lib/html2rss/feed_pipeline/strategy_plan.rb` — plan vs transport locality for `:auto`.
4. `lib/html2rss/request_service/network_guard.rb` — SSRF single home behind Policy.
5. `lib/html2rss/request_service/puppet_commander/{navigation_guards,preload_runner}.rb` — browser session choreography splits.
6. `lib/html2rss/auto_source/scraper/link_heuristics/container_assessor.rb` + `.../wordpress_api/page_scope/date_archive_range.rb` — AutoSource observation/calendar pure seams.

## Validation

- `make ready` — green (1132 examples, 0 failures; lint, yard-lint, schema, fixtures, docs, shellcheck)