### PR TITLE
feat: dynamic slot budgeting, refactor request strategy adapters & unified config schema

### DIFF
--- a/lib/html2rss/auto_source.rb
+++ b/lib/html2rss/auto_source.rb
@@ -56,6 +56,26 @@ module Html2rss
       cleanup: Cleanup::DEFAULT_CONFIG
     }.freeze
 
+    class << self
+      ##
+      # Returns the sum of required request slots for all enabled scrapers in the config.
+      #
+      # @param config [Hash, nil] auto_source configuration hash
+      # @return [Integer] total request slots required by scrapers
+      def request_slots_for(config)
+        return 0 unless config
+
+        Scraper::SCRAPERS.sum do |scraper|
+          if config.dig(:scraper, scraper.options_key, :enabled)
+            opts = config.dig(:scraper, scraper.options_key)
+            scraper.respond_to?(:request_slots) ? scraper.request_slots(opts) : 0
+          else
+            0
+          end
+        end
+      end
+    end
+
     ##
     # @param response [Html2rss::RequestService::Response] initial page response
     # @param opts [Hash] validated auto-source options

--- a/lib/html2rss/auto_source/scraper/sitemap.rb
+++ b/lib/html2rss/auto_source/scraper/sitemap.rb
@@ -20,6 +20,15 @@ module Html2rss
         def self.options_key = :sitemap
 
         ##
+        # Returns the number of request slots needed for sitemap discovery and fan-out.
+        #
+        # @param _opts [Hash] unused options
+        # @return [Integer] number of follow-up requests needed
+        def self.request_slots(_opts = {})
+          1 + MAX_SUB_SITEMAPS
+        end
+
+        ##
         # @param parsed_body [Nokogiri::HTML::Document, nil] parsed document
         # @return [Boolean] whether the page links to a sitemap or is a sitemap
         def self.articles?(parsed_body)

--- a/lib/html2rss/auto_source/scraper/wordpress_api.rb
+++ b/lib/html2rss/auto_source/scraper/wordpress_api.rb
@@ -25,6 +25,15 @@ module Html2rss
         def self.options_key = :wordpress_api
 
         ##
+        # Returns the number of request slots needed for WordPress API posts fetch.
+        #
+        # @param _opts [Hash] unused options
+        # @return [Integer] number of follow-up requests needed
+        def self.request_slots(_opts = {})
+          1
+        end
+
+        ##
         # @param parsed_body [Nokogiri::HTML::Document, nil] parsed HTML document
         # @return [Boolean] whether the page advertises a WordPress REST API endpoint
         def self.articles?(parsed_body)

--- a/lib/html2rss/config/schema.rb
+++ b/lib/html2rss/config/schema.rb
@@ -60,7 +60,8 @@ module Html2rss
         def call
           schema = validator_schema
           apply_top_level(schema)
-          assign_properties(schema.fetch(:properties))
+          schema.fetch(:properties).merge!(overlay)
+          schema.fetch(:properties).delete(:dynamic_params_error)
           DeepStringifier.call(schema)
         end
 
@@ -78,161 +79,74 @@ module Html2rss
           ]
         end
 
