### PR TITLE
refactor: ItemPresentation for feed wire bodies

### DIFF
--- a/lib/html2rss/article.rb
+++ b/lib/html2rss/article.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 require 'zlib'
-require 'sanitize'
-require 'nokogiri'
 
 module Html2rss
   ##
   # Article is a simple data object representing an article extracted from a page.
   # It is enumerable and responds to all keys specified in PROVIDED_KEYS.
-  # rubocop:disable Metrics/ClassLength
+  #
+  # Description and enclosure wire presentation live in {FeedBuilder::ItemPresentation}.
+  # rubocop:disable Metrics/ClassLength -- value object retains Marshal + defensive freeze helpers
   class Article
     include Enumerable
     include Comparable
@@ -26,7 +26,7 @@ module Html2rss
     # @param options [Hash{Symbol => String}]
     # @option options [String] :id stable article identifier
     # @option options [String] :title article title
-    # @option options [String] :description article description/content
+    # @option options [String] :description raw extracted description/content (not feed-rendered HTML)
     # @option options [String, Html2rss::Url] :url canonical article URL
     # @option options [String, Html2rss::Url] :image image URL for description / JSON Feed +image+
     # @option options [String] :author author name
@@ -36,9 +36,9 @@ module Html2rss
     # @option options [Array<String>] :categories category labels
     # @option options [Class] :scraper scraper class that produced the article
     def initialize(**options)
-      @to_h = options.each_with_object({}) { |(k, v), h| h[k] = v.freeze if v }.freeze
+      @to_h = options.each_with_object({}) { |(key, value), hash| hash[key] = freeze_option(value) }.freeze
 
-      @description = @url = @image = @guid = @enclosures = @enclosure = @categories = @published_at = NOT_SET
+      @url = @image = @guid = @enclosures = @categories = @published_at = NOT_SET
 
       return unless (unknown_keys = options.keys - PROVIDED_KEYS).any?
 
@@ -65,18 +65,10 @@ module Html2rss
     # @return [String, nil] article title
     def title = blank_string_to_nil(@to_h[:title])
 
-    # @return [String] rendered article description
-    def description
-      return @description unless @description == NOT_SET
-
-      @description = Html::Rendering::DescriptionBuilder.new(
-        base: @to_h[:description],
-        title:,
-        url:,
-        enclosures:,
-        image:
-      ).call
-    end
+    # Raw extracted description — feed HTML enrichment is {FeedBuilder::ItemPresentation.description_for}.
+    #
+    # @return [String, nil]
+    def description = blank_string_to_nil(@to_h[:description])
 
     # @return [Url, nil]
     def url
@@ -117,16 +109,7 @@ module Html2rss
 
       @enclosures = Array(@to_h[:enclosures])
                     .map { |enclosure| Enclosure.new(**enclosure) }
-    end
-
-    # First non-image enclosure for RSS +<enclosure>+.
-    # Never falls back to {#image} — JSON Feed still emits +image+ separately.
-    #
-    # @return [Html2rss::Article::Enclosure, nil]
-    def enclosure
-      return @enclosure unless @enclosure == NOT_SET
-
-      @enclosure = enclosures.find { |enc| !image_mime_type?(enc.type) }
+                    .freeze
     end
 
     # @return [Array<String>] normalized, unique category names
@@ -137,7 +120,7 @@ module Html2rss
         categories.map! { |category| category.to_s.strip }
         categories.reject!(&:empty?)
         categories.uniq!
-      end
+      end.freeze
     end
 
     # Parses and returns the published_at time.
@@ -166,8 +149,33 @@ module Html2rss
 
     private
 
