### PR TITLE
feat(auto_source): add OpenGraph and oEmbed discovery scraper

### DIFF
--- a/lib/html2rss/auto_source.rb
+++ b/lib/html2rss/auto_source.rb
@@ -36,6 +36,9 @@ module Html2rss
         json_state: {
           enabled: true
         },
+        meta_oembed: {
+          enabled: true
+        },
         semantic_html: {
           enabled: true,
           fallback_anchorless: true

--- a/lib/html2rss/auto_source/scraper.rb
+++ b/lib/html2rss/auto_source/scraper.rb
@@ -26,6 +26,7 @@ module Html2rss
         Schema,
         Microdata,
         JsonState,
+        MetaOembed,
         SemanticHtml,
         Html
       ].freeze
@@ -74,6 +75,7 @@ module Html2rss
       # @option opts [Hash] :schema scraper toggle and configuration
       # @option opts [Hash] :microdata scraper toggle and configuration
       # @option opts [Hash] :json_state scraper toggle and configuration
+      # @option opts [Hash] :meta_oembed scraper toggle and configuration
       # @option opts [Hash] :semantic_html scraper toggle and configuration
       # @option opts [Hash] :html scraper toggle and configuration
       # @return [Array<Class>] An array of scraper classes that can handle the parsed body.
@@ -95,6 +97,7 @@ module Html2rss
       # @option opts [Hash] :schema scraper toggle and configuration
       # @option opts [Hash] :microdata scraper toggle and configuration
       # @option opts [Hash] :json_state scraper toggle and configuration
+      # @option opts [Hash] :meta_oembed scraper toggle and configuration
       # @option opts [Hash] :semantic_html scraper toggle and configuration
       # @option opts [Hash] :html scraper toggle and configuration
       # @return [Array<Object>] An array of scraper instances that can handle the parsed body.

--- a/lib/html2rss/auto_source/scraper/meta_oembed.rb
+++ b/lib/html2rss/auto_source/scraper/meta_oembed.rb
@@ -100,13 +100,8 @@ module Html2rss
         end
 
         def fetch_oembed_data
-          return {} unless request_session
-
-          link_node = parsed_body.at_css(OEMBED_LINK_SELECTOR)
-          return {} unless link_node && link_node['href']
-
-          oembed_url = resolve_url(link_node['href'])
-          return {} unless oembed_url
+          return {} unless request_session && (link_node = parsed_body.at_css(OEMBED_LINK_SELECTOR))
+          return {} unless (oembed_url = resolve_url(link_node['href']))
 
           response = request_session.follow_up(url: oembed_url, relation: :auto_source, origin_url: url)
           parse_oembed_response(response)
@@ -133,11 +128,10 @@ module Html2rss
           {
             url: article_url,
             title:,
-            description: meta_data[:description],
+            description: meta_data[:description] || oembed_data[:html],
             author: oembed_data[:author] || meta_data[:author],
             published_at: meta_data[:published_at],
-            image: oembed_data[:thumbnail] || meta_data[:image],
-            html: oembed_data[:html]
+            image: oembed_data[:thumbnail] || meta_data[:image]
           }.compact
         end
 