-        def assign_properties(properties)
-          properties.merge!(
-            strategy: Components.strategy,
-            headers: Components.headers,
-            stylesheets: Components.stylesheets,
-            auto_source: Components.auto_source,
-            selectors: Components.selectors
-          )
-          properties.delete(:dynamic_params_error)
-        end
-      end
-
-      ##
-      # Exposes schema fragments that populate the top-level configuration schema.
-      module Components
-        module_function
-
-        # @return [Hash{Symbol => Object}] schema fragment for strategy selection
-        def strategy
-          {
-            type: 'string',
-            not: { type: 'null' }
-          }
-        end
-
-        # @return [Hash{Symbol => Object}] schema fragment for headers
-        def headers
-          {
-            type: 'object',
-            description: 'HTTP headers applied to every request.',
-            additionalProperties: { type: 'string' }
-          }
-        end
-
-        # @return [Hash{Symbol => Object}] schema fragment for stylesheet definitions
-        def stylesheets
-          {
-            type: 'array',
-            description: 'Collection of stylesheets to attach to the RSS feed.',
-            items: Html2rss::Config::Validator::StylesheetConfig.json_schema(loose: true)
-          }
-        end
-
-        # @return [Hash{Symbol => Object}] schema fragment for pagination configuration
-        def pagination
-          {
+        # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Layout/LineLength
+        def overlay
+          items_schema = Html2rss::Config::SelectorsValidator::Items.new.schema.json_schema(loose: true)
+          items_schema[:properties][:pagination] = {
             description: 'Pagination configuration or maximum page count integer.',
-            oneOf: [{ type: 'integer', exclusiveMinimum: 0 }, pagination_object_schema]
+            oneOf: [
+              { type: 'integer', exclusiveMinimum: 0 },
+              {
+                type: 'object',
+                properties: {
+                  strategy: { type: 'string', enum: Html2rss::RequestSession::Pager.strategy_names },
+                  max_pages: { type: 'integer', exclusiveMinimum: 0 },
+                  selector: { type: 'string' },
+                  param: { type: 'string' },
+                  start_page: { type: 'integer' },
+                  step: { type: 'integer', exclusiveMinimum: 0 },
+                  start_offset: { type: 'integer' },
+                  increment: { type: 'integer', exclusiveMinimum: 0 },
+                  cursor_path: { type: 'string' },
+                  next_url_path: { type: 'string' }
+                },
+                additionalProperties: true
+              }
+            ]
           }
-        end
 
-        # @return [Hash{Symbol => Object}] schema fragment for object-style pagination configuration
-        def pagination_object_schema
           {
-            type: 'object',
-            properties: pagination_properties,
-            additionalProperties: true
+            strategy: {
+              type: 'string',
+              not: { type: 'null' }
+            },
+            headers: {
+              type: 'object',
+              description: 'HTTP headers applied to every request.',
+              additionalProperties: { type: 'string' }
+            },
+            stylesheets: {
+              type: 'array',
+              description: 'Collection of stylesheets to attach to the RSS feed.',
+              items: Html2rss::Config::Validator::StylesheetConfig.json_schema(loose: true)
+            },
+            auto_source: Html2rss::Config::AutoSourceContract.json_schema(loose: true).merge(
+              default: DeepStringifier.call(Html2rss::AutoSource::DEFAULT_CONFIG)
+            ),
+            selectors: {
+              type: 'object',
+              description: 'Selectors used to extract article attributes.',
+              properties: {
+                items: items_schema.merge(
+                  description: 'Defines the items selector and optional enhancement settings.'
+                ),
+                enclosure: Html2rss::Config::SelectorsValidator::Enclosure.new.schema.json_schema(loose: true).merge(
+                  description: 'Describes enclosure extraction settings.'
+                ),
+                guid: reference_array('List of selector keys used to build the GUID. Each entry must reference a sibling selector key; runtime validation enforces those references.'),
+                categories: reference_array('List of selector keys whose values will be used as categories. Each entry must reference a sibling selector key; runtime validation enforces those references.')
+              },
+              patternProperties: {
+                '^(?!items$|enclosure$|guid$|categories$).+$' => Html2rss::Config::SelectorsValidator::Selector.new.schema.json_schema(loose: true).merge(
+                  description: 'Dynamic selector definition keyed by attribute name.'
+                )
+              },
+              additionalProperties: true
+            }
           }
         end
+        # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Layout/LineLength
 
-        # @return [Hash{Symbol => Object}] schema fragment for pagination object properties
-        # rubocop:disable Metrics/MethodLength -- property map mirrors runtime pager keys 1:1
-        def pagination_properties
-          {
-            strategy: { type: 'string', enum: Html2rss::RequestSession::Pager.strategy_names },
-            max_pages: { type: 'integer', exclusiveMinimum: 0 },
-            selector: { type: 'string' },
-            param: { type: 'string' },
-            start_page: { type: 'integer' },
-            step: { type: 'integer', exclusiveMinimum: 0 },
-            start_offset: { type: 'integer' },
-            increment: { type: 'integer', exclusiveMinimum: 0 },
-            cursor_path: { type: 'string' },
-            next_url_path: { type: 'string' }
-          }
-        end
-        # rubocop:enable Metrics/MethodLength
-
-        # @return [Hash{Symbol => Object}] schema fragment for auto_source configuration
-        def auto_source
-          schema = Html2rss::Config::AutoSourceContract.json_schema(loose: true)
-          schema[:default] = DeepStringifier.call(Html2rss::AutoSource::DEFAULT_CONFIG)
-          schema
-        end
-
-        # @return [Hash{Symbol => Object}] schema fragment for selectors configuration
-        def selectors
-          Selectors.schema
-        end
-      end
-
-      ##
-      # Provides schema fragments that document selector configuration.
-      module Selectors
-        module_function
-
-        # Pattern used for dynamic selector keys excluding reserved selector names.
-        RESERVED_SELECTOR_PATTERN = '^(?!items$|enclosure$|guid$|categories$).+$'
-
-        # @return [Hash{Symbol => Object}] schema fragment for selectors root object
-        def schema
-          {
-            type: 'object',
-            description: 'Selectors used to extract article attributes.',
-            properties: selector_properties,
-            patternProperties: pattern_properties,
-            additionalProperties: true
-          }
-        end
-
-        # rubocop:disable Layout/LineLength
-        # @return [Hash{Symbol => Object}] schema map for reserved selector properties
-        def selector_properties
-          {
-            items: items_schema,
-            enclosure: enclosure_schema,
-            guid: reference_array('List of selector keys used to build the GUID. Each entry must reference a sibling selector key; runtime validation enforces those references.'),
-            categories: reference_array('List of selector keys whose values will be used as categories. Each entry must reference a sibling selector key; runtime validation enforces those references.')
-          }
-        end
-        # rubocop:enable Layout/LineLength
-
-        # @return [Hash{String => Object}] schema map for dynamic selector keys
-        def pattern_properties
-          { RESERVED_SELECTOR_PATTERN => dynamic_selector_schema }
-        end
-
-        # @return [Hash{Symbol => Object}] schema fragment for dynamic selector entries
-        def dynamic_selector_schema
-          Html2rss::Config::SelectorsValidator::Selector.new.schema.json_schema(loose: true).merge(
-            description: 'Dynamic selector definition keyed by attribute name.'
-          )
-        end
-
-        # @return [Hash{Symbol => Object}] schema fragment for `items` selector configuration
-        def items_schema
-          schema = Html2rss::Config::SelectorsValidator::Items.new.schema.json_schema(loose: true).merge(
-            description: 'Defines the items selector and optional enhancement settings.'
-          )
-          schema[:properties][:pagination] = Components.pagination
-          schema
-        end
-
-        # @return [Hash{Symbol => Object}] schema fragment for `enclosure` selector configuration
-        def enclosure_schema
-          Html2rss::Config::SelectorsValidator::Enclosure.new.schema.json_schema(loose: true).merge(
-            description: 'Describes enclosure extraction settings.'
-          )
-        end
-
-        # JSON Schema can enforce non-empty reference arrays, while runtime
-        # validation remains authoritative for checking that each entry points
-        # to an existing sibling selector key.
-        # @param description [String] human-readable description for the reference field
-        # @return [Hash{Symbol => Object}] JSON schema fragment for selector references
         def reference_array(description)
           {
             type: 'array',

--- a/lib/html2rss/feed_pipeline/runtime_policy.rb
+++ b/lib/html2rss/feed_pipeline/runtime_policy.rb
@@ -66,28 +66,10 @@ module Html2rss
         # Reserve enough HTTP request slots for the initial request plus predictable
         # follow-ups. Preload interactions are planned separately.
         def baseline_request_budget_for(config)
-          1 + pagination_follow_up_budget_for(config) +
-            known_auto_source_follow_up_budget_for(config) +
-            auto_strategy_fallback_budget_for(config)
-        end
-
-        def auto_strategy_fallback_budget_for(config)
-          plan = StrategyPlan.resolve(config.strategy)
-          return 0 unless plan.is_a?(StrategyPlan::Auto)
-
-          [AutoFallback::CHAIN.size - 1, 0].max
-        end
-
-        def pagination_follow_up_budget_for(config)
-          pagination_config = config.selectors&.dig(:items, :pagination)
-          return 0 unless pagination_config
-
-          max_pages = RequestSession::Pager.normalize_config(pagination_config)[:max_pages] || RequestSession::Pager::Base::DEFAULT_MAX_PAGES
-          [max_pages - 1, 0].max
-        end
-
-        def known_auto_source_follow_up_budget_for(config)
-          config.auto_source&.dig(:scraper, :wordpress_api, :enabled) ? 1 : 0
+          1 +
+            RequestSession::Pager.request_slots_for(config.selectors&.dig(:items, :pagination)) +
+            AutoSource.request_slots_for(config.auto_source) +
+            StrategyPlan.resolve(config.strategy).request_slots
         end
 
         def browserless_preload_budget_for(config)

--- a/lib/html2rss/feed_pipeline/strategy_plan.rb
+++ b/lib/html2rss/feed_pipeline/strategy_plan.rb
@@ -9,10 +9,18 @@ module Html2rss
     # any session or adapter call — plan vs transport locality.
     class StrategyPlan
       # Feed-level auto plan: try {AutoFallback::CHAIN} until items are extracted.
-      Auto = Data.define
+      Auto = Data.define do
+        # @return [Integer]
+        def request_slots
+          [AutoFallback::CHAIN.size - 1, 0].max
+        end
+      end
 
       # Concrete transport strategy name for {RequestService}.
-      Concrete = Data.define(:strategy)
+      Concrete = Data.define(:strategy) do
+        # @return [Integer]
+        def request_slots = 0
+      end
 
       # Symbol used in config / configure for the auto plan.
       AUTO_NAME = :auto

--- a/lib/html2rss/request_service/botasaurus_strategy.rb
+++ b/lib/html2rss/request_service/botasaurus_strategy.rb
@@ -8,22 +8,6 @@ module Html2rss
     ##
     # Strategy to delegate fetching to a Botasaurus scrape API.
     class BotasaurusStrategy < Strategy
-      ##
-      # Executes a Botasaurus-backed request with shared request policy guards.
-      #
-      # @return [Response] normalized request response
-      # @raise [BotasaurusConfigurationError] when BOTASAURUS_SCRAPER_URL is missing or invalid
-      # @raise [BotasaurusConnectionFailed] when Botasaurus cannot be reached or returns an invalid payload
-      # @raise [RequestTimedOut] when the Botasaurus request exceeds configured timeout
-      def execute
-        check_timeout!
-        run_guarded_fetch
-      rescue Faraday::TimeoutError, Timeout::Error => error
-        raise RequestTimedOut, error.message
-      rescue Faraday::ConnectionFailed, Faraday::SSLError => error
-        raise BotasaurusConnectionFailed, "Botasaurus connection failed: #{error.message}"
-      end
-
       private
 
       def fetch
@@ -94,6 +78,10 @@ module Html2rss
         rescue ArgumentError => error
           raise BotasaurusConfigurationError, "BOTASAURUS_SCRAPER_URL is invalid: #{error.message}"
         end
+      end
+
+      def translate_connection_error(error)
+        raise BotasaurusConnectionFailed, "Botasaurus connection failed: #{error.message}"
       end
     end
   end

--- a/lib/html2rss/request_service/browserless_strategy.rb
+++ b/lib/html2rss/request_service/browserless_strategy.rb
@@ -32,18 +32,6 @@ module Html2rss
     # @see https://github.com/browserless/browserless/pkgs/container/chromium
     class BrowserlessStrategy < Strategy
       ##
-      # Executes a Browserless-backed request with the shared request policy.
-      #
-      # @return [Response] normalized request response
-      # @raise [RequestTimedOut] if the browser session exceeds the configured timeout
-      def execute
-        check_timeout!
-        run_guarded_fetch
-      rescue Puppeteer::TimeoutError => error
-        raise RequestTimedOut, error.message
-      end
-
-      ##
       # @return [String] the Browserless websocket endpoint with token query param
       # @raise [ArgumentError] if a custom endpoint is configured without an API token
       def browser_ws_endpoint

--- a/lib/html2rss/request_service/faraday_strategy.rb
+++ b/lib/html2rss/request_service/faraday_strategy.rb
@@ -27,34 +27,24 @@ module Html2rss
       end
 
       ##
-      # Executes a request with runtime policy enforcement.
+      # @return [ResponseGuard]
+      attr_reader :response_guard
+
+      # Executes the request with runtime policy enforcement, returning the normalized response.
       #
-      # @return [Response] normalized request response
-      # @note Unlike BrowserlessStrategy, Faraday does not expose the remote IP after connect.
-      #   SSRF protection here is pre-connection only (DNS resolution via Policy).
-      #   A DNS rebinding attack between resolution and connect cannot be caught at this layer.
-      def execute
-        check_timeout!
+      # @return [Response] normalized response
+      def perform_execute
         deadline = request_deadline
-        response_guard, raw_response = perform_request(deadline:)
-        response = build_response(raw_response)
-        postflight!(response, response_guard:)
-        response
-      rescue Faraday::TimeoutError, Timeout::Error => error
-        raise RequestTimedOut, error.message
+        @response_guard = ResponseGuard.new(policy: ctx.policy)
+        raw_response = faraday_request(response_guard, deadline:, streaming_buffer: true)
+        raw_response = retry_without_streaming(response_guard, deadline:) if retry_without_streaming?(raw_response)
+        build_response(raw_response)
       end
 
       private
 
       def request_deadline
         monotonic_now + ctx.budget.effective_timeout_seconds(fallback: ctx.policy.total_timeout_seconds)
-      end
-
-      def perform_request(deadline:)
-        response_guard = ResponseGuard.new(policy: ctx.policy)
-        response = faraday_request(response_guard, deadline:, streaming_buffer: true)
-        response = retry_without_streaming(response_guard, deadline:) if retry_without_streaming?(response)
-        [response_guard, response]
       end
 
       def build_response(response)

--- a/lib/html2rss/request_service/strategy.rb
+++ b/lib/html2rss/request_service/strategy.rb
@@ -21,7 +21,11 @@ module Html2rss
       # @raise [NotImplementedError] if the subclass does not implement `#fetch`
       def execute
         check_timeout!
-        run_guarded_fetch
+        response = perform_execute
+        postflight!(response, response_guard:)
+        response
+      rescue StandardError => error
+        handle_error(error)
       end
 
       private
@@ -30,24 +34,21 @@ module Html2rss
       attr_reader :ctx
 
       ##
+      # Adapter hook: perform the preflight, fetch, and optional retry lifecycle.
+      #
+      # @return [Response] normalized response
+      def perform_execute
+        preflight!
+        fetch
+      end
+
+      ##
       # Adapter hook: perform the transport-specific fetch after preflight.
       #
       # @return [Response] normalized response
       # @raise [NotImplementedError] when a subclass omits the hook
       def fetch
         raise NotImplementedError, 'Subclass must implement #fetch'
-      end
-
-      ##
-      # Runs budget/policy preflight, adapter fetch, and ResponseGuard postflight.
-      #
-      # @param consume_budget [Boolean] whether this attempt consumes a request slot
-      # @return [Response] guarded response
-      def run_guarded_fetch(consume_budget: true)
-        preflight!(consume_budget:)
-        response = fetch
-        postflight!(response)
-        response
       end
 
       ##
@@ -85,6 +86,43 @@ module Html2rss
 
       def check_timeout!
         ctx.budget.effective_timeout_seconds(fallback: ctx.policy.total_timeout_seconds)
+      end
+
+      # @return [ResponseGuard, nil]
+      def response_guard = nil
+
+      # @param error [StandardError]
+      # @return [void]
+      # @raise [StandardError]
+      def handle_error(error)
+        if timeout_error?(error)
+          raise RequestTimedOut, error.message
+        elsif connection_error?(error)
+          translate_connection_error(error)
+        else
+          raise error
+        end
+      end
+
+      # @param error [StandardError]
+      # @return [void]
+      # @raise [StandardError]
+      def translate_connection_error(error)
+        raise error
+      end
+
+      # @param error [StandardError]
+      # @return [Boolean]
+      def timeout_error?(error)
+        error.is_a?(Faraday::TimeoutError) ||
+          error.is_a?(Timeout::Error) ||
+          (defined?(Puppeteer::TimeoutError) && error.is_a?(Puppeteer::TimeoutError))
+      end
+
+      # @param error [StandardError]
+      # @return [Boolean]
+      def connection_error?(error)
+        error.is_a?(Faraday::ConnectionFailed) || error.is_a?(Faraday::SSLError)
       end
     end
   end

--- a/lib/html2rss/request_session/pager.rb
+++ b/lib/html2rss/request_session/pager.rb
@@ -24,6 +24,18 @@ module Html2rss
       end
 
       ##
+      # Returns the number of request slots needed for the pagination configuration.
+      #
+      # @param config [Hash, Integer, nil] pagination configuration
+      # @return [Integer] number of follow-up requests needed
+      def self.request_slots_for(config)
+        return 0 unless config
+
+        max_pages = normalize_config(config)[:max_pages] || Base::DEFAULT_MAX_PAGES
+        [max_pages - 1, 0].max
+      end
+
+      ##
       # Returns a pager instance for the provided configuration.
       #
       # @param config [Hash, Integer, nil] pagination configuration

--- a/spec/lib/html2rss/feed_pipeline/runtime_policy_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline/runtime_policy_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Html2rss::FeedPipeline::RuntimePolicy do
       let(:config) { Html2rss::Config.from_hash(raw_config) }
 
       it 'sizes HTTP request slots without stuffing preload into max_requests', :aggregate_failures do
-        expect(runtime_policy.max_requests).to eq(4)
+        expect(runtime_policy.max_requests).to eq(8)
         expect(runtime_policy.max_redirects).to eq(8)
         expect(described_class.interaction_budget_for(config)).to eq(2)
       end
@@ -48,7 +48,7 @@ RSpec.describe Html2rss::FeedPipeline::RuntimePolicy do
       it 'adds auto fallback retry budget to the runtime policy', :aggregate_failures do
         expected_retry_budget = Html2rss::FeedPipeline::AutoFallback::CHAIN.size - 1
 
-        expect(runtime_policy.max_requests).to eq(4 + expected_retry_budget)
+        expect(runtime_policy.max_requests).to eq(8 + expected_retry_budget)
         expect(runtime_policy.max_redirects).to eq(8)
       end
     end
@@ -57,7 +57,7 @@ RSpec.describe Html2rss::FeedPipeline::RuntimePolicy do
       let(:config) { Html2rss::Config.from_hash(raw_config.merge(strategy: :faraday)) }
 
       it 'keeps baseline request budget unchanged for non-auto strategies' do
-        expect(runtime_policy.max_requests).to eq(4)
+        expect(runtime_policy.max_requests).to eq(8)
       end
     end
 
@@ -74,7 +74,7 @@ RSpec.describe Html2rss::FeedPipeline::RuntimePolicy do
       end
 
       it 'reserves request budget using default max_pages of 5' do
-        expect(runtime_policy.max_requests).to eq(6) # 1 initial + (5-1) pagination + 1 wordpress_api
+        expect(runtime_policy.max_requests).to eq(10) # 1 initial + (5-1) pagination + 1 wordpress_api + 4 sitemap
       end
     end
 
@@ -98,7 +98,7 @@ RSpec.describe Html2rss::FeedPipeline::RuntimePolicy do
       end
 
       it 'does not reserve preload interaction budget', :aggregate_failures do
-        expect(runtime_policy.max_requests).to eq(4)
+        expect(runtime_policy.max_requests).to eq(8)
         expect(described_class.interaction_budget_for(config)).to eq(0)
         expect(runtime_policy.max_redirects).to eq(8)
       end
@@ -117,7 +117,7 @@ RSpec.describe Html2rss::FeedPipeline::RuntimePolicy do
       end
 
       it 'counts click actions on the interaction budget, not request slots', :aggregate_failures do
-        expect(runtime_policy.max_requests).to eq(4)
+        expect(runtime_policy.max_requests).to eq(8)
         expect(described_class.interaction_budget_for(config)).to eq(2)
       end
     end
@@ -144,7 +144,7 @@ RSpec.describe Html2rss::FeedPipeline::RuntimePolicy do
 
       it 'counts scroll actions on the interaction budget so pagination keeps its HTTP slots',
          :aggregate_failures do
-        expect(runtime_policy.max_requests).to eq(4)
+        expect(runtime_policy.max_requests).to eq(8)
         expect(described_class.interaction_budget_for(config)).to eq(3)
       end
     end
@@ -156,7 +156,7 @@ RSpec.describe Html2rss::FeedPipeline::RuntimePolicy do
     it 'builds a Budget with separate request and interaction pools', :aggregate_failures do
       budget = described_class.budget_for(config)
 
-      expect(budget.remaining_requests).to eq(4)
+      expect(budget.remaining_requests).to eq(8)
       expect(budget.remaining_interactions).to eq(2)
     end
   end

--- a/spec/lib/html2rss/feed_pipeline/strategy_plan_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline/strategy_plan_spec.rb
@@ -44,5 +44,13 @@ RSpec.describe Html2rss::FeedPipeline::StrategyPlan do
         [:auto, *Html2rss::RequestService.strategy_names.map(&:to_sym)].uniq
       )
     end
+  describe '#request_slots' do
+    it 'returns the fallback retry budget size for Auto' do
+      expect(described_class::Auto.new.request_slots).to eq(Html2rss::FeedPipeline::AutoFallback::CHAIN.size - 1)
+    end
+
+    it 'returns 0 for Concrete' do
+      expect(described_class::Concrete.new(strategy: :faraday).request_slots).to eq(0)
+    end
   end
 end

--- a/spec/lib/html2rss/feed_pipeline/strategy_plan_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline/strategy_plan_spec.rb
@@ -44,6 +44,8 @@ RSpec.describe Html2rss::FeedPipeline::StrategyPlan do
         [:auto, *Html2rss::RequestService.strategy_names.map(&:to_sym)].uniq
       )
     end