-    def image_mime_type?(type)
-      type.to_s.downcase.start_with?('image/')
+    ##
+    # Marshal only the constructor payload so lazy +NOT_SET+ sentinels do not break
+    # {FeedResult} cache round-trips.
+    #
+    # @return [Hash{Symbol => Object}]
+    def marshal_dump = @to_h
+
+    ##
+    # @param payload [Hash{Symbol => Object}] constructor options from {#marshal_dump}
+    # @return [void]
+    def marshal_load(payload)
+      initialize(**payload)
+    end
+
+    def freeze_option(value)
+      case value
+      when String then value.dup.freeze
+      when Array then freeze_array_option(value)
+      when Hash then value.transform_values { freeze_option(_1) }.freeze
+      else value
+      end
+    end
+
+    def freeze_array_option(value)
+      value.map do |entry|
+        entry.is_a?(Hash) ? entry.transform_values { freeze_option(_1) }.freeze : freeze_option(entry)
+      end.freeze
     end
 
     def dedup_from_url

--- a/lib/html2rss/feed_builder/item_presentation.rb
+++ b/lib/html2rss/feed_builder/item_presentation.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Html2rss
+  module FeedBuilder
+    ##
+    # Presentation rules for rendering an {Html2rss::Article} into feed wire formats.
+    #
+    # Owns description enrichment ({Html::Rendering::DescriptionBuilder}) and RSS
+    # non-image enclosure selection. {Article} keeps raw extracted fields only.
+    module ItemPresentation
+      class << self
+        ##
+        # @param article [Html2rss::Article]
+        # @return [String, nil] sanitized description HTML/text for feed item bodies
+        def description_for(article)
+          Html::Rendering::DescriptionBuilder.new(
+            base: article.description,
+            title: article.title,
+            url: article.url,
+            enclosures: article.enclosures,
+            image: article.image
+          ).call
+        end
+
+        ##
+        # First non-image enclosure for RSS +enclosure+ (images stay on description / JSON Feed).
+        #
+        # @param article [Html2rss::Article]
+        # @return [Html2rss::Article::Enclosure, nil]
+        def rss_enclosure_for(article)
+          article.enclosures.find { |enc| !image_mime_type?(enc.type) }
+        end
+
+        private
+
+        def image_mime_type?(type)
+          type.to_s.downcase.start_with?('image/')
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/feed_builder/json_feed.rb
+++ b/lib/html2rss/feed_builder/json_feed.rb
@@ -13,13 +13,15 @@ module Html2rss
       ##
       # @param channel [Html2rss::Channel]
       # @param articles [Array<Html2rss::Article>]
-      # @param user_comment [String, nil] optional generator comment (from {Status})
-      # @param feed_url [String, nil] optional absolute self URL for the feed
-      def initialize(channel:, articles:, user_comment: nil, feed_url: nil)
+      # @param user_comment [String] required generator comment (from {Status})
+      # @param feed_url [String, nil] optional absolute self URL for the feed (JSON Feed feed_url)
+      def initialize(channel:, articles:, user_comment:, feed_url: nil)
+        raise ArgumentError, 'user_comment must be a non-blank String' if blank_string?(user_comment)
+
         @channel = channel
         @articles = articles
+        @feed_url = normalize_feed_url(feed_url)
         @user_comment = user_comment
-        @feed_url = feed_url
       end
 
       ##
@@ -32,7 +34,19 @@ module Html2rss
 
       private
 
-      attr_reader :channel, :articles, :user_comment, :feed_url
+      attr_reader :channel, :articles, :feed_url, :user_comment
+
+      def blank_string?(value)
+        !value.is_a?(String) || value.strip.empty?
+      end
+
+      def normalize_feed_url(value)
+        return if value.nil?
+        raise ArgumentError, 'feed_url must be a String or nil' unless value.is_a?(String)
+        return if value.strip.empty?
+
+        Url.from_absolute(value).to_s
+      end
 
       ##
       # @return [Hash]
@@ -41,11 +55,11 @@ module Html2rss
           version: VERSION_URL,
           title: channel.title,
           home_page_url: channel.url.to_s,
-          description: channel.description,
-          language: channel.language,
-          icon: channel.image&.to_s,
           feed_url:,
-          user_comment:
+          description: channel.description,
+          user_comment:,
+          language: channel.language,
+          icon: channel.image&.to_s
         }
       end
 