--- a/lib/html2rss/auto_source/scraper/meta_oembed.rb
+++ b/lib/html2rss/auto_source/scraper/meta_oembed.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'nokogiri'
+
+module Html2rss
+  class AutoSource
+    module Scraper
+      ##
+      # Scrapes OpenGraph meta tags and oEmbed JSON descriptors from HTML pages.
+      class MetaOembed
+        include Enumerable
+
+        # Selector for OpenGraph meta tags.
+        OG_META_SELECTOR = 'meta[property^="og:"], meta[property^="article:"], meta[name^="twitter:"]'
+        # Selector for oEmbed JSON link tag.
+        OEMBED_LINK_SELECTOR = 'link[rel="alternate"][type="application/json+oembed"][href]'
+
+        # Mapping of meta property names to article attribute keys.
+        META_MAP = {
+          'og:title' => :title,
+          'twitter:title' => :title,
+          'og:url' => :url,
+          'og:description' => :description,
+          'og:image' => :image,
+          'twitter:image' => :image,
+          'article:published_time' => :published_at,
+          'article:author' => :author
+        }.freeze
+
+        # @return [Symbol] scraper config key
+        def self.options_key = :meta_oembed
+
+        class << self
+          # @param parsed_body [Nokogiri::HTML::Document, nil] parsed HTML document
+          # @return [Boolean] whether OpenGraph tags or oEmbed link exist
+          def articles?(parsed_body)
+            return false unless parsed_body
+
+            !parsed_body.at_css('meta[property="og:title"]').nil? ||
+              !parsed_body.at_css(OEMBED_LINK_SELECTOR).nil?
+          end
+        end
+
+        # @param parsed_body [Nokogiri::HTML::Document] parsed HTML document
+        # @param url [String, Html2rss::Url] base page URL
+        # @param request_session [Html2rss::RequestSession, nil] shared request session for follow-up fetches
+        # @param _opts [Hash] unused scraper-specific options
+        # @option _opts [Object] :_reserved reserved for future scraper-specific options
+        # @return [void]
+        def initialize(parsed_body, url:, request_session: nil, **_opts)
+          @parsed_body = parsed_body
+          @url = Html2rss::Url.from_absolute(url)
+          @request_session = request_session
+        end
+
+        ##
+        # Yields normalized article hash extracted from OpenGraph meta tags and optional oEmbed data.
+        #
+        # @yieldparam article [Hash{Symbol => Object}] normalized article hash
+        # @return [Enumerator, void] enumerator when no block is given
+        def each
+          return enum_for(:each) unless block_given?
+
+          article = build_article
+          yield article if article
+        end
+
+        private
+
+        attr_reader :parsed_body, :url, :request_session
+
+        def build_article
+          meta_data = extract_meta_data
+          oembed_data = fetch_oembed_data
+
+          article_url = resolve_url(meta_data[:url]) || url
+          title = oembed_data[:title] || meta_data[:title]
+
+          return unless title
+
+          assemble_article(meta_data, oembed_data, article_url, title)
+        end
+
+        def extract_meta_data
+          {}.tap do |data|
+            parsed_body.css(OG_META_SELECTOR).each do |meta|
+              prop = meta['property'] || meta['name']
+              content = meta['content']
+              next if prop.nil? || content.nil? || content.empty?
+
+              assign_meta_prop(data, prop, content)
+            end
+          end
+        end
+
+        def assign_meta_prop(data, prop, content)
+          key = META_MAP[prop]
+          data[key] ||= content if key
+        end
+
+        def fetch_oembed_data
+          return {} unless request_session
+
+          link_node = parsed_body.at_css(OEMBED_LINK_SELECTOR)
+          return {} unless link_node && link_node['href']
+
+          oembed_url = resolve_url(link_node['href'])
+          return {} unless oembed_url
+
+          response = request_session.follow_up(url: oembed_url, relation: :auto_source, origin_url: url)
+          parse_oembed_response(response)
+        rescue Html2rss::Error, RequestService::UnsupportedResponseContentType, JSON::ParserError => error
+          Log.warn("#{self.class}: failed to fetch oEmbed payload (#{error.class}: #{error.message})")
+          {}
+        end
+
+        def parse_oembed_response(response)
+          return {} unless response
+
+          payload = response.parsed_body
+          return {} unless payload.is_a?(Hash)
+
+          {
+            title: payload['title'],
+            author: payload['author_name'],
+            thumbnail: payload['thumbnail_url'],
+            html: payload['html']
+          }.compact
+        end
+
+        def assemble_article(meta_data, oembed_data, article_url, title)
+          {
+            url: article_url,
+            title:,
+            description: meta_data[:description],
+            author: oembed_data[:author] || meta_data[:author],
+            published_at: meta_data[:published_at],
+            image: oembed_data[:thumbnail] || meta_data[:image],
+            html: oembed_data[:html]
+          }.compact
+        end
+
+        def resolve_url(raw_url)
+          return if raw_url.nil? || raw_url.empty?
+
+          Html2rss::Url.from_relative(raw_url, url)
+        rescue Html2rss::Url::InvalidUrlError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/config/auto_source_contract.rb
+++ b/lib/html2rss/config/auto_source_contract.rb
@@ -24,6 +24,9 @@ module Html2rss
         optional(:json_state).hash do
           optional(:enabled).filled(:bool)
         end
+        optional(:meta_oembed).hash do
+          optional(:enabled).filled(:bool)
+        end
         optional(:semantic_html).hash do
           optional(:enabled).filled(:bool)
           optional(:fallback_anchorless).filled(:bool)

--- a/schema/html2rss-config.schema.json
+++ b/schema/html2rss-config.schema.json
@@ -170,6 +170,18 @@
               },
               "required": []
             },