+  end
+
   describe '#request_slots' do
     it 'returns the fallback retry budget size for Auto' do
       expect(described_class::Auto.new.request_slots).to eq(Html2rss::FeedPipeline::AutoFallback::CHAIN.size - 1)


### PR DESCRIPTION
## What changed

- **Deepened Strategy base class**: Consolidated timeout validations, monotonic timing clocks, preflight checks, and exception mapping in `Html2rss::RequestService::Strategy`. Concrete strategies now only implement a simplified `fetch` (or `perform_execute`) method.
- **Dynamic Request Slot Budgeting**: Replaced static request budgeting in `RuntimePolicy` with polymorphic `#request_slots` lookups on `Pager`, `StrategyPlan`, and `AutoSource`. Sitemap scrapers now correctly budget `1 + MAX_SUB_SITEMAPS = 4` request slots.
- **Unified Config Schema**: Replaced the twin dual-module structure of `Components` and `Selectors` in `schema.rb` with a single, declarative overlay hash in `Builder`, dynamically merged onto the Dry::Validation contracts.

## Why

- Concrete strategies previously duplicated `execute` overrides and rescued transport-specific timeout errors redundantly. Owning the timing/lifecycle in the base class turns them into deep modules with a clear separation of concerns.
- `html2rss-web` previously had to inject a hardcoded `max_requests: 4` override to prevent sitemap sub-fetches from failing. Relocating slot demand calculations to their source classes lets the gem dynamically calculate a correct and safe budget.
- The config schema was maintained separate from the validation contracts, creating a high maintenance burden and risking representation drift.

## Risk

- Low. The refactored schema builder produces the exact same config schema file. Adapter timeout/retry behaviors remain structurally identical.

## Review map

1. `lib/html2rss/request_service/strategy.rb` — owns timing clock, timeouts, preflight/postflight, and error mapping.
2. `lib/html2rss/feed_pipeline/runtime_policy.rb` — sums slots dynamically from Pager, StrategyPlan, and AutoSource.
3. `lib/html2rss/config/schema.rb` — builds schema by merging declarative overlay on top of validator contracts.

## Validation

- Ran `make ready` (all PR readiness checks including `rspec`, `rubocop`, `yard-lint`, `shellcheck`, and `validate-fixtures` passed).
- Verified JSON Schema output matches exactly via `make schema`.
