### PR TITLE
refactor: materialize Channel

### DIFF
--- a/lib/html2rss/channel.rb
+++ b/lib/html2rss/channel.rb
@@ -1,118 +1,198 @@
 # frozen_string_literal: true
 
+require 'time'
+
+# rubocop:disable Metrics/ModuleLength -- Channel value object owns extract + freeze + Marshal
 module Html2rss
   ##
-  # Channel metadata for feed builders, extracted from the HTML document head
-  # and HTTP response (with optional config overrides).
+  # Materialized channel metadata for feed builders and {FeedResult}.
   #
-  # Format adapters ({FeedBuilder::Rss}, {FeedBuilder::JsonFeed}) consume this type; they do
-  # not own channel extraction.
-  class Channel
-    # Fallback RSS ttl (in minutes) when no cache directives are present.
-    DEFAULT_TTL_IN_MINUTES = 360
-    # Description template used when no explicit or discovered description exists.
-    DEFAULT_DESCRIPTION_TEMPLATE = 'Latest items from %<url>s'
+  # Extract once via {Channel.from_response}; builders consume this value object and
+  # do not own channel extraction. Safe to Marshal (no Response / Nokogiri retained).
+  # Strings and image URL are normalized and frozen at construction (including Marshal load).
+  #
+  # @!attribute [r] title
+  #   @return [String]
+  # @!attribute [r] url
+  #   @return [Html2rss::Url]
+  # @!attribute [r] description
+  #   @return [String]
+  # @!attribute [r] language
+  #   @return [String, nil]
+  # @!attribute [r] ttl
+  #   @return [Integer]
+  # @!attribute [r] last_build_date
+  #   @return [Time]
+  # @!attribute [r] image
+  #   @return [Html2rss::Url, nil]
+  # @!attribute [r] author
+  #   @return [String, nil]
+  Channel = Data.define(:title, :url, :description, :language, :ttl, :last_build_date, :image, :author) do
+    class << self
+      ##
+      # Materializes channel attributes from an HTTP response and optional overrides.
+      #
+      # @param response [Html2rss::RequestService::Response]
+      # @param overrides [Hash{Symbol => Object}] optional overrides for channel attributes
+      # @return [Html2rss::Channel]
+      def from_response(response, overrides: {})
+        new(
+          title: title_for(response, overrides),
+          url: url_for(response),
+          description: description_for(response, overrides),
+          language: language_for(response, overrides),
+          ttl: ttl_for(response, overrides),
+          last_build_date: last_build_date_for(response),
+          image: image_for(response, overrides),
+          author: author_for(response, overrides)
+        )
+      end
+
+      private
+
+      # Fallback RSS ttl (in minutes) when no cache directives are present.
+      def default_ttl_in_minutes = 360
+
+      # Description template used when no explicit or discovered description exists.
+      def default_description_template = 'Latest items from %<url>s'
+
+      def url_for(response) = Html2rss::Url.from_absolute(response.url)
+
+      def title_for(response, overrides)
+        return overrides[:title] if overrides[:title]
+
+        title = parsed_title(response)
+        return title if title
+
+        url_for(response).channel_titleized
+      end
+
+      def parsed_title(response)
+        return unless html_response?(response)
+
+        title = parsed_body(response).at_css('head > title')&.text.to_s
+        return if title.empty?
+
+        title.gsub(/\s+/, ' ').strip
+      end
+
+      def description_for(response, overrides)
+        return overrides[:description] unless overrides[:description].to_s.empty?
+
+        description = meta_description(response)
+        return format(default_description_template, url: url_for(response)) if description.to_s.empty?
+
+        description
+      end
+
+      def meta_description(response)
+        return unless html_response?(response)
+
+        parsed_body(response).at_css('meta[name="description"]')&.[]('content')
+      end
+
+      def ttl_for(response, overrides)
+        calculated = if overrides[:ttl]
+                       overrides[:ttl].to_i
+                     elsif (max_age = headers(response)['cache-control']&.match(/max-age=(\d+)/)&.[](1))
+                       max_age.to_i.fdiv(60).ceil
+                     else
+                       default_ttl_in_minutes
+                     end
+
+        min_ttl = Html2rss.defaults.min_ttl
+        min_ttl ? [calculated, min_ttl].max : calculated
+      end
+
+      def language_for(response, overrides)
+        return overrides[:language] if overrides[:language]
+
+        if (language_code = headers(response)['content-language']&.match(/^([a-z]{2})/))
+          return language_code[0]
+        end
+
+        return unless html_response?(response)
+
+        parsed_body(response)['lang'] || parsed_body(response).at_css('[lang]')&.[]('lang')
+      end
+
+      def author_for(response, overrides)
+        return overrides[:author] if overrides[:author]
+        return unless html_response?(response)
+
+        parsed_body(response).at_css('meta[name="author"]')&.[]('content')
+      end
+
+      def last_build_date_for(response)
+        header = headers(response)['last-modified']
+        return Time.now unless header
+
+        Time.httpdate(header)
+      rescue ArgumentError
+        Time.now
+      end
+
+      def image_for(response, overrides)
+        return overrides[:image] if overrides[:image]
+        return unless html_response?(response)
+
+        if (image_url = parsed_body(response).at_css('meta[property="og:image"]')&.[]('content'))
+          Url.sanitize(image_url)
+        end
+      end
+
+      def parsed_body(response) = response.parsed_body
+      def headers(response) = response.headers
+      def html_response?(response) = response.html_response?
+    end
 
     ##