--- a/lib/html2rss/feed_builder/json_feed/item.rb
+++ b/lib/html2rss/feed_builder/json_feed/item.rb
@@ -50,15 +50,31 @@ module Html2rss
 
         ##
         # JSON Feed items must include content_html or content_text.
+        # Title is a fallback only when description is absent.
+        #
         # @return [Hash]
         def content_fields
-          description = article.description
-          return { content_html: description } if description
+          if (description = ItemPresentation.description_for(article))
+            return content_for(description)
+          end
 
-          title = article.title
-          return { content_text: title } if title
+          return { content_text: article.title } if article.title
 
           {}
+        end
+
+        ##
+        # @param description [String]
+        # @return [Hash]
+        def content_for(description)
+          html?(description) ? { content_html: description } : { content_text: description }
+        end
+
+        ##
+        # @param value [String]
+        # @return [Boolean]
+        def html?(value)
+          Nokogiri::HTML.fragment(value).children.any?(&:element?)
         end
 
         ##

--- a/lib/html2rss/feed_builder/rss.rb
+++ b/lib/html2rss/feed_builder/rss.rb
@@ -14,7 +14,7 @@ module Html2rss
         def add_item(article, item_maker)
           add_item_string_values(article, item_maker)
           add_item_categories(article, item_maker)
-          add_enclosure(article.enclosure, item_maker)
+          add_enclosure(ItemPresentation.rss_enclosure_for(article), item_maker)
           add_item_guid(article, item_maker)
         end
 
@@ -34,11 +34,14 @@ module Html2rss
         private
 
         def add_item_string_values(article, item_maker)
-          %i[title description author].each do |attr|
-            next unless (value = article.send(attr))
-            next if value.empty?
+          {
+            title: article.title,
+            description: ItemPresentation.description_for(article),
+            author: article.author
+          }.each do |attr, value|
+            next if value.nil? || value.empty?
 
-            item_maker.send(:"#{attr}=", value)
+            item_maker.public_send(:"#{attr}=", value)
           end
 
           item_maker.link = article.url.to_s if article.url
@@ -61,8 +64,10 @@ module Html2rss
       # @param channel [Html2rss::Channel] The channel information for the RSS feed.
       # @param articles [Array<Html2rss::Article>] The list of articles to include in the RSS feed.
       # @param stylesheets [Array<Hash>] An optional array of stylesheet configurations.
-      # @param generator [String, nil] optional preformatted generator (from {Status}); falls back to article tallies
-      def initialize(channel:, articles:, stylesheets: [], generator: nil)
+      # @param generator [String] required preformatted generator comment (from {Status})
+      def initialize(channel:, articles:, generator:, stylesheets: [])
+        raise ArgumentError, 'generator must be a non-blank String' if blank_string?(generator)
+
         @channel = channel
         @articles = articles
         @stylesheets = stylesheets
@@ -81,7 +86,11 @@ module Html2rss
 
       private
 
-      attr_reader :channel, :articles
+      attr_reader :channel, :articles, :generator
+
+      def blank_string?(value)
+        !value.is_a?(String) || value.strip.empty?
+      end
 
       def stylesheets
         @stylesheets.map { |style| Stylesheet.new(**style) }
@@ -101,19 +110,6 @@ module Html2rss
         articles.each do |article|
           maker.items.new_item { |item_maker| self.class.add_item(article, item_maker) }
         end
-      end
-
-      def generator
-        return @generator if @generator
-
-        scraper_namespace_regex = /(?<namespace>Html2rss|Scraper)::/
-
-        scraper_counts = articles.flat_map(&:scraper).tally.map do |klass, count|
-          scraper_name = klass.to_s.gsub(scraper_namespace_regex, '')
-          "#{scraper_name} (#{count})"
-        end
-
-        "html2rss V. #{Html2rss::VERSION} (scrapers: #{scraper_counts.join(', ')})"
       end
     end
   end

