### PR TITLE
refactor: FeedPipeline to_result and AutoFallback

### DIFF
--- a/lib/html2rss/feed_pipeline.rb
+++ b/lib/html2rss/feed_pipeline.rb
@@ -4,8 +4,10 @@ module Html2rss
   ##
   # Builds feeds from validated config through request, extraction, and rendering stages.
   class FeedPipeline
-    # Bundle of inputs shared by selector and auto-source article collection.
-    ExtractionContext = Data.define(:config, :response, :request_session)
+    # Scrape-finished facts after request + extraction + dedup (before Channel/Status materialize).
+    # selected_strategy: set on :auto success; nil otherwise.
+    # attempt_count: auto attempts attempted; 0 outside :auto.
+    PipelineOutcome = Data.define(:response, :articles, :dedup_dropped, :selected_strategy, :attempt_count)
 
     ##
     # @param raw_config [Hash{Symbol => Object}] user-provided feed config
@@ -18,32 +20,48 @@ module Html2rss
     #
     # @return [Html2rss::FeedResult]
     def to_result
-      run do |response:, config:, articles:|
-        channel = Html2rss::Channel.from_response(response, overrides: config.channel)
-        status = Status.build(articles:)
-        FeedResult.new(channel:, articles:, status:, stylesheets: config.stylesheets)
-      end
+      config = Config.from_hash(raw_config, params: raw_config[:params])
+      outcome = pipeline_outcome_for(config)
+      channel = Channel.from_response(outcome.response, overrides: config.channel)
+      status = Status.build(
+        articles: outcome.articles,
+        dedup_dropped: outcome.dedup_dropped,
+        selected_strategy: outcome.selected_strategy,
+        attempt_count: outcome.attempt_count
+      )
+      FeedResult.new(channel:, articles: outcome.articles, status:, stylesheets: config.stylesheets)
     end
 
-    ##
-    # @return [RSS::Rss] generated RSS feed
-    def to_rss = to_result.to_rss
+    # @api private Host seam for {AutoFallback} (and single-strategy path).
+    # @param config [Html2rss::Config]
+    # @param strategy [Symbol]
+    # @param resources [Html2rss::FeedPipeline::RuntimePolicy::Resources]
+    # @return [Html2rss::RequestSession]
+    def request_session_for(config, strategy:, resources:)
+      RequestSession.build(
+        config:,
+        strategy:,
+        budget: resources.budget,
+        policy: resources.policy
+      )
+    end
 
-    ##
-    # @return [Hash] generated JSONFeed 1.1 payload
-    def to_json_feed = to_result.to_json_feed
+    # @api private Host seam for {AutoFallback} (and single-strategy path).
+    # @param config [Html2rss::Config]
+    # @param response [Html2rss::RequestService::Response]
+    # @param request_session [Html2rss::RequestSession]
+    # @return [Array(Array<Html2rss::Article>, Integer)] unique articles and drop count
+    def deduplicated_articles(config:, response:, request_session:)
+      collected = collect_articles(config:, response:, request_session:)
+      unique = Article::Deduplicator.new(collected).call
+      [unique, collected.size - unique.size]
+    end
 
     private
 
     attr_reader :raw_config
 
-    def run
-      config = Config.from_hash(raw_config, params: raw_config[:params])
-      state = pipeline_state_for(config)
-      yield response: state.fetch(:response), config:, articles: state.fetch(:articles)
-    end
-
-    def pipeline_state_for(config)
+    def pipeline_outcome_for(config)
       plan = StrategyPlan.resolve(config.strategy)
       resources = RuntimePolicy.resources_for(config)
       if plan.is_a?(StrategyPlan::Auto)
@@ -56,52 +74,31 @@ module Html2rss
     def run_pipeline_for_strategy(config, strategy:, resources:)
       request_session = request_session_for(config, strategy:, resources:)
       response = request_session.fetch_initial_response