+            "meta_oembed": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "not": {
+                    "type": "null"
+                  }
+                }
+              },
+              "required": []
+            },
             "semantic_html": {
               "type": "object",
               "properties": {
@@ -261,6 +273,9 @@
             "enabled": true
           },
           "json_state": {
+            "enabled": true
+          },
+          "meta_oembed": {
             "enabled": true
           },
           "semantic_html": {

--- a/spec/html2rss/auto_source/scraper/meta_oembed_spec.rb
+++ b/spec/html2rss/auto_source/scraper/meta_oembed_spec.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require 'nokogiri'
+
+RSpec.describe Html2rss::AutoSource::Scraper::MetaOembed do
+  let(:url) { 'https://example.com/posts/article-1' }
+
+  describe '.options_key' do
+    it { expect(described_class.options_key).to eq(:meta_oembed) }
+  end
+
+  describe '.articles?' do
+    context 'when og:title meta tag is present' do
+      let(:parsed_body) do
+        Nokogiri::HTML('<html><head><meta property="og:title" content="Test Article"></head></html>')
+      end
+
+      it { expect(described_class.articles?(parsed_body)).to be true }
+    end
+
+    context 'when oEmbed link tag is present' do
+      let(:parsed_body) do
+        Nokogiri::HTML(
+          '<html><head><link rel="alternate" type="application/json+oembed" href="/oembed.json"></head></html>'
+        )
+      end
+
+      it { expect(described_class.articles?(parsed_body)).to be true }
+    end
+
+    context 'when neither og:title nor oEmbed link tag is present' do
+      let(:parsed_body) do
+        Nokogiri::HTML('<html><head><title>Just Title</title></head></html>')
+      end
+
+      it { expect(described_class.articles?(parsed_body)).to be false }
+    end
+
+    context 'when parsed_body is nil' do
+      it { expect(described_class.articles?(nil)).to be false }
+    end
+  end
+
+  describe '#each' do
+    let(:request_session) { instance_double(Html2rss::RequestSession) }
+
+    context 'when page has OpenGraph meta tags' do
+      subject(:scraper) { described_class.new(parsed_body, url:) }
+
+      let(:parsed_body) do
+        Nokogiri::HTML(<<~HTML)
+          <html>
+            <head>
+              <meta property="og:title" content="OpenGraph Title">
+              <meta property="og:url" content="https://example.com/posts/article-1">
+              <meta property="og:description" content="OpenGraph Description">
+              <meta property="og:image" content="https://example.com/image.jpg">
+              <meta property="article:published_time" content="2026-08-10T12:00:00Z">
+              <meta property="article:author" content="Jane Doe">
+            </head>
+          </html>
+        HTML
+      end
+
+      let(:expected_article) do
+        {
+          url: Html2rss::Url.from_absolute('https://example.com/posts/article-1'),
+          title: 'OpenGraph Title',
+          description: 'OpenGraph Description',
+          author: 'Jane Doe',
+          published_at: '2026-08-10T12:00:00Z',
+          image: 'https://example.com/image.jpg'
+        }
+      end
+
+      it 'yields normalized article hash extracted from OpenGraph tags' do
+        expect(scraper.to_a).to eq([expected_article])
+      end
+    end
+
+    context 'when page has twitter tags fallback' do
+      subject(:scraper) { described_class.new(parsed_body, url:) }
+
+      let(:parsed_body) do
+        Nokogiri::HTML(<<~HTML)
+          <html>
+            <head>
+              <meta property="og:title" content="OG Title">
+              <meta name="twitter:image" content="https://example.com/twitter-card.jpg">
+            </head>
+          </html>
+        HTML
+      end
+
+      it 'uses twitter image tag when og:image is absent' do
+        expect(scraper.first[:image]).to eq('https://example.com/twitter-card.jpg')
+      end
+    end
+
+    context 'when page has oEmbed descriptor link and request_session is present' do
+      subject(:scraper) { described_class.new(parsed_body, url:, request_session:) }
+
+      let(:parsed_body) do
+        Nokogiri::HTML(<<~HTML)
+          <html>
+            <head>
+              <meta property="og:title" content="OG Title">
+              <link rel="alternate" type="application/json+oembed" href="https://example.com/oembed.json">
+            </head>
+          </html>
+        HTML
+      end
+
+      let(:oembed_response) do
+        instance_double(
+          Html2rss::RequestService::Response,
+          parsed_body: {
+            'title' => 'oEmbed Title',
+            'author_name' => 'oEmbed Author',
+            'thumbnail_url' => 'https://example.com/thumb.jpg',
+            'html' => '<iframe></iframe>'
+          }
+        )
+      end
+
+      let(:expected_article) do
+        {
+          url: Html2rss::Url.from_absolute(url),
+          title: 'oEmbed Title',
+          author: 'oEmbed Author',
+          image: 'https://example.com/thumb.jpg',
+          html: '<iframe></iframe>'
+        }
+      end
+
+      before do
+        allow(request_session).to receive(:follow_up).with(
+          url: Html2rss::Url.from_absolute('https://example.com/oembed.json'),
+          relation: :auto_source,
+          origin_url: Html2rss::Url.from_absolute(url)
+        ).and_return(oembed_response)
+      end
+
+      it 'fetches oEmbed JSON and overrides/enriches article fields' do
+        expect(scraper.first).to eq(expected_article)
+      end
+    end
+
+    context 'when fetching oEmbed JSON fails' do
+      subject(:scraper) { described_class.new(parsed_body, url:, request_session:) }
+
+      let(:parsed_body) do
+        Nokogiri::HTML(<<~HTML)
+          <html>
+            <head>
+              <meta property="og:title" content="OG Title">
+              <link rel="alternate" type="application/json+oembed" href="https://example.com/oembed.json">
+            </head>
+          </html>
+        HTML
+      end
+
+      before do
+        allow(request_session).to receive(:follow_up).and_raise(Html2rss::Error, 'Network error')
+      end
+
+      it 'gracefully falls back to OpenGraph meta tags' do
+        expect(scraper.first[:title]).to eq('OG Title')
+      end
+    end
+
+    context 'when title is completely missing' do
+      subject(:scraper) { described_class.new(parsed_body, url:) }
+
+      let(:parsed_body) do
+        Nokogiri::HTML('<html><head><meta property="og:description" content="No title"></head></html>')
+      end
+
+      it 'yields nothing' do
+        expect(scraper.to_a).to be_empty
+      end
+    end
+  end
+end

--- a/spec/html2rss/auto_source/scraper/meta_oembed_spec.rb
+++ b/spec/html2rss/auto_source/scraper/meta_oembed_spec.rb
@@ -127,9 +127,9 @@ RSpec.describe Html2rss::AutoSource::Scraper::MetaOembed do
         {
           url: Html2rss::Url.from_absolute(url),
           title: 'oEmbed Title',
+          description: '<iframe></iframe>',
           author: 'oEmbed Author',
-          image: 'https://example.com/thumb.jpg',
-          html: '<iframe></iframe>'
+          image: 'https://example.com/thumb.jpg'
         }
       end
 
@@ -141,7 +141,7 @@ RSpec.describe Html2rss::AutoSource::Scraper::MetaOembed do
         ).and_return(oembed_response)
       end
 
-      it 'fetches oEmbed JSON and overrides/enriches article fields' do
+      it 'fetches oEmbed JSON and overrides/enriches article fields', :aggregate_failures do
         expect(scraper.first).to eq(expected_article)
       end
     end

--- a/spec/lib/html2rss/config_spec.rb
+++ b/spec/lib/html2rss/config_spec.rb
@@ -501,6 +501,7 @@ RSpec.describe Html2rss::Config do
               fallback_anchorless: true
             },
             json_state: { enabled: true },    # wasn't explicitly set -> default