--- a/spec/lib/html2rss/article_spec.rb
+++ b/spec/lib/html2rss/article_spec.rb
@@ -22,6 +22,41 @@ RSpec.describe Html2rss::Article do
     end
   end
 
+  describe 'Marshal round-trip' do
+    let(:options) do
+      { id: '1', title: 'Sample', url: 'http://example.com', description: 'Body', scraper: Html2rss::Selectors,
+        categories: ['News'], enclosures: [{ url: Html2rss::Url.from_absolute('https://example.com/a.mp3'),
+                                             type: 'audio/mpeg', bytes_length: 1 }] }
+    end
+
+    # rubocop:disable RSpec/ExampleLength -- asserts restored scalars + frozen collections
+    it 'restores attributes without NOT_SET sentinel leakage', :aggregate_failures do
+      restored = Marshal.load(Marshal.dump(instance))
+
+      expect(restored.title).to eq('Sample')
+      expect(restored.description).to include('Body')
+      expect(restored.categories).to eq(['News'])
+      expect(restored.categories).to be_frozen
+      expect(restored.enclosures).to be_frozen
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    it 'keeps marshal hooks off the public API' do
+      expect(instance.public_methods(false)).not_to include(:marshal_dump, :marshal_load)
+    end
+  end
+
+  describe 'defensive copies' do
+    it 'does not freeze caller-owned option collections', :aggregate_failures do
+      categories = ['News']
+      article = described_class.new(id: '1', title: 'T', url: 'https://example.com/a', categories:)
+      categories << 'Extra'
+
+      expect(article.categories).to eq(['News'])
+      expect { article.categories << 'More' }.to raise_error(FrozenError)
+    end
+  end
+
   describe '#each' do
     let(:yields) do
       described_class::PROVIDED_KEYS.map do |key|
@@ -43,14 +78,15 @@ RSpec.describe Html2rss::Article do
   end
 
   describe '#description' do
-    before do
-      allow(Html2rss::Html::Rendering::DescriptionBuilder).to receive(:new).and_call_original
-      instance.description
+    it 'returns the raw extracted description without DescriptionBuilder', :aggregate_failures do
+      allow(Html2rss::Html::Rendering::DescriptionBuilder).to receive(:new)
+
+      expect(instance.description).to eq('By John Doe')
+      expect(Html2rss::Html::Rendering::DescriptionBuilder).not_to have_received(:new)
     end
 
-    it 'calls the DescriptionBuilder' do
-      expect(Html2rss::Html::Rendering::DescriptionBuilder).to have_received(:new)
-        .with(base: 'By John Doe', title: 'Sample instance', url: instance.url, enclosures: [], image: nil)
+    it 'returns nil for a blank description' do
+      expect(described_class.new(description: '  ').description).to be_nil
     end
   end
 
@@ -168,49 +204,6 @@ RSpec.describe Html2rss::Article do
 
       expect(article.deduplication_fingerprint).to eq(expected)
     end
-  end
-
-  describe '#enclosure' do
-    let(:audio_url) { Html2rss::Url.from_absolute('https://example.com/episode.mp3') }
-    let(:image_url) { Html2rss::Url.from_absolute('https://example.com/cover.jpg') }
-
-    it 'does not fall back to image when enclosures are absent' do
-      article = described_class.new(image: image_url)
-
-      expect(article.enclosure).to be_nil
-    end
-
-    it 'keeps image available for JSON Feed / description when enclosures are absent', :aggregate_failures do
-      article = described_class.new(image: image_url)
-
-      expect(article.image).to eq(image_url)
-      expect(article.enclosure).to be_nil
-    end
-
-    it 'skips image/* enclosures so RSS never uses an image as <enclosure>' do
-      article = described_class.new(
-        enclosures: [{ url: image_url, type: 'image/jpeg' }],
-        image: image_url
-      )
-
-      expect(article.enclosure).to be_nil
-    end
-
-    # rubocop:disable RSpec/ExampleLength -- prefers non-image enclosure while preserving image field
-    it 'prefers the first non-image enclosure over image enclosures', :aggregate_failures do
-      article = described_class.new(
-        enclosures: [
-          { url: image_url, type: 'image/jpeg' },
-          { url: audio_url, type: 'audio/mpeg' }
-        ],
-        image: image_url
-      )
-
-      expect(article.enclosure.url).to eq(audio_url)
-      expect(article.enclosure.type).to eq('audio/mpeg')
-      expect(article.image).to eq(image_url)
-    end
-    # rubocop:enable RSpec/ExampleLength
   end
 
   describe '#categories' do

