### PR TITLE
docs: CONTEXT ownership map

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,35 +1,68 @@
-# Context — deepened request and AutoSource seams
+# Context — ownership map
 
-Contributor map for the four Strong module deepenings on this branch. Prefer these homes over reintroducing dual ownership.
+Where contributor-facing seams live. Prefer these homes over a second owner.
 
-## Request Budget
+## Request budget and sessions
 
-Shared wall-clock and HTTP/interaction meters for one feed build. Constructed via `RequestSession::RuntimePolicy.resources_for(config)` (policy + budget from one expansion); `budget_for` remains a thin alias. `FeedPipeline` builds sessions with `RequestSession.build` (Context normalizes once — no `RuntimeInput` passthrough). `RequestService::Context` requires an explicit `budget:`. Adapter attempt timeouts resolve through `Budget#effective_timeout_seconds` / `#effective_timeout_ms` — strategies must not reimplement `remaining || policy.total`. `PuppetCommander` public interface is `#call`; navigation `response_url` lives on `PuppetCommander::NavigationGuards`. Auto fallback run state lives on `FeedPipeline::AutoFallback::AttemptState`. Article collection threads `FeedPipeline::ExtractionContext`.
+| Concern | Home |
+| --- | --- |
+| Policy + budget for one feed build | `FeedPipeline::RuntimePolicy.resources_for` (`budget_for` is a thin alias) |
+| Session construction | `RequestSession.build` (Context normalizes once) |
+| Required on every request Context | explicit `budget:` |
+| Adapter attempt timeouts | `Budget#effective_timeout_seconds` / `#effective_timeout_ms` (Strategy only — not a pipeline pre-check) |
+| Browserless puppet public API | `PuppetCommander#call`; navigation `response_url` on `PuppetCommander::NavigationGuards` |
+| Auto fallback run state | `FeedPipeline::AutoFallback::AttemptState` |
+| Auto fallback host | `FeedPipeline::AutoFallback` via `pipeline:` → `request_session_for` / `deduplicated_articles` |
+| Article collection inputs | kwargs on `FeedPipeline` private collectors (`config:`, `response:`, `request_session:`) |
 
-## DOM chrome
+## HTML / AutoSource
 
-Layout noise and primary-link recognition for HTML trees: ignored container tags/paths (`IGNORED_CONTAINER_TAGS`), class-clustering exclusions (`CLUSTER_EXCLUDED_TAGS`), utility landmark tags (`UTILITY_LANDMARK_TAGS`), heading tags, main-anchor CSS, and visible-text extraction (`Html2rss::Html::Navigator::TextExtractor`). Owned solely by `Html2rss::Html::Navigator`. Article field extraction (`Html2rss::Html::ArticleExtractor`) and AutoSource discovery/scrapers import those constants — they do not redefine chrome tag sets.
+| Concern | Home |
+| --- | --- |
+| DOM chrome constants + visible text | `Html2rss::Html::Navigator` (`IGNORED_CONTAINER_TAGS`, `CLUSTER_EXCLUDED_TAGS`, `UTILITY_LANDMARK_TAGS`, `TextExtractor`) — import, do not redefine |
+| Container ranking / `hard_junk?` | `AutoSource::LinkHeuristics#assess_container` → `ContainerSignals` |
+| Junk vs content permalink | `AutoSource::LinkHeuristics#noise_anchor?` (Html + SemanticAnchorCandidates consume this) |
+| Anchorless / classless list discovery | `AutoSource::Discovery::DomClustering#call` |
+| `fallback_anchorless` on SemanticHtml | scraper-local permit flag |
+| `fallback_anchorless` on `Html::ArticleExtractor` | field-extraction only — not Discovery |
 
-## Container assessment
+Heading-linked “Recommended …” titles stay eligible at the noise gate so container `hard_junk?` can keep real posts with publish markers.
 
-Observing a semantic container plus its selected anchor and destination facts into ranking/`hard_junk?` signals. Owned by `AutoSource::LinkHeuristics#assess_container`, which builds `ContainerSignals` (including `#final_score`). `SemanticHtml` orchestrates candidates and extraction only — it does not rebuild observation kwargs husks or recompute `quality - junk`.
+## Feed pipeline and rendering
 
