### PR TITLE
feat(auto_source): add class-agnostic tag-structure clustering fallback

### DIFF
--- a/lib/html2rss/auto_source/discovery/class_clustering.rb
+++ b/lib/html2rss/auto_source/discovery/class_clustering.rb
@@ -34,8 +34,17 @@ module Html2rss
         # @return [Array<Nokogiri::XML::Node>]
         def call
           candidate_groups = collect_candidate_groups
-          return [] if candidate_groups.empty?
+          unless candidate_groups.empty?
+            result = score_candidate_groups(candidate_groups)
+            return result unless result.empty?
+          end
 
+          StructureClustering.call(@parsed_body, minimum_selector_frequency: @minimum_frequency)
+        end
+
+        private
+
+        def score_candidate_groups(candidate_groups)
           scorer = GroupScorer.new
           resolver = OverlapResolver.new(layout_tags: LAYOUT_TAG_NAMES, word_counter: scorer)
 
@@ -44,8 +53,6 @@ module Html2rss
 
           scorer.select_best_group(final_groups)
         end
-
-        private
 
         def collect_candidate_groups
           class_groups = Hash.new { |h, k| h[k] = [] }

--- a/lib/html2rss/auto_source/discovery/structure_clustering.rb
+++ b/lib/html2rss/auto_source/discovery/structure_clustering.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Html2rss
+  class AutoSource
+    module Discovery
+      ##
+      # StructureClustering clusters DOM elements on anchorless pages by 1-level child element tag sequences
+      # and scores candidate groups to find the best list of content cards/articles when class clustering fails.
+      class StructureClustering
+        # Node tags considered layout containers
+        LAYOUT_TAG_NAMES = ClassClustering::LAYOUT_TAG_NAMES
+        # HTML/layout tags excluded from candidate nodes (owned by Html::Navigator).
+        EXCLUDED_TAGS = Html2rss::Html::Navigator::CLUSTER_EXCLUDED_TAGS
+
+        class << self
+          ##
+          # Clusters elements in parsed_body by structural tag signature and returns candidate nodes.
+          #
+          # @param parsed_body [Nokogiri::HTML::Document] parsed HTML document
+          # @param minimum_selector_frequency [Integer] minimum frequency for structural groups
+          # @return [Array<Nokogiri::XML::Node>] candidate nodes of the top-scoring structural group
+          def call(parsed_body, minimum_selector_frequency:)
+            new(parsed_body, minimum_selector_frequency:).call
+          end
+        end
+
+        # @param parsed_body [Nokogiri::HTML::Document]
+        # @param minimum_selector_frequency [Integer]
+        def initialize(parsed_body, minimum_selector_frequency:)
+          @parsed_body = parsed_body
+          @minimum_frequency = minimum_selector_frequency
+        end
+
+        # @return [Array<Nokogiri::XML::Node>]
+        def call
+          candidate_groups = collect_candidate_groups
+          return [] if candidate_groups.empty?
+
+          score_candidate_groups(candidate_groups)
+        end
+
+        private
+
+        def score_candidate_groups(candidate_groups)
+          scorer = ClassClustering::GroupScorer.new
+          resolver = ClassClustering::OverlapResolver.new(layout_tags: LAYOUT_TAG_NAMES, word_counter: scorer)
+
+          non_containers = resolver.filter_containers(candidate_groups)
+          final_groups = resolver.filter_1_to_1_overlap(non_containers)
+
+          scorer.select_best_group(final_groups)
+        end
+
+        def collect_candidate_groups
+          structure_groups = Hash.new { |h, k| h[k] = [] }
+          cache = {}.compare_by_identity
+
+          @parsed_body.xpath('//*').each { |node| add_node_to_groups(node, structure_groups, cache) }
+
+          structure_groups.select { |_, nodes| nodes.size >= @minimum_frequency }
+        end
+
+        def add_node_to_groups(node, structure_groups, cache)
+          return if EXCLUDED_TAGS.include?(node.name)
+          return if Html2rss::Html::Navigator.ignored_container_path?(node, cache)
+
+          sig = structure_signature(node)
+          structure_groups[sig] << node unless sig.empty?
+        end
+
+        def structure_signature(node)
+          child_tags = node.children.select(&:element?).map(&:name)
+          return '' if child_tags.empty?
+
+          child_tags.join('>')
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/auto_source/discovery/structure_clustering.rb
+++ b/lib/html2rss/auto_source/discovery/structure_clustering.rb
@@ -69,10 +69,10 @@ module Html2rss
         end
 
         def structure_signature(node)