--- a/spec/lib/html2rss/feed_builder/item_presentation_spec.rb
+++ b/spec/lib/html2rss/feed_builder/item_presentation_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Html2rss::FeedBuilder::ItemPresentation do
+  describe '.description_for' do
+    it 'renders via DescriptionBuilder from raw article fields' do
+      article = Html2rss::Article.new(title: 'Sample instance', url: 'http://example.com', description: 'By John Doe')
+
+      expect(described_class.description_for(article)).to include('By John Doe')
+    end
+  end
+
+  describe '.rss_enclosure_for' do
+    let(:audio_url) { Html2rss::Url.from_absolute('https://example.com/episode.mp3') }
+    let(:image_url) { Html2rss::Url.from_absolute('https://example.com/cover.jpg') }
+
+    it 'does not fall back to image when enclosures are absent' do
+      article = Html2rss::Article.new(image: image_url)
+
+      expect(described_class.rss_enclosure_for(article)).to be_nil
+    end
+
+    it 'skips image/* enclosures so RSS never uses an image as enclosure' do
+      article = Html2rss::Article.new(
+        enclosures: [{ url: image_url, type: 'image/jpeg' }],
+        image: image_url
+      )
+
+      expect(described_class.rss_enclosure_for(article)).to be_nil
+    end
+
+    # rubocop:disable RSpec/ExampleLength -- prefers non-image enclosure while preserving image field
+    it 'prefers the first non-image enclosure over image enclosures', :aggregate_failures do
+      article = Html2rss::Article.new(
+        enclosures: [
+          { url: image_url, type: 'image/jpeg' },
+          { url: audio_url, type: 'audio/mpeg' }
+        ],
+        image: image_url
+      )
+      enclosure = described_class.rss_enclosure_for(article)
+
+      expect(enclosure.url).to eq(audio_url)
+      expect(enclosure.type).to eq('audio/mpeg')
+      expect(article.image).to eq(image_url)
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
+end

--- a/spec/lib/html2rss/feed_builder/json_feed/item_spec.rb
+++ b/spec/lib/html2rss/feed_builder/json_feed/item_spec.rb
@@ -18,14 +18,30 @@ RSpec.describe Html2rss::FeedBuilder::JsonFeed::Item do
   it 'serializes an item with html content', :aggregate_failures do
     expect(item_hash[:title]).to eq('Sample title')
     expect(item_hash[:content_html]).to eq('<p>Sample description</p>')
+    expect(item_hash).not_to have_key(:content_text)
     expect(item_hash[:authors]).to eq([{ name: 'Author Name' }])
+  end
+
+  it 'maps a plain-text description to content_text', :aggregate_failures do
+    article = build_article.call(**attributes, description: 'Plain description without markup')
+    hash = described_class.new(article).to_h
+
+    expect(hash[:content_text]).to eq('Plain description without markup')
+    expect(hash).not_to have_key(:content_html)
   end
 
   it 'falls back to content_text when only a title is available', :aggregate_failures do
     article = build_article.call(id: 'article-1', title: 'Sample title', url: 'https://example.com/articles/1')
+    hash = described_class.new(article).to_h
 
-    expect(described_class.new(article).to_h[:content_text]).to eq('Sample title')
-    expect(described_class.new(article).to_h).not_to have_key(:content_html)
+    expect(hash[:content_text]).to eq('Sample title')
+    expect(hash).not_to have_key(:content_html)
+  end
+
+  it 'does not fall back to title when a description is present' do
+    article = build_article.call(**attributes, description: 'Only body')
+
+    expect(described_class.new(article).to_h[:content_text]).to eq('Only body')
   end
 
   it 'returns nil when the article has no usable content' do