-    # @param response [Html2rss::RequestService::Response]
-    # @param overrides [Hash{Symbol => String}] optional overrides for channel attributes
-    def initialize(response, overrides: {})
-      @response = response
-      @overrides = overrides
+    # @param title [String]
+    # @param url [Html2rss::Url, String]
+    # @param description [String]
+    # @param language [String, nil]
+    # @param ttl [Integer]
+    # @param last_build_date [Time, String]
+    # @param image [Html2rss::Url, String, nil]
+    # @param author [String, nil]
+    # rubocop:disable Metrics/ParameterLists -- Data.define members are the channel contract
+    def initialize(title:, url:, description:, language:, ttl:, last_build_date:, image:, author:)
+      super(
+        title: freeze_string(title),
+        url: url.is_a?(Url) ? url : Url.from_absolute(url),
+        description: freeze_string(description),
+        language: language && freeze_string(language),
+        ttl: Integer(ttl),
+        last_build_date: normalize_last_build_date(last_build_date),
+        image: normalize_image(image),
+        author: author && freeze_string(author)
+      )
     end
-
-    # @return [String] channel title derived from overrides, document title, or URL
-    def title
-      @title ||= fetch_title
-    end
-
-    # @return [Html2rss::Url] canonical channel URL
-    def url = @url ||= Html2rss::Url.from_absolute(@response.url)
-
-    # @return [String] channel description text
-    def description
-      return overrides[:description] unless overrides[:description].to_s.empty?
-
-      description = parsed_body.at_css('meta[name="description"]')&.[]('content') if html_response?
-
-      return format(DEFAULT_DESCRIPTION_TEMPLATE, url:) if description.to_s.empty?
-
-      description
-    end
-
-    # @return [Integer] cache time-to-live in minutes
-    def ttl
-      calculated = if overrides[:ttl]
-                     overrides[:ttl].to_i
-                   elsif (max_age = headers['cache-control']&.match(/max-age=(\d+)/)&.[](1))
-                     max_age.to_i.fdiv(60).ceil
-                   else
-                     DEFAULT_TTL_IN_MINUTES
-                   end
-
-      min_ttl = Html2rss.defaults.min_ttl
-      min_ttl ? [calculated, min_ttl].max : calculated
-    end
-
-    # @return [String, nil] ISO-like language code when available
-    def language
-      return overrides[:language] if overrides[:language]
-
-      if (language_code = headers['content-language']&.match(/^([a-z]{2})/))
-        return language_code[0]
-      end
-
-      return unless html_response?
-
-      parsed_body['lang'] || parsed_body.at_css('[lang]')&.[]('lang')
-    end
-
-    # @return [String, nil] channel author metadata
-    def author
-      return overrides[:author] if overrides[:author]
-
-      return unless html_response?
-
-      parsed_body.at_css('meta[name="author"]')&.[]('content')
-    end
-
-    # @return [String, Time] source last-modified timestamp or current time fallback
-    def last_build_date = headers['last-modified'] || Time.now
-
-    # @return [Html2rss::Url, nil] channel image URL
-    def image
-      return overrides[:image] if overrides[:image]
-
-      return unless html_response?
-
-      if (image_url = parsed_body.at_css('meta[property="og:image"]')&.[]('content'))
-        Url.sanitize(image_url)
-      end
-    end
+    # rubocop:enable Metrics/ParameterLists
 
     private
 