-          child_tags = node.children.select(&:element?).map(&:name)
-          return '' if child_tags.empty?
+          child_elements = node.element_children
+          return '' if child_elements.empty?
 
-          child_tags.join('>')
+          child_elements.map(&:name).join('>')
         end
       end
     end

--- a/spec/html2rss/auto_source/discovery/structure_clustering_spec.rb
+++ b/spec/html2rss/auto_source/discovery/structure_clustering_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'nokogiri'
+
+RSpec.describe Html2rss::AutoSource::Discovery::StructureClustering do
+  describe '.call' do
+    let(:tailwind_html) do
+      <<~HTML
+        <!DOCTYPE html>
+        <html>
+        <body>
+          <nav class="flex items-center justify-between p-4 bg-gray-900 text-white">
+            <a class="text-xl font-bold" href="/home">Home</a>
+            <a class="hover:underline" href="/about">About</a>
+          </nav>
+          <main class="max-w-4xl mx-auto py-8 px-4">
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+              <div class="rounded-xl bg-slate-800 p-6 shadow-lg border border-slate-700">
+                <h3 class="text-xl font-semibold text-white">Tailwind Article One</h3>
+                <p class="mt-2 text-slate-300">Detailed summary description of the first article post.</p>
+                <a href="/articles/one" class="inline-block mt-4 text-indigo-400 font-medium">Read article</a>
+              </div>
+              <div class="rounded-xl bg-slate-800 p-6 shadow-lg border border-slate-700">
+                <h3 class="text-xl font-semibold text-white">Tailwind Article Two</h3>
+                <p class="mt-2 text-slate-300">Detailed summary description of the second article post.</p>
+                <a href="/articles/two" class="inline-block mt-4 text-indigo-400 font-medium">Read article</a>
+              </div>
+              <div class="rounded-xl bg-slate-800 p-6 shadow-lg border border-slate-700">
+                <h3 class="text-xl font-semibold text-white">Tailwind Article Three</h3>
+                <p class="mt-2 text-slate-300">Detailed summary description of the third article post.</p>
+                <a href="/articles/three" class="inline-block mt-4 text-indigo-400 font-medium">Read article</a>
+              </div>
+            </div>
+          </main>
+        </body>
+        </html>
+      HTML
+    end
+
+    let(:parsed_body) { Nokogiri::HTML(tailwind_html) }
+
+    it 'returns candidate nodes of the top-scoring structural tag group', :aggregate_failures do
+      nodes = described_class.call(parsed_body, minimum_selector_frequency: 3)
+      expect(nodes.size).to eq(3)
+      expect(nodes.first.at_css('h3').text).to eq('Tailwind Article One')
+    end
+
+    context 'when elements have differing class, id, and style attributes' do
+      let(:classless_differing_html) do
+        <<~HTML
+          <!DOCTYPE html>
+          <html>
+          <body>
+            <main>
+              <div>
+                <article id="item-1" class="c-a1" style="margin: 10px;">
+                  <h2>Unique Post Alpha</h2>
+                  <p>Content text for item alpha which is long enough to pass word score.</p>
+                  <a href="/alpha">View details</a>
+                </article>
+                <article id="item-2" class="c-b2" style="margin: 20px;">
+                  <h2>Unique Post Beta</h2>
+                  <p>Content text for item beta which is long enough to pass word score.</p>
+                  <a href="/beta">View details</a>
+                </article>
+                <article id="item-3" class="c-c3" style="margin: 30px;">
+                  <h2>Unique Post Gamma</h2>
+                  <p>Content text for item gamma which is long enough to pass word score.</p>
+                  <a href="/gamma">View details</a>
+                </article>
+              </div>
+            </main>
+          </body>
+          </html>
+        HTML
+      end
+
+      let(:parsed_differing_body) { Nokogiri::HTML(classless_differing_html) }
+
+      it 'ignores class, id, and inline style attributes when computing structural signatures' do
+        nodes = described_class.call(parsed_differing_body, minimum_selector_frequency: 3)
+        expect(nodes.size).to eq(3)
+      end
+    end
+
+    context 'when no structural groups meet the minimum frequency' do
+      it 'returns an empty array' do
+        nodes = described_class.call(parsed_body, minimum_selector_frequency: 5)
+        expect(nodes).to eq([])
+      end
+    end
+  end
+
+  describe 'ClassClustering fallback integration' do
+    let(:unique_classes_html) do
+      <<~HTML
+        <!DOCTYPE html>
+        <html>
+        <body>
+          <main>
+            <div>
+              <div class="hash-hash1">
+                <h3>Scoped Title One</h3>
+                <p>Detailed summary description text for scoped article one.</p>
+                <a href="/post/1">Read post</a>
+              </div>
+              <div class="hash-hash2">
+                <h3>Scoped Title Two</h3>
+                <p>Detailed summary description text for scoped article two.</p>
+                <a href="/post/2">Read post</a>
+              </div>
+              <div class="hash-hash3">
+                <h3>Scoped Title Three</h3>
+                <p>Detailed summary description text for scoped article three.</p>
+                <a href="/post/3">Read post</a>
+              </div>
+            </div>
+          </main>
+        </body>
+        </html>
+      HTML
+    end
+
+    let(:parsed_body) { Nokogiri::HTML(unique_classes_html) }
+
+    it 'falls back to StructureClustering when ClassClustering produces zero candidate groups', :aggregate_failures do
+      nodes = Html2rss::AutoSource::Discovery::ClassClustering.call(parsed_body, minimum_selector_frequency: 3)
+      expect(nodes.size).to eq(3)
+      expect(nodes.first.at_css('h3').text).to eq('Scoped Title One')
+    end
+  end
+end