-      articles = deduplicated_articles(
-        ExtractionContext.new(config:, response:, request_session:)
-      )
-      { response:, articles: }
+      articles, dedup_dropped = deduplicated_articles(config:, response:, request_session:)
+      PipelineOutcome.new(response:, articles:, dedup_dropped:, selected_strategy: nil, attempt_count: 0)
     end
 
-    def request_session_for(config, strategy:, resources:)
-      RequestSession.build(
-        config:,
-        strategy:,
-        budget: resources.budget,
-        policy: resources.policy
-      )
-    end
-
-    def deduplicated_articles(extraction)
-      Article::Deduplicator.new(collect_articles(extraction)).call
-    end
-
-    # rubocop:disable Metrics/MethodLength
     def run_auto_pipeline(config, resources:)
       AutoFallback.new(
         strategies: AutoFallback::CHAIN,
         budget: resources.budget,
-        session_for: lambda do |strategy:, budget:|
-          budget.effective_timeout_seconds(fallback: resources.policy.total_timeout_seconds)
-          request_session_for(config, strategy:, resources:)
-        end,
-        articles_for: lambda do |response:, request_session:|
-          deduplicated_articles(ExtractionContext.new(config:, response:, request_session:))
-        end
+        pipeline: self,
+        config:,
+        resources:
       ).call
     end
-    # rubocop:enable Metrics/MethodLength
 
-    def collect_articles(extraction)
-      selector_articles(extraction) + auto_source_articles(extraction)
+    def collect_articles(config:, response:, request_session:)
+      selector_articles(config:, response:, request_session:) +
+        auto_source_articles(config:, response:, request_session:)
     end
 
     # rubocop:disable Metrics/MethodLength
-    def selector_articles(extraction)
-      config = extraction.config
+    def selector_articles(config:, response:, request_session:)
       return [] unless (selectors = config.selectors)
 
