### PR TITLE
fix(logging): keep transport details out of info logs

### DIFF
--- a/lib/html2rss/request_service/budget.rb
+++ b/lib/html2rss/request_service/budget.rb
@@ -82,9 +82,14 @@ module Html2rss
       def remaining_timeout_seconds
         return unless @total_timeout_seconds
 
-        elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - @start_time
-        remaining = @total_timeout_seconds - elapsed
+        remaining = @total_timeout_seconds - elapsed_seconds
         [remaining, 0.0].max
+      end
+
+      ##
+      # @return [Float] seconds since this budget was created
+      def elapsed_seconds
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) - @start_time
       end
 
       ##

--- a/lib/html2rss/request_service/strategy.rb
+++ b/lib/html2rss/request_service/strategy.rb
@@ -86,6 +86,9 @@ module Html2rss
 
       def check_timeout!
         ctx.budget.effective_timeout_seconds(fallback: ctx.policy.total_timeout_seconds)
+      rescue RequestTimedOut
+        log_timeout!(reason: 'budget_exhausted')
+        raise
       end
 
       # @return [ResponseGuard, nil]
@@ -96,6 +99,8 @@ module Html2rss
       # @raise [StandardError]
       def handle_error(error)
         if timeout_error?(error)
+          log_timeout!(reason: 'transport')
+          Log.debug("#{self.class}: transport timeout message=#{error.message}")
           raise RequestTimedOut, error.message
         elsif connection_error?(error)
           translate_connection_error(error)
@@ -103,6 +108,23 @@ module Html2rss
           raise error
         end
       end
+
+      # @param reason [String] timeout classification (budget_exhausted / transport)
+      # @return [void]
+      # rubocop:disable Metrics/AbcSize -- structured timeout fields stay in one log line
+      def log_timeout!(reason:)
+        remaining = ctx.budget.remaining_timeout_seconds
+        remaining_label = remaining.nil? ? 'untracked' : format('%.3f', remaining)
+        detail = [
+          "strategy=#{self.class.name}",
+          "host=#{ctx.url.host}",
+          "elapsed=#{format('%.3f', ctx.budget.elapsed_seconds)}s",
+          "budget_remaining=#{remaining_label}",
+          "reason=#{reason}"
+        ]
+        Log.info("#{self.class}: request timeout #{detail.join(' ')}")
+      end
+      # rubocop:enable Metrics/AbcSize
 
       # @param error [StandardError]
       # @return [void]

--- a/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
       Html2rss::RequestService::Budget,
       consume!: nil,
       remaining_timeout_seconds: nil,
-      effective_timeout_seconds: 30.0
+      effective_timeout_seconds: 30.0,
+      elapsed_seconds: 0.0
     )
   end
   let(:request_config) { {} }

--- a/spec/lib/html2rss/request_service/browserless_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/browserless_strategy_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Html2rss::RequestService::BrowserlessStrategy do
       consume!: nil,
       remaining_timeout_seconds: nil,
       effective_timeout_seconds: 30.0,
-      effective_timeout_ms: 30_000
+      effective_timeout_ms: 30_000,
+      elapsed_seconds: 0.0
     )
   end
   let(:ctx) { Html2rss::RequestService::Context.new(url: 'https://example.com', policy:, budget:) }

--- a/spec/lib/html2rss/request_service/budget_spec.rb
+++ b/spec/lib/html2rss/request_service/budget_spec.rb
@@ -49,6 +49,13 @@ RSpec.describe Html2rss::RequestService::Budget do
     end
   end
 
+  describe '#elapsed_seconds' do
+    it 'reports wall-clock time since budget creation' do
+      budget = described_class.new(max_requests: 2)
+      expect(budget.elapsed_seconds).to be >= 0.0
+    end
+  end
+
   describe '#remaining_timeout_seconds' do
     it 'returns nil when total_timeout_seconds is not provided' do
       budget = described_class.new(max_requests: 2)

--- a/spec/lib/html2rss/request_service/faraday_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/faraday_strategy_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe Html2rss::RequestService::FaradayStrategy do # rubocop:disable RS
       Html2rss::RequestService::Budget,
       consume!: nil,
       remaining_timeout_seconds: nil,
-      effective_timeout_seconds: 30.0
+      effective_timeout_seconds: 30.0,
+      elapsed_seconds: 0.0
     )
   end
   let(:ctx) do

--- a/spec/lib/html2rss/request_service/local_file_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/local_file_strategy_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Html2rss::RequestService::LocalFileStrategy do
       Html2rss::RequestService::Budget,
       consume!: nil,
       remaining_timeout_seconds: nil,
-      effective_timeout_seconds: 30.0
+      effective_timeout_seconds: 30.0,
+      elapsed_seconds: 0.0
     )
   end
   let(:temp_file) do

--- a/spec/lib/html2rss/request_service/strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/strategy_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe Html2rss::RequestService::Strategy do
       Html2rss::RequestService::Budget,
       consume!: nil,
       remaining_timeout_seconds: nil,
-      effective_timeout_seconds: 30.0
+      effective_timeout_seconds: 30.0,
+      elapsed_seconds: 0.0
     )
   end
   let(:ctx) do
@@ -72,5 +73,39 @@ RSpec.describe Html2rss::RequestService::Strategy do
 
       expect(Html2rss::RequestService::ResponseGuard).to have_received(:new).with(policy:)
     end
+  end
+
+  describe 'timeout logging' do
+    let(:adapter) do
+      Class.new(described_class) do
+        private
+
+        def fetch
+          raise Faraday::TimeoutError, 'execution expired for https://secret.example/path?token=abc'
+        end
+      end
+    end
+
+    before do
+      allow(Html2rss::Log).to receive(:info)
+      allow(Html2rss::Log).to receive(:debug)
+    end
+
+    # rubocop:disable RSpec/ExampleLength -- structured info fields + debug message redaction
+    it 'keeps transport details out of info logs', :aggregate_failures do
+      expect { adapter.new(ctx).execute }.to raise_error(Html2rss::RequestService::RequestTimedOut)
+
+      expect(Html2rss::Log).to have_received(:info) do |message|
+        expect(message).to include('request timeout')
+        expect(message).to include('host=example.com')
+        expect(message).to include('reason=transport')
+        expect(message).not_to include('token=abc')
+        expect(message).not_to include('secret.example')
+      end
+      expect(Html2rss::Log).to have_received(:debug).with(
+        a_string_matching(/transport timeout message=.*token=abc/)
+      )
+    end
+    # rubocop:enable RSpec/ExampleLength
   end
 end


### PR DESCRIPTION
## What changed

- Structured request timeout `Log.info` lines stay limited to strategy/host/timing/budget/reason
- Raw transport exception text moves to `Log.debug`
- Adds `Budget#elapsed_seconds` so timeout logs can report wall-clock elapsed without recomputing inline

## Why

Info-level request logs were a path for promoting transport error strings (hosts, query tokens) into operator-visible logs.

## Risk

- Low — logging shape only; timeout still raises `RequestTimedOut` with the original message

## Review map

Review map: whole PR is small — start at `lib/html2rss/request_service/strategy.rb`.

## Validation

- `mise exec -- bundle exec rspec spec/lib/html2rss/request_service/strategy_spec.rb spec/lib/html2rss/request_service/budget_spec.rb` — 16 examples, 0 failures

## Split note

Peeled from #418 / `feat/feed-result-api`. Prefer merging before the FeedResult PR when practical.