--- a/spec/lib/html2rss/feed_builder/json_feed_spec.rb
+++ b/spec/lib/html2rss/feed_builder/json_feed_spec.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe Html2rss::FeedBuilder::JsonFeed do
-  subject(:feed_hash) { described_class.new(channel:, articles:).call }
+  subject(:feed_hash) do
+    described_class.new(channel:, articles:, feed_url:, user_comment:).call
+  end
 
+  let(:feed_url) { nil }
+  let(:user_comment) { 'html2rss V. test (scrapers: none)' }
   let(:channel) do
     instance_double(
       Html2rss::Channel,
@@ -21,10 +25,53 @@ RSpec.describe Html2rss::FeedBuilder::JsonFeed do
     ]
   end
 
+  it 'requires a non-blank user_comment' do
+    expect do
+      described_class.new(channel:, articles:, user_comment: nil)
+    end.to raise_error(ArgumentError, /user_comment/)
+  end
+
   it 'filters out items that cannot satisfy the JSON Feed content requirement', :aggregate_failures do
     expect(feed_hash[:items].size).to eq(1)
     expect(feed_hash[:items].first[:id]).to eq(Html2rss::Article.new(id: 'with-content', title: 'Visible',
                                                                      url: 'https://example.com/1').guid)
     expect(feed_hash[:items].first[:content_text]).to eq('Visible')
+  end
+
+  context 'with feed_url and user_comment' do
+    let(:feed_url) { 'https://example.com/feed.json' }
+    let(:user_comment) { 'html2rss V. 1.0 (scrapers: Selectors (1))' }
+
+    it 'includes feed identity and generator comment', :aggregate_failures do
+      expect(feed_hash[:feed_url]).to eq(feed_url)
+      expect(feed_hash[:user_comment]).to eq(user_comment)
+    end
+  end
+
+  describe 'feed_url boundary validation' do
+    it 'omits feed_url when nil or blank', :aggregate_failures do
+      expect(described_class.new(channel:, articles:, user_comment:, feed_url: nil).call).not_to have_key(:feed_url)
+      expect(described_class.new(channel:, articles:, user_comment:, feed_url: '  ').call).not_to have_key(:feed_url)
+    end
+
+    it 'normalizes a valid absolute feed_url' do
+      payload = described_class.new(
+        channel:, articles:, user_comment:, feed_url: 'https://example.com/feed.json'
+      ).call
+
+      expect(payload[:feed_url]).to eq('https://example.com/feed.json')
+    end
+
+    it 'rejects a relative feed_url' do
+      expect do
+        described_class.new(channel:, articles:, user_comment:, feed_url: '/relative.json')
+      end.to raise_error(ArgumentError, /absolute/)
+    end
+
+    it 'rejects a non-string feed_url' do
+      expect do
+        described_class.new(channel:, articles:, user_comment:, feed_url: :symbol)
+      end.to raise_error(ArgumentError, /feed_url must be a String or nil/)
+    end
   end
 end

--- a/spec/lib/html2rss/feed_builder/rss_spec.rb
+++ b/spec/lib/html2rss/feed_builder/rss_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Html2rss::FeedBuilder::Rss do
                         articles:,
                         stylesheets: [
                           { href: 'rss.xsl', type: 'text/xsl' }
-                        ])
+                        ],
+                        generator: "html2rss V. #{Html2rss::VERSION} (scrapers: RSpec (1), AutoSource::Html (1))")
   end
 
   let(:channel) do
@@ -39,6 +40,12 @@ RSpec.describe Html2rss::FeedBuilder::Rss do
   end
 
   it { expect(described_class).to be_a Class }
+
+  it 'requires a non-blank generator' do
+    expect do
+      described_class.new(channel:, articles:, generator: ' ')
+    end.to raise_error(ArgumentError, /generator/)
+  end
 
   describe '#call' do
     subject(:rss) { instance.call }