-      page_responses = extraction.request_session.page_responses(
-        extraction.response,
+      page_responses = request_session.page_responses(
+        response,
         pagination_config: selectors.dig(:items, :pagination)
       )
 
@@ -116,10 +113,10 @@ module Html2rss
     end
     # rubocop:enable Metrics/MethodLength
 
-    def auto_source_articles(extraction)
-      return [] unless (auto_source = extraction.config.auto_source)
+    def auto_source_articles(config:, response:, request_session:)
+      return [] unless (auto_source = config.auto_source)
 
-      AutoSource.new(extraction.response, auto_source, request_session: extraction.request_session).articles
+      AutoSource.new(response, auto_source, request_session:).articles
     end
   end
 end

--- a/lib/html2rss/feed_pipeline/auto_fallback.rb
+++ b/lib/html2rss/feed_pipeline/auto_fallback.rb
@@ -5,6 +5,7 @@ module Html2rss
     # Retries feed extraction across concrete request strategies for the :auto plan.
     #
     # Owned by {FeedPipeline}; invoked only after {StrategyPlan} resolves +:auto+.
+    # Hosted by the pipeline instance: session + extract call back into FeedPipeline.
     class AutoFallback
       # Ordered list of concrete request strategies attempted by the :auto plan.
       CHAIN = %i[faraday botasaurus browserless].freeze
@@ -51,27 +52,38 @@ module Html2rss
 
         # @param response [RequestService::Response] successful response
         # @param articles [Array] extracted articles
+        # @param dedup_dropped [Integer] articles removed by deduplication
+        # @param selected_strategy [Symbol] concrete strategy that produced items
+        # @param attempt_count [Integer] number of attempts recorded for this chain
         # @return [void]
-        def succeed!(response:, articles:)
-          @result = { response:, articles: }
+        def succeed!(response:, articles:, dedup_dropped:, selected_strategy:, attempt_count:)
+          @result = PipelineOutcome.new(
+            response:,
+            articles:,
+            dedup_dropped:,
+            selected_strategy:,
+            attempt_count:
+          )
         end
       end
 
       ##
       # @param strategies [Array<Symbol>] ordered concrete strategies for fallback
       # @param budget [RequestService::Budget] shared request budget across retries
-      # @param session_for [Proc] request session factory proc
-      # @param articles_for [Proc] article extraction proc
+      # @param pipeline [Html2rss::FeedPipeline] host for session + article extraction
+      # @param config [Html2rss::Config] validated feed config
+      # @param resources [Html2rss::FeedPipeline::RuntimePolicy::Resources] budget + policy
       # @return [void]
-      def initialize(strategies:, budget:, session_for:, articles_for:)
+      def initialize(strategies:, budget:, pipeline:, config:, resources:)
         @strategies = strategies
         @budget = budget
-        @session_for = session_for
-        @articles_for = articles_for
+        @pipeline = pipeline
+        @config = config
+        @resources = resources
       end
 
       ##
-      # @return [Hash{Symbol => Object}] pipeline state containing :response and :articles
+      # @return [Html2rss::FeedPipeline::PipelineOutcome] scrape-finished state for materialization
       def call
         state = run_attempts
         return state.result if state.succeeded?
@@ -81,7 +93,7 @@ module Html2rss
 
       private
 
-      attr_reader :strategies, :budget, :session_for, :articles_for
+      attr_reader :strategies, :budget, :pipeline, :config, :resources
 
       def run_attempts
         AttemptState.new.tap do |state|
@@ -93,7 +105,7 @@ module Html2rss
       end
 
       def attempt(strategy:, next_strategy:, state:)
-        request_session = session_for.call(strategy:, budget:)
+        request_session = pipeline.request_session_for(config, strategy:, resources:)
         response = fetch_response(request_session:, strategy:, next_strategy:, state:)
         return unless response
 
@@ -106,38 +118,65 @@ module Html2rss
         raise
       rescue StandardError => error
         state.record_error(strategy:, error:)
-        log_warn_fallback_error(strategy:, next_strategy:, error:) if next_strategy
-        Log.debug("#{self.class}: strategy=#{strategy} error=#{error.class}: #{error.message}")
+        log_fallback_error(strategy:, next_strategy:, error:, request_session:) if next_strategy
         nil
       end
 
       def process_response(response:, strategy:, next_strategy:, request_session:, state:)
-        articles = articles_for.call(response:, request_session:)
+        articles, dedup_dropped = articles_for(response:, request_session:)
         items_count = articles.size
         state.record_items(strategy:, items_count:)
-        Log.debug("#{self.class}: strategy=#{strategy} items=#{items_count}")
-        return record_success(response:, strategy:, articles:, state:) if items_count.positive?
+        Log.debug("#{self.class}: strategy=#{strategy} items=#{items_count} " \
+                  "host=#{response.url.host} elapsed=#{format('%.3f', budget.elapsed_seconds)}s " \
+                  "budget_remaining=#{budget_remaining_label}")
+        return record_success(response:, strategy:, articles:, dedup_dropped:, state:) if items_count.positive?
 
-        log_info_fallback_zero_items(strategy:, next_strategy:) if next_strategy
+        log_info_fallback_zero_items(strategy:, next_strategy:, response:) if next_strategy
       end
 
-      def record_success(response:, strategy:, articles:, state:)
-        state.succeed!(response:, articles:)
-        return unless state.attempts.size > 1
+      def articles_for(response:, request_session:)
+        pipeline.deduplicated_articles(config:, response:, request_session:)
+      end
 
-        Log.info("#{self.class}: auto selected strategy=#{strategy} after attempts=#{state.attempts.size}")
+      def record_success(response:, strategy:, articles:, dedup_dropped:, state:)
+        attempt_count = state.attempts.size
+        state.succeed!(response:, articles:, dedup_dropped:, selected_strategy: strategy, attempt_count:)
+        return unless attempt_count > 1
+
+        Log.info("#{self.class}: auto selected strategy=#{strategy} after attempts=#{attempt_count} " \
+                 "host=#{response.url.host} elapsed=#{format('%.3f', budget.elapsed_seconds)}s " \
+                 "budget_remaining=#{budget_remaining_label}")
       end
 
       def finalize_failure(attempts:)
         raise NoFeedItemsExtracted.new(attempts:)
       end
 
-      def log_warn_fallback_error(strategy:, next_strategy:, error:)
-        Log.warn("#{self.class}: auto fallback #{strategy} -> #{next_strategy} after error=#{error.class}")
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      def log_fallback_error(strategy:, next_strategy:, error:, request_session:)
+        host = request_session.url.host
+        detail = "host=#{host} elapsed=#{format('%.3f', budget.elapsed_seconds)}s " \
+                 "budget_remaining=#{budget_remaining_label}"
+        if error.is_a?(RequestService::RequestTimedOut)
+          Log.info("#{self.class}: auto fallback #{strategy} -> #{next_strategy} " \
+                   "after timeout=#{error.class} #{detail}")
+        else
+          Log.warn("#{self.class}: auto fallback #{strategy} -> #{next_strategy} " \
+                   "after error=#{error.class} #{detail}")
+        end
+        Log.debug("#{self.class}: strategy=#{strategy} error=#{error.class}: #{error.message} #{detail}")
+      end
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+      def log_info_fallback_zero_items(strategy:, next_strategy:, response:)
+        Log.info("#{self.class}: auto fallback #{strategy} -> #{next_strategy} after zero extracted items " \
+                 "host=#{response.url.host} elapsed=#{format('%.3f', budget.elapsed_seconds)}s " \
+                 "budget_remaining=#{budget_remaining_label}")
       end
 
-      def log_info_fallback_zero_items(strategy:, next_strategy:)
-        Log.info("#{self.class}: auto fallback #{strategy} -> #{next_strategy} after zero extracted items")
+      def budget_remaining_label
+        remaining = budget.remaining_timeout_seconds
+        remaining.nil? ? 'untracked' : format('%.3f', remaining)
       end
     end
   end

--- a/lib/html2rss/request_session.rb
+++ b/lib/html2rss/request_session.rb
@@ -109,6 +109,10 @@ module Html2rss
       visited_urls.add(normalize_url(url))
     end
 
+    ##
+    # @return [Html2rss::Url] the session's current request URL
+    def url = context.url
+
     private
 
     attr_reader :context, :strategy, :logger, :visited_urls

--- a/spec/lib/html2rss/feed_pipeline_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Html2rss::FeedPipeline do
     }
   end
 