-## Content-anchor eligibility
+| Concern | Home |
+| --- | --- |
+| Channel metadata | `Html2rss::Channel.from_response` (or keyword attrs) |
+| Format adapters | `FeedBuilder::Rss` / `FeedBuilder::JsonFeed` — consume Channel + Article; constructed by `FeedResult` |
+| Opaque scrape handle | `FeedResult`: `empty?`, `channel_title`, `to_rss`, `to_json_feed`, `status` |
+| Scrape handoff | `FeedPipeline#to_result` → `FeedResult` (pipeline does not render) |
+| Contributor format entrypoints | `Html2rss.feed` / `Html2rss.json_feed` (also `Html2rss.feed_result`) |
+| Stylesheets | cached scrape artifact on `FeedResult` |
+| `feed_url` | render-time JSON Feed option only |
+| Description HTML + RSS non-image enclosure | `FeedBuilder::ItemPresentation` (`description_for`, `rss_enclosure_for`) |
+| `Article#description` | raw extracted text only |
+| JSON Feed `content_html` / `content_text` | `FeedBuilder::JsonFeed::Item` after presentation returns the body |
 
-Whether an anchor is junk chrome vs a content permalink. Owned solely by `AutoSource::LinkHeuristics#noise_anchor?` (text/destination rules plus optional icon-only and utility-landmark DOM checks). `Html` and `Discovery::SemanticAnchorCandidates` consume that method; they must not keep parallel `ineligible_anchor?` / `utility_text_suppressed?` policy. Heading-linked “Recommended …” titles are not rejected at this gate so container `hard_junk?` can keep real posts with publish markers.
+Do not expose Channel or Articles readers on `FeedResult`; grow that set only with an explicit consumer-contract change.
 
-## DOM candidate clustering
+Channel projection: Rss uses language/title/description/ttl/link/updated; JsonFeed adds icon/authors.
 
-Candidate list discovery for anchorless or classless pages is owned by `AutoSource::Discovery::DomClustering`. It encapsulates class clustering with lazy fallback to 1-level tag structure clustering behind a single `#call` interface with shared scoring and overlap resolution. `SemanticHtml` uses its own `:fallback_anchorless` boolean directly. `Html::ArticleExtractor`'s `fallback_anchorless:` flag is field-extraction only and is not owned by Discovery.
+## Status and dedup
 
-## Channel
+| Concern | Home |
+| --- | --- |
+| Telemetry on `FeedResult#status` | `Status.build` — version, scraper_tallies, dedup_dropped, auto `selected_strategy`, `attempt_count` (0 outside `:auto`) |
+| Generator / user_comment string | `Status#to_generator_comment` (scraper-focused; omits `(scrapers: …)` when tallies empty) |
+| Observability hash for web | `Status#to_h` (`scraper_status`) — omits empty `scraper_tallies`, nil `selected_strategy`, zero `attempt_count`; no article bodies/URLs |
+| Typed scrape-finished handoff | `FeedPipeline::PipelineOutcome` |
+| Dedup before handoff | `#deduplicated_articles` → `[unique, dedup_dropped]` |
 
-Feed channel metadata (title, description, ttl, language, author, image, last_build_date) extracted from the response/document with config overrides. Owned by `Html2rss::Channel`. `FeedBuilder::Rss` and `FeedBuilder::JsonFeed` are format adapters that consume Channel + Article — they do not own channel extraction.
+## Selectors and pagination
 
-## ItemScope post-process config
+| Concern | Home |
+| --- | --- |
+| ItemScope channel + post-processor config | `ItemScope#context_for` → `{ channel: scope.channel }` |
+| Pagination strategy names / factories | `RequestSession::Pager::STRATEGIES` / `Pager.strategy_names` |
+| Runtime pager | `Pager.for` (e.g. `rel_next` → `Pager::RelNext`) |
 
-Per-item extraction scope carries `channel` (url/time_zone). Post-processor `Context` config is derived as `{ channel: scope.channel }` in `ItemScope#context_for` — there is no parallel `post_process_config` bag.
-
-## Pagination strategy registry
-
-Supported pagination strategy names and factory classes live in `RequestSession::Pager::STRATEGIES` / `Pager.strategy_names`. Selectors validation (`Selectors::Config::Items`) and the exported JSON schema enum consume that list. Runtime pagination uses `Pager.for` (e.g. `rel_next` → `Pager::RelNext`).
+Selectors validation and the exported JSON schema enum consume `Pager.strategy_names`.


### PR DESCRIPTION
## What changed

- Sync `CONTEXT.md` ownership map with the FeedResult / Status / Channel / ItemPresentation / FeedPipeline stack

## Why

Slice 8/8 from feed-result tip `77c9f03` for stacked review. Completes the split of [#420](https://github.com/html2rss/html2rss/pull/420).

## Risk

- Docs only

## Stack

- Position: **8/8**
- Base: `split/fr-07-selectors` (#428)
- Depends on: #428

## Validation

- `make quick` — exit 0
- Stack tip tree matches `77c9f03` (no CHANGELOG in splits)

## Test plan

- [ ] Skim CONTEXT ownership map against landed modules