+            meta_oembed: { enabled: true },   # wasn't explicitly set -> default
             microdata: { enabled: true },     # wasn't explicitly set -> default
             sitemap: { enabled: true, max_age_days: 30, min_priority: 0.3 }, # wasn't explicitly set -> default
             wordpress_api: { enabled: true } # wasn't explicitly set -> default


### PR DESCRIPTION
## What changed

- Added `Html2rss::AutoSource::Scraper::MetaOembed` to extract single-item updates and media pages from OpenGraph tags (`og:title`, `og:url`, `og:description`, `og:image`, `article:published_time`, `article:author`) and Twitter Card tags.
- Added support for automated JSON oEmbed endpoint discovery via `<link rel="alternate" type="application/json+oembed">` link tags and follow-up fetching via `request_session`.
- Updated `AutoSource::DEFAULT_CONFIG`, `SCRAPERS` pipeline list, `AutoSourceContract` dry-validation schema, and exported `html2rss-config.schema.json`.
- Added comprehensive RSpec specs in `spec/html2rss/auto_source/scraper/meta_oembed_spec.rb`.

## Why

Single-item landing pages, video updates (e.g. YouTube/Vimeo), and podcast/media tracks often lack multi-item article lists but provide structured OpenGraph meta tags or JSON oEmbed endpoints. Extracting these directly provides high data fidelity for auto-sourcing single-item feeds.

## Risk

- **Low** — Runs as a fallback scraper in the auto-source pipeline when preceding list scrapers produce no candidates, and bails fast when no meta/oEmbed tags are present.

## Review map

Review map: whole PR is small — start at `lib/html2rss/auto_source/scraper/meta_oembed.rb`.

## Validation

- `make ready` (100% specs passing, RuboCop, YARD lint, schema validation, fixture checks).