-    attr_reader :overrides
+    def marshal_dump = [title, url, description, language, ttl, last_build_date, image, author]
 
-    def parsed_body = @parsed_body ||= @response.parsed_body
-    def headers = @headers ||= @response.headers
-    def html_response? = @html_response ||= @response.html_response?
-
-    def fetch_title
-      override_title = overrides[:title]
-      return override_title if override_title
-      return parsed_title if parsed_title
-
-      url.channel_titleized
+    def marshal_load((title, url, description, language, ttl, last_build_date, image, author))
+      initialize(title:, url:, description:, language:, ttl:, last_build_date:, image:, author:)
     end
 
-    def parsed_title
-      return unless html_response?
+    def freeze_string(value) = value.to_s.dup.freeze
 
-      title = parsed_body.at_css('head > title')&.text.to_s
-      return if title.empty?
+    def normalize_image(value)
+      return value if value.is_a?(Url)
+      return if value.nil?
 
-      title.gsub(/\s+/, ' ').strip
+      Url.sanitize(value.to_s)
+    end
+
+    def normalize_last_build_date(value)
+      return value if value.is_a?(Time)
+      raise ArgumentError, 'last_build_date must be a Time or HTTP-date String' unless value.is_a?(String)
+
+      Time.httpdate(value)
     end
   end
+  # rubocop:enable Metrics/ModuleLength
 end

--- a/lib/html2rss/feed_pipeline.rb
+++ b/lib/html2rss/feed_pipeline.rb
@@ -19,7 +19,7 @@ module Html2rss
     # @return [Html2rss::FeedResult]
     def to_result
       run do |response:, config:, articles:|
-        channel = Html2rss::Channel.new(response, overrides: config.channel)
+        channel = Html2rss::Channel.from_response(response, overrides: config.channel)
         status = Status.build(articles:)
         FeedResult.new(channel:, articles:, status:, stylesheets: config.stylesheets)
       end

--- a/spec/lib/html2rss/channel_spec.rb
+++ b/spec/lib/html2rss/channel_spec.rb
@@ -5,7 +5,7 @@
 require 'timecop'
 
 RSpec.describe Html2rss::Channel do
-  subject(:instance) { described_class.new(response, overrides:) }
+  subject(:instance) { described_class.from_response(response, overrides:) }
 
   let(:overrides) { {} }
   let(:response) { build_response.call(body:, headers:, url:) }
@@ -179,7 +179,8 @@ RSpec.describe Html2rss::Channel do
       end
     end
 
-    it_behaves_like 'returns overridden value', :image, :image, 'https://example.com/override.jpg'
+    it_behaves_like 'returns overridden value', :image, :image,
+                    Html2rss::Url.from_absolute('https://example.com/override.jpg')
 
     context 'with og:image meta tag' do
       let(:body) { build_html_with_property.call(property: 'og:image', content: 'https://example.com/image.jpg') }
