### PR TITLE
chore(release): bump version to v0.23.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    html2rss (0.22.2)
+    html2rss (0.23.0)
       addressable (~> 2.7)
       brotli
       dry-validation
@@ -349,7 +349,7 @@ CHECKSUMS
   fiber-annotation (0.2.0) sha256=7abfadf1d119f508867d4103bf231c0354d019cc39a5738945dec2edadaf6c03
   fiber-local (1.1.0) sha256=c885f94f210fb9b05737de65d511136ea602e00c5105953748aa0f8793489f06
   fiber-storage (1.0.1) sha256=f48e5b6d8b0be96dac486332b55cee82240057065dc761c1ea692b2e719240e1
-  html2rss (0.22.2)
+  html2rss (0.23.0)
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   io-endpoint (0.17.2) sha256=3feaf766c116b35839c11fac68b6aaadc47887bb488902a57bf8e1d288fb3338
   io-event (1.19.4) sha256=c291146e2e70849b9d6b64078f8e98f0154bfd3bc4f9759861ff13e9895e0cce

--- a/lib/html2rss/version.rb
+++ b/lib/html2rss/version.rb
@@ -2,6 +2,6 @@
 
 module Html2rss
   # Current application version.
-  VERSION = '0.22.2'
+  VERSION = '0.23.0'
   public_constant :VERSION
 end


### PR DESCRIPTION
Automated version bump to `v0.23.0`.

This PR contains the version update in `lib/html2rss/version.rb` and regenerated schema.

### 🚀 Next Steps
1. Verify that all CI checks pass.
2. Merge this Pull Request.
3. Go to the draft release on GitHub and publish it.