### PR DESCRIPTION
## What changed

- Introduced `Html2rss::AutoSource::Discovery::StructureClustering` to discover content card containers by 1-level child element tag sequences (`element_children.map(&:name).join('>')`).
- Added fallback integration in `Html2rss::AutoSource::Discovery::ClassClustering.call` when class-based DOM clustering yields zero candidate groups or when candidate scoring filters all class candidates down to an empty set (such as Tailwind CSS utility class layouts or classless HTML pages).
- Reused `GroupScorer` and `OverlapResolver` to filter container elements and 1-to-1 wrapper overlaps.
- Added comprehensive unit tests in `spec/html2rss/auto_source/discovery/structure_clustering_spec.rb`.

## Why

On sites utilizing utility-first CSS frameworks (like Tailwind CSS) or classless markup, DOM elements lack shared functional class names. As a result, `ClassClustering` produces zero candidate groups or fails to find repeated content cards. Adding `StructureClustering` as a fallback ensures reliable auto-sourcing on modern and classless layouts without compromising existing class-clustering signal.

## Risk

- Low — `StructureClustering` is invoked strictly as a fallback when `ClassClustering` produces no candidates or yields an empty scored result set.
- Overhead is minimized by leveraging Nokogiri's native `element_children` C-level traversal and existing container path filters.

## Review map

Review map: whole PR is small — start at `lib/html2rss/auto_source/discovery/structure_clustering.rb`.

## Validation

- `bundle exec rspec` — 1185 examples, 0 failures
- `bin/lint-changed` — 0 offenses
- `bundle exec yard-lint lib/` — 100% documented
- `make ready` — All local quality gates passed