-  describe '#to_rss' do
+  describe '#to_result' do
     context 'when strategy is non-auto' do # rubocop:disable RSpec/MultipleMemoizedHelpers
       let(:config) { base_config.merge(strategy: :faraday) }
       let(:pipeline) { described_class.new(config) }
@@ -53,7 +53,8 @@ RSpec.describe Html2rss::FeedPipeline do
       end
 
       it 'runs the configured strategy path and does not invoke auto fallback', :aggregate_failures do
-        rss = pipeline.to_rss
+        result = pipeline.to_result
+        rss = result.to_rss
 
         expect(rss.items.map(&:title)).to eq(['faraday'])
         expect(Html2rss::RequestService).to have_received(:execute).with(anything, strategy: :faraday).once
@@ -94,7 +95,8 @@ RSpec.describe Html2rss::FeedPipeline do
       end
 
       it 'uses auto fallback chain when the first strategy yields zero items', :aggregate_failures do
-        rss = pipeline.to_rss
+        result = pipeline.to_result
+        rss = result.to_rss
 
         expect(rss.items.map(&:title)).to eq(['bota'])
         expect(Html2rss::RequestService).to have_received(:execute).with(anything, strategy: :faraday).once
@@ -102,7 +104,7 @@ RSpec.describe Html2rss::FeedPipeline do
       end
 
       it 'logs fallback transition when first strategy returns zero items' do