@@ -201,8 +202,8 @@ RSpec.describe Html2rss::Channel do
 
   describe '#last_build_date' do
     context 'with a last-modified header' do
-      it 'extracts the last-modified header' do
-        expect(instance.last_build_date).to eq('Tue, 01 Jan 2019 00:00:00 GMT')
+      it 'parses the header into a Time' do
+        expect(instance.last_build_date).to eq(Time.httpdate('Tue, 01 Jan 2019 00:00:00 GMT'))
       end
     end
 
@@ -252,6 +253,35 @@ RSpec.describe Html2rss::Channel do
         expect(instance.author).to be_nil
       end
     end
+  end
+
+  describe 'immutability' do
+    # rubocop:disable RSpec/ExampleLength -- freeze + Url normalize + caller isolation
+    it 'freezes retained strings and resists caller mutation of override image input', :aggregate_failures do
+      image = +'https://example.com/override.jpg'
+      channel = described_class.from_response(response, overrides: { title: +'Mutable', image: })
+
+      expect(channel.title).to be_frozen
+      expect(channel.image).to be_a(Html2rss::Url)
+      expect(channel.last_build_date).to be_a(Time)
+      expect { channel.title << 'X' }.to raise_error(FrozenError)
+
+      image.replace('https://evil.example/x.jpg')
+      expect(channel.image.to_s).to eq('https://example.com/override.jpg')
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    # rubocop:disable RSpec/ExampleLength -- Marshal round-trip freeze contract
+    it 're-freezes nested state after Marshal.round-trip', :aggregate_failures do
+      channel = described_class.from_response(response, overrides: { title: 'Cached' })
+      restored = Marshal.load(Marshal.dump(channel))
+
+      expect(restored).to be_frozen
+      expect(restored.title).to be_frozen
+      expect(restored.last_build_date).to be_a(Time)
+      expect { restored.title << 'X' }.to raise_error(FrozenError)
+    end
+    # rubocop:enable RSpec/ExampleLength
   end
 end
 # rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/lib/html2rss/defaults_spec.rb
+++ b/spec/lib/html2rss/defaults_spec.rb
@@ -361,21 +361,21 @@ RSpec.describe Html2rss::Defaults do
       it 'enforces min_ttl as a strict lower bound' do
         Html2rss.configure { |config| config.min_ttl = 60 }
 
-        channel = Html2rss::Channel.new(response)
+        channel = Html2rss::Channel.from_response(response)
         expect(channel.ttl).to eq(60) # 30 mins clamped to min_ttl (60)
       end
 
       it 'does not clamp if computed ttl is larger than min_ttl' do
         Html2rss.configure { |config| config.min_ttl = 15 }
 
-        channel = Html2rss::Channel.new(response)
+        channel = Html2rss::Channel.from_response(response)
         expect(channel.ttl).to eq(30) # 30 mins is > 15, so unchanged
       end
 
       it 'clamps config overrides for ttl as well' do
         Html2rss.configure { |config| config.min_ttl = 60 }
 
-        channel = Html2rss::Channel.new(response, overrides: { ttl: 20 })
+        channel = Html2rss::Channel.from_response(response, overrides: { ttl: 20 })
         expect(channel.ttl).to eq(60) # override 20 clamped to min_ttl (60)
       end
     end

--- a/spec/lib/html2rss/feed_result_spec.rb
+++ b/spec/lib/html2rss/feed_result_spec.rb
@@ -7,22 +7,16 @@ RSpec.describe Html2rss::FeedResult do
     described_class.new(channel:, articles:, status:, stylesheets: [{ href: 'rss.xsl', type: 'text/xsl' }])
   end
 