@@ -88,14 +95,17 @@ RSpec.describe Html2rss::FeedBuilder::Rss do
       let(:item) { Nokogiri::XML(rss.to_s).css('item').first }
       let(:article) { articles.first }
 
+      # rubocop:disable RSpec/ExampleLength -- title/guid/description/link/pubDate contract
       it 'has tags with correct values', :aggregate_failures do
-        %i[title description guid].each do |tag|
-          expect(item.css(tag).text).to eq(article.public_send(tag).to_s), tag
-        end
-
+        expect(item.css('title').text).to eq(article.title.to_s)
+        expect(item.css('guid').text).to eq(article.guid.to_s)
+        expect(item.css('description').text).to eq(
+          Html2rss::FeedBuilder::ItemPresentation.description_for(article).to_s
+        )
         expect(item.css('link').text).to eq(article.url.to_s), 'link'
         expect(item.css('pubDate').text).to eq(article.published_at.rfc822), 'pubDate'
       end
+      # rubocop:enable RSpec/ExampleLength
 
       it 'omits <enclosure> when the article only has an image' do
         expect(item.css('enclosure')).to be_empty

--- a/spec/lib/html2rss/feed_result_spec.rb
+++ b/spec/lib/html2rss/feed_result_spec.rb
@@ -85,8 +85,8 @@ RSpec.describe Html2rss::FeedResult do
         user_comment: status.to_generator_comment
       )
       expect(payload[:items].size).to eq(1)
-      expect(payload[:items].first[:content_html]).to eq('Body')
-      expect(payload[:items].first).not_to have_key(:content_text)
+      expect(payload[:items].first[:content_text]).to eq('Body')
+      expect(payload[:items].first).not_to have_key(:content_html)
     end
     # rubocop:enable RSpec/ExampleLength
   end
@@ -126,18 +126,18 @@ RSpec.describe Html2rss::FeedResult do
   end
 
   describe 'Marshal contract' do
-    # Render-after-load for articles lands with ItemPresentation/Article slice.
-    # rubocop:disable RSpec/ExampleLength -- round-trip identity + status telemetry fields
-    it 'round-trips FeedResult, Channel title, and Status through Marshal', :aggregate_failures do
+    # rubocop:disable RSpec/ExampleLength -- round-trip identity + both render formats
+    it 'round-trips through Marshal and still renders both formats', :aggregate_failures do
       restored = Marshal.load(Marshal.dump(result))
 
       expect(restored).to be_a(described_class)
       expect(restored).to be_frozen
       expect(restored).not_to be_empty
-      expect(restored.channel_title).to eq('Example')
       expect(restored.status.to_generator_comment).to eq(status.to_generator_comment)
       expect(restored.status.selected_strategy).to eq(status.selected_strategy)
       expect(restored.status.attempt_count).to eq(status.attempt_count)
+      expect(restored.to_rss).to be_a(RSS::Rss)
+      expect(restored.to_json_feed[:title]).to eq('Example')
     end
     # rubocop:enable RSpec/ExampleLength
   end


### PR DESCRIPTION
## What changed

- Move description enrichment and RSS non-image enclosure selection into `FeedBuilder::ItemPresentation`
- Make `Article#description` raw extracted content; remove `Article#enclosure`
- Wire RSS/JSON Feed adapters through presentation helpers; restore full FeedResult Marshal render contract

## Why

Slice 4/8 from feed-result tip `77c9f03` for stacked review.

## Risk

- Breaking: callers that relied on `Article#description` HTML enrichment or `Article#enclosure` must use `ItemPresentation`

## Stack

- Position: **4/8**
- Base: `split/fr-03-channel` (#424)
- Depends on: #424

## Validation

- Focused presentation/article/rss/json_feed/feed_result specs — 128 examples, 0 failures
- `make quick` — exit 0

## Test plan

- [ ] Review ItemPresentation description + enclosure rules
- [ ] Confirm JSON Feed content_text vs content_html routing