-        pipeline.to_rss
+        pipeline.to_result
 
         expect(Html2rss::Log).to have_received(:info).with(
           /auto fallback faraday -> botasaurus after zero extracted items/
@@ -110,7 +112,7 @@ RSpec.describe Html2rss::FeedPipeline do
       end
 
       it 'logs selected strategy when fallback succeeds after retries' do
-        pipeline.to_rss
+        pipeline.to_result
 
         expect(Html2rss::Log).to have_received(:info).with(
           /auto selected strategy=botasaurus after attempts=2/
@@ -120,7 +122,7 @@ RSpec.describe Html2rss::FeedPipeline do
       it 'does not call fallback strategy when first strategy succeeds', :aggregate_failures do
         stub_first_strategy_success.call(item_response)
 
-        pipeline.to_rss
+        pipeline.to_result
 
         expect(Html2rss::RequestService).to have_received(:execute).with(anything, strategy: :faraday).once
         expect(Html2rss::RequestService).not_to have_received(:execute).with(anything, strategy: :botasaurus)
@@ -129,7 +131,7 @@ RSpec.describe Html2rss::FeedPipeline do
       it 'does not emit fallback info when first strategy succeeds' do
         stub_first_strategy_success.call(item_response)
 
-        pipeline.to_rss
+        pipeline.to_result
 
         expect(Html2rss::Log).not_to have_received(:info)
       end
@@ -138,7 +140,8 @@ RSpec.describe Html2rss::FeedPipeline do
         strategy_results[:botasaurus] = Html2rss::RequestService::BotasaurusConfigurationError.new('missing url')
         strategy_results[:browserless] = browserless_response
 
-        rss = pipeline.to_rss
+        result = pipeline.to_result
+        rss = result.to_rss
 
         expect(rss.items.map(&:title)).to eq(['browser'])
         expect(Html2rss::RequestService).to have_received(:execute).with(anything, strategy: :botasaurus).once
@@ -153,11 +156,11 @@ RSpec.describe Html2rss::FeedPipeline do
           }
         end
 
-        before { pipeline.to_rss }
+        before { pipeline.to_result }
 
-        it 'warns with class-only detail' do
-          expect(Html2rss::Log).to have_received(:warn).with(
-            /auto fallback faraday -> botasaurus after error=Html2rss::RequestService::RequestTimedOut/
+        it 'logs timeout fallback at info with host and budget context' do
+          expect(Html2rss::Log).to have_received(:info).with(
+            /auto fallback faraday -> botasaurus after timeout=Html2rss::RequestService::RequestTimedOut.*host=/
           ).once
         end
 
@@ -169,7 +172,7 @@ RSpec.describe Html2rss::FeedPipeline do
       end
 
       # rubocop:disable RSpec/ExampleLength
-      it 'halts fallback chain immediately if the time budget is exhausted', :aggregate_failures do
+      it 'lets Strategy enforce exhausted time budget on later auto attempts', :aggregate_failures do
         t = 0.0
         allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { t }
         allow(Html2rss::RequestService).to receive(:execute).and_call_original
@@ -179,9 +182,13 @@ RSpec.describe Html2rss::FeedPipeline do
         end
 
         pipeline = described_class.new(base_config.merge(strategy: :auto, request: { total_timeout_seconds: 1 }))
-        expect { pipeline.to_rss }.to raise_error(Html2rss::RequestService::RequestTimedOut)
+        expect { pipeline.to_result }.to raise_error(Html2rss::NoFeedItemsExtracted) do |error|
+          expect(error.attempts.map { |attempt| attempt[:strategy] }).to include(:faraday, :botasaurus)
+          expect(error.attempts).to include(
+            hash_including(strategy: :botasaurus, error_class: 'Html2rss::RequestService::RequestTimedOut')
+          )
+        end
         expect(Html2rss::RequestService).to have_received(:execute).with(anything, strategy: :faraday).once
-        expect(Html2rss::RequestService).not_to have_received(:execute).with(anything, strategy: :botasaurus)
       end
       # rubocop:enable RSpec/ExampleLength
     end
@@ -218,7 +225,8 @@ RSpec.describe Html2rss::FeedPipeline do
           Html2rss::Config.from_hash(config)
         )
 
-        rss = pipeline.to_rss
+        result = pipeline.to_result
+        rss = result.to_rss
 
         expect(rss.items.map(&:title)).to eq(['browser'])
         expect(captured_budget).to eq(
@@ -251,11 +259,69 @@ RSpec.describe Html2rss::FeedPipeline do
           responses.fetch(ctx.url.to_s)
         end
 
-        rss = described_class.new(config).to_rss
+        rss = described_class.new(config).to_result.to_rss
         expect(rss.items.map(&:title)).to eq(['Item 1', 'Item 2'])
         expect(Html2rss::RequestService).to have_received(:execute).exactly(3).times
       end
       # rubocop:enable RSpec/ExampleLength
+    end
+
+    # rubocop:disable RSpec/ExampleLength -- inline config + duplicate HTML fixture
+    it 'reports dedup_dropped on status after pipeline deduplication', :aggregate_failures do
+      config = base_config.merge(
+        strategy: :faraday,
+        selectors: base_config[:selectors].merge(
+          url: { selector: 'a', extractor: 'href' },
+          id: { selector: 'a', extractor: 'href' }
+        )
+      )
+      response = build_response.call(
+        body: <<~HTML,
+          <html><body>
+            <article><a href="https://example.com/news/dup"><h1>First</h1></a></article>
+            <article><a href="https://example.com/news/dup"><h1>Second</h1></a></article>
+          </body></html>
+        HTML
+        url: 'https://example.com/news'
+      )
+      stub_first_strategy_success.call(response)
+
+      result = described_class.new(config).to_result
+
+      expect(result.status.dedup_dropped).to eq(1)
+      expect(result.status.selected_strategy).to be_nil
+      expect(result.status.attempt_count).to eq(0)
+      expect(result.to_rss.items.size).to eq(1)
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    context 'when strategy is auto and fallback succeeds' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      let(:config) { base_config.merge(strategy: :auto, request: { max_requests: 3 }) }
+      let(:empty_response) do
+        build_response.call(body: '<html><body><div>empty</div></body></html>')
+      end
+      let(:item_response) do
+        build_response.call(body: '<html><body><article><h1>bota</h1></article></body></html>')
+      end
+
+      before do
+        allow(Html2rss::Log).to receive(:info)
+        allow(Html2rss::Log).to receive(:warn)
+        allow(Html2rss::Log).to receive(:debug)
+        allow(Html2rss::RequestService).to receive(:execute) do |ctx, strategy:|
+          ctx.budget.consume!
+          strategy == :faraday ? empty_response : item_response
+        end
+      end
+
+      it 'puts selected_strategy and attempt_count on status', :aggregate_failures do
+        result = described_class.new(config).to_result
+
+        expect(result.status.selected_strategy).to eq(:botasaurus)
+        expect(result.status.attempt_count).to eq(2)
+        expect(result.status.to_h).to include(selected_strategy: :botasaurus, attempt_count: 2)
+        expect(result.status.to_generator_comment).not_to include('botasaurus')
+      end
     end
   end
 end


### PR DESCRIPTION
## What changed

- Make `FeedPipeline#to_result` the scrape entrypoint with typed `PipelineOutcome`
- Fold AutoFallback onto pipeline host seams; surface `RequestSession#url`
- Wire Status with `dedup_dropped` / `selected_strategy` / `attempt_count`

## Why

Slice 5/8 from feed-result tip `77c9f03` for stacked review.

## Risk

- Mid-chain auto budget exhaustion raises `NoFeedItemsExtracted` (not bare `RequestTimedOut`)
- `Status#to_h` still omits empty/absent optional keys

## Stack

- Position: **5/8**
- Base: `split/fr-04-presentation` (#425)
- Depends on: #425

## Validation

- feed_pipeline + html2rss + feed_result specs — 81 examples, 0 failures
- `make quick` — exit 0

## Test plan

- [ ] Review AutoFallback timeout/budget error mapping
- [ ] Confirm Status auto strategy fields on successful `:auto` runs