-  let(:channel_response) do
-    Html2rss::RequestService::Response.new(
-      body: '<html><head><title>Example</title></head></html>',
-      url: Html2rss::Url.from_absolute('https://example.com'),
-      headers: {
-        'content-type' => 'text/html',
-        'content-language' => 'en',
-        'cache-control' => 'max-age=3600',
-        'last-modified' => 'Mon, 01 Jan 2024 00:00:00 GMT'
-      }
-    )
-  end
   let(:channel) do
     Html2rss::Channel.new(
-      channel_response,
-      overrides: { title: 'Example', description: 'Example feed', language: 'en', ttl: 60 }
+      title: 'Example',
+      url: Html2rss::Url.from_absolute('https://example.com'),
+      description: 'Example feed',
+      language: 'en',
+      ttl: 60,
+      last_build_date: Time.utc(2024, 1, 1),
+      image: nil,
+      author: nil
     )
   end
   let(:articles) do
@@ -63,21 +57,12 @@ RSpec.describe Html2rss::FeedResult do
       expect(result.channel_title).to eq('Example')
     end
 
-    context 'when the scrape produced no items' do
-      let(:page_channel) do
-        Html2rss::Channel.new(
-          channel_response,
-          overrides: { title: 'Page Title From Head', description: 'Example feed' }
-        )
-      end
+    it 'preserves page title when the scrape produced no items', :aggregate_failures do
+      empty = described_class.new(channel: channel.with(title: 'Page Title From Head'), articles: [],
+                                  status: Html2rss::Status.build(articles: []))
 
-      it 'preserves page title', :aggregate_failures do
-        empty = described_class.new(channel: page_channel, articles: [],
-                                    status: Html2rss::Status.build(articles: []))
-
-        expect(empty).to be_empty
-        expect(empty.channel_title).to eq('Page Title From Head')
-      end
+      expect(empty).to be_empty
+      expect(empty.channel_title).to eq('Page Title From Head')
     end
   end
 
@@ -133,16 +118,17 @@ RSpec.describe Html2rss::FeedResult do
     end
     # rubocop:enable RSpec/ExampleLength
 
-    it 'exposes channel_title for callers without a channel reader', :aggregate_failures do
-      expect(result.channel_title).to eq('Example')
-      expect(result).not_to respond_to(:channel)
+    it 'keeps channel_title immutable for callers', :aggregate_failures do
+      expect(result.channel_title).to be_frozen
+      expect { result.channel_title << 'X' }.to raise_error(FrozenError)
+      expect(result.to_json_feed[:title]).to eq('Example')
     end
   end
 
   describe 'Marshal contract' do
-    # Full render-after-load lands with materialized Channel/Article (later stack PRs).
+    # Render-after-load for articles lands with ItemPresentation/Article slice.
     # rubocop:disable RSpec/ExampleLength -- round-trip identity + status telemetry fields
-    it 'round-trips FeedResult and Status through Marshal', :aggregate_failures do
+    it 'round-trips FeedResult, Channel title, and Status through Marshal', :aggregate_failures do
       restored = Marshal.load(Marshal.dump(result))
 
       expect(restored).to be_a(described_class)


### PR DESCRIPTION
## What changed

- Replace response-backed `Channel` with a materialized, Marshal-safe value object (`Channel.from_response`)
- Point `FeedPipeline#to_result` at `Channel.from_response`
- Update channel / defaults / FeedResult specs for the value-object API

## Why

Slice 3/8 from feed-result tip `77c9f03` for stacked review.

## Risk

- Breaking: `Channel.new(response, overrides:)` is gone — use `Channel.from_response`
- FeedResult Marshal render-after-load for articles still deferred to the ItemPresentation/Article slice

## Stack

- Position: **3/8**
- Base: `split/fr-02-status` (#423)
- Depends on: #423

## Validation

- Focused channel/feed_result/defaults/rss/json_feed/pipeline/html2rss specs — exit 0
- `make quick` — exit 0

## Test plan

- [ ] Review `Channel.from_response` extraction parity with old lazy Channel
- [ ] Confirm builders consume frozen channel fields