### PR TITLE
feat(request): Botasaurus-first auto scrape path

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Most people looking for a first working feed should start with `html2rss-web`, r
 Detailed usage guides, reference docs, and the feed directory live on the project website:
 
 - [Ruby gem documentation](https://html2rss.github.io/ruby-gem)
-- [Request strategies](https://html2rss.github.io/ruby-gem/reference/strategy) (`auto`, `faraday`, `botasaurus`, `browserless`)
+- [Request strategies](https://html2rss.github.io/ruby-gem/reference/strategy) (`auto` = `faraday` → `botasaurus`; pin `browserless` explicitly)
 - [Selectors & pagination](https://html2rss.github.io/ruby-gem/reference/selectors#paginated-feeds)
 - [Web application](https://html2rss.github.io/web-application)
 - [Feed directory](https://html2rss.github.io/feed-directory)
@@ -26,7 +26,7 @@ Cloud development: [Open in GitHub Codespaces](https://github.com/codespaces/new
 ## Architecture
 
 1. **Config** — loads and validates configuration (YAML/hash); schema via `html2rss schema` / `schema/html2rss-config.schema.json`
-2. **RequestService** — fetches pages (`faraday`, `botasaurus`, or `browserless`)
+2. **RequestService** — fetches pages (`faraday`, `botasaurus`, or explicit `browserless`)
 3. **Selectors** — extracts content via CSS selectors with extractors/post-processors
 4. **AutoSource** — auto-detects content (Schema.org, JSON state, semantic HTML, structural patterns)
 5. **FeedBuilder** — assembles Article objects and renders feeds (RSS 2.0 / JSON Feed 1.1)

--- a/lib/html2rss/feed_pipeline.rb
+++ b/lib/html2rss/feed_pipeline.rb
@@ -7,7 +7,10 @@ module Html2rss
     # Scrape-finished facts after request + extraction + dedup (before Channel/Status materialize).
     # selected_strategy: set on :auto success; nil otherwise.
     # attempt_count: auto attempts attempted; 0 outside :auto.
-    PipelineOutcome = Data.define(:response, :articles, :dedup_dropped, :selected_strategy, :attempt_count)
+    # strategy_attempts: auto attempt hashes (with optional transport_meta); empty outside :auto.
+    PipelineOutcome = Data.define(
+      :response, :articles, :dedup_dropped, :selected_strategy, :attempt_count, :strategy_attempts
+    )
 
     ##
     # @param raw_config [Hash{Symbol => Object}] user-provided feed config
@@ -19,6 +22,7 @@ module Html2rss
     # Runs the pipeline once and returns an opaque, Marshal-cacheable result.
     #
     # @return [Html2rss::FeedResult]
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength -- Status kwargs stay co-located with Channel
     def to_result
       config = Config.from_hash(raw_config, params: raw_config[:params])
       outcome = pipeline_outcome_for(config)
@@ -27,10 +31,12 @@ module Html2rss
         articles: outcome.articles,
         dedup_dropped: outcome.dedup_dropped,
         selected_strategy: outcome.selected_strategy,
-        attempt_count: outcome.attempt_count
+        attempt_count: outcome.attempt_count,
+        strategy_attempts: outcome.strategy_attempts
       )
       FeedResult.new(channel:, articles: outcome.articles, status:, stylesheets: config.stylesheets)
     end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     # @api private Host seam for {AutoFallback} (and single-strategy path).
     # @param config [Html2rss::Config]
@@ -75,7 +81,9 @@ module Html2rss
       request_session = request_session_for(config, strategy:, resources:)
       response = request_session.fetch_initial_response
       articles, dedup_dropped = deduplicated_articles(config:, response:, request_session:)
-      PipelineOutcome.new(response:, articles:, dedup_dropped:, selected_strategy: nil, attempt_count: 0)
+      PipelineOutcome.new(
+        response:, articles:, dedup_dropped:, selected_strategy: nil, attempt_count: 0, strategy_attempts: []
+      )
     end
 
     def run_auto_pipeline(config, resources:)

--- a/lib/html2rss/feed_pipeline/auto_fallback.rb
+++ b/lib/html2rss/feed_pipeline/auto_fallback.rb
@@ -45,9 +45,12 @@ module Html2rss
 
         # @param strategy [Symbol] strategy that returned a response
         # @param items_count [Integer] extracted article count
+        # @param transport_meta [Hash, nil] optional allowlisted upstream telemetry
         # @return [void]
-        def record_items(strategy:, items_count:)
-          @attempts << { strategy:, items_count:, error_class: nil }
+        def record_items(strategy:, items_count:, transport_meta: nil)
+          attempt = { strategy:, items_count:, error_class: nil }
+          attempt[:transport_meta] = transport_meta if transport_meta && !transport_meta.empty?
+          @attempts << attempt
         end
 
         # @param response [RequestService::Response] successful response
@@ -62,7 +65,8 @@ module Html2rss
             articles:,
             dedup_dropped:,
             selected_strategy:,
-            attempt_count:
+            attempt_count:,
+            strategy_attempts: attempts
           )
         end
       end
@@ -125,7 +129,7 @@ module Html2rss
       def process_response(response:, strategy:, next_strategy:, request_session:, state:)
         articles, dedup_dropped = articles_for(response:, request_session:)
         items_count = articles.size
-        state.record_items(strategy:, items_count:)
+        state.record_items(strategy:, items_count:, transport_meta: response.transport_meta)
         Log.debug("#{self.class}: strategy=#{strategy} items=#{items_count} " \
                   "host=#{response.url.host} elapsed=#{format('%.3f', budget.elapsed_seconds)}s " \
                   "budget_remaining=#{budget_remaining_label}")

--- a/lib/html2rss/feed_pipeline/auto_fallback.rb
+++ b/lib/html2rss/feed_pipeline/auto_fallback.rb
@@ -8,7 +8,7 @@ module Html2rss
     # Hosted by the pipeline instance: session + extract call back into FeedPipeline.
     class AutoFallback
       # Ordered list of concrete request strategies attempted by the :auto plan.
-      CHAIN = %i[faraday botasaurus browserless].freeze
+      CHAIN = %i[faraday botasaurus].freeze
 
       # Error classes that should abort auto fallback immediately.
       NON_FALLBACK_ERRORS = [

--- a/lib/html2rss/request_service/botasaurus_contract.rb
+++ b/lib/html2rss/request_service/botasaurus_contract.rb
@@ -10,7 +10,7 @@ module Html2rss
       # Default Botasaurus scrape options when no explicit config is provided.
       DEFAULT_OPTIONS = {
         navigation_mode: 'auto',
-        max_retries: 2,
+        max_retries: 1,
         headless: false
       }.freeze
 

--- a/lib/html2rss/request_service/botasaurus_contract.rb
+++ b/lib/html2rss/request_service/botasaurus_contract.rb
@@ -30,6 +30,17 @@ module Html2rss
         lang
       ].freeze
 
+      # Allowlisted upstream response keys exposed as Response#transport_meta.
+      META_KEYS = %w[
+        request_id strategy_used render_ms challenge_detected blocked_detected attempts error_category
+      ].freeze
+
+      # Remaining seconds at or below which Botasaurus retries are disabled.
+      TIGHT_BUDGET_SECONDS = 12
+
+      # Seconds reserved from remaining budget before setting wait_timeout_seconds.
+      BUDGET_WAIT_RESERVE_SECONDS = 2
+
       # Parsed Botasaurus response wrapper.
       class ParsedResponse
         # Fallback headers when upstream omits response headers.
@@ -90,6 +101,9 @@ module Html2rss
         # @return [String, nil] final URL reported by upstream
         def final_url = payload['final_url']
 
+        # @return [Hash{String => Object}] allowlisted upstream telemetry (frozen)
+        def transport_meta = payload.slice(*META_KEYS).compact.freeze
+
         private
 
         attr_reader :payload, :transport_status
@@ -109,6 +123,7 @@ module Html2rss
       ##
       # @param url [Html2rss::Url] canonical URL to scrape
       # @param options [Hash] validated request.botasaurus options
+      # @param remaining_timeout_seconds [Numeric, nil] shared request budget remainder for clamps
       # @option options [String] :navigation_mode
       # @option options [Integer] :max_retries
       # @option options [String] :wait_for_selector
@@ -121,14 +136,15 @@ module Html2rss
       # @option options [String] :user_agent
       # @option options [Array<Integer>] :window_size
       # @option options [String] :lang
-      def initialize(url:, options: {})
+      def initialize(url:, options: {}, remaining_timeout_seconds: nil)
         @url = url
         @options = options
+        @remaining_timeout_seconds = remaining_timeout_seconds
       end
 
-      # @return [Hash] payload for POST /scrape
+      # @return [Hash] payload for POST /scrape (budget-clamped when remaining is known)
       def request_payload
-        DEFAULT_OPTIONS.merge(filtered_options).merge(url: url.to_s)
+        DEFAULT_OPTIONS.merge(filtered_options).merge(url: url.to_s).then { clamp_for_budget(_1) }
       end
 
       # @param transport_response [Faraday::Response] upstream HTTP response
@@ -145,12 +161,24 @@ module Html2rss
 
       private
 
-      attr_reader :url, :options
+      attr_reader :url, :options, :remaining_timeout_seconds
 
       def filtered_options
         OPTION_KEYS.each_with_object({}) do |key, normalized|
           normalized[key] = options[key] if options.key?(key)
         end
+      end
+
+      def clamp_for_budget(payload)
+        remaining = remaining_timeout_seconds
+        return payload if remaining.nil?
+
+        clamped = payload.dup
+        clamped[:max_retries] = 0 if remaining <= TIGHT_BUDGET_SECONDS
+        budget_wait = [1, (remaining - BUDGET_WAIT_RESERVE_SECONDS).floor].max
+        configured = clamped[:wait_timeout_seconds]
+        clamped[:wait_timeout_seconds] = configured ? [configured, budget_wait].min : budget_wait
+        clamped
       end
     end
   end

--- a/lib/html2rss/request_service/botasaurus_strategy.rb
+++ b/lib/html2rss/request_service/botasaurus_strategy.rb
@@ -27,7 +27,8 @@ module Html2rss
           body: parsed_response.html,
           headers: parsed_response.headers,
           url: response_url(parsed_response.final_url),
-          status: parsed_response.status
+          status: parsed_response.status,
+          transport_meta: parsed_response.transport_meta
         )
       end
 
@@ -52,7 +53,11 @@ module Html2rss
       end
 
       def contract
-        @contract ||= BotasaurusContract.new(url: ctx.url, options: ctx.request.fetch(:botasaurus, {}))
+        @contract ||= BotasaurusContract.new(
+          url: ctx.url,
+          options: ctx.request.fetch(:botasaurus, {}),
+          remaining_timeout_seconds: attempt_timeout_seconds
+        )
       end
 
       def client
@@ -60,9 +65,13 @@ module Html2rss
       end
 
       def request_options
-        timeout = ctx.budget.effective_timeout_seconds(fallback: ctx.policy.total_timeout_seconds)
+        { timeout: attempt_timeout_seconds.to_i }
+      end
 
-        { timeout: timeout.to_i }
+      def attempt_timeout_seconds
+        @attempt_timeout_seconds ||= ctx.budget.effective_timeout_seconds(
+          fallback: ctx.policy.total_timeout_seconds
+        )
       end
 
       def content_type_header

--- a/lib/html2rss/request_service/response.rb
+++ b/lib/html2rss/request_service/response.rb
@@ -7,12 +7,16 @@ module Html2rss
     ##
     # To be used by strategies to provide their response.
     class Response
+      # Default when a strategy does not attach transport telemetry.
+      EMPTY_TRANSPORT_META = {}.freeze
+
       ##
       # @param body [String] the body of the response
       # @param url [Html2rss::Url] the final request URL
       # @param headers [Hash] the headers of the response
       # @param status [Integer, nil] the HTTP status code when available
-      def initialize(body:, url:, headers: {}, status: nil)
+      # @param transport_meta [Hash] allowlisted upstream telemetry (frozen when present)
+      def initialize(body:, url:, headers: {}, status: nil, transport_meta: EMPTY_TRANSPORT_META)
         @body = body
 
         headers = headers.dup
@@ -22,6 +26,7 @@ module Html2rss
         @headers = headers
         @status = status
         @url = url
+        @transport_meta = transport_meta.nil? || transport_meta.empty? ? EMPTY_TRANSPORT_META : transport_meta.freeze
       end
 
       # @return [String] the raw body of the response
@@ -35,6 +40,9 @@ module Html2rss
 
       # @return [Html2rss::Url] the URL of the response
       attr_reader :url
+
+      # @return [Hash] allowlisted upstream transport telemetry
+      attr_reader :transport_meta
 
       # @return [String] normalized content type header value
       def content_type = header('content-type').to_s

--- a/lib/html2rss/status.rb
+++ b/lib/html2rss/status.rb
@@ -7,7 +7,9 @@ module Html2rss
   # Exposed publicly via {FeedResult#status}. Safe to log without reading articles.
   # Stable telemetry payload for cross-repo consumers (e.g. html2rss-web observability).
   # Tallies and counters are validated and frozen at construction (including Marshal load).
-  Status = Data.define(:version, :scraper_tallies, :dedup_dropped, :selected_strategy, :attempt_count) do
+  Status = Data.define(
+    :version, :scraper_tallies, :dedup_dropped, :selected_strategy, :attempt_count, :strategy_attempts
+  ) do
     class << self
       ##
       # Builds status from extracted articles and scrape telemetry.
@@ -16,15 +18,17 @@ module Html2rss
       # @param dedup_dropped [Integer] number of articles removed by deduplication
       # @param selected_strategy [Symbol, nil] concrete strategy that succeeded under +:auto+ (else +nil+)
       # @param attempt_count [Integer] auto-fallback attempt count (0 when not under +:auto+)
+      # @param strategy_attempts [Array<Hash>] auto-fallback attempt hashes (empty outside +:auto+)
       # @return [Html2rss::Status]
-      def build(articles:, dedup_dropped: 0, selected_strategy: nil, attempt_count: 0)
+      def build(articles:, dedup_dropped: 0, selected_strategy: nil, attempt_count: 0, strategy_attempts: [])
         tallies = articles.filter_map(&:scraper).tally.transform_keys { |klass| scraper_name(klass) }
         new(
           version: Html2rss::VERSION,
           scraper_tallies: tallies,
           dedup_dropped:,
           selected_strategy:,
-          attempt_count:
+          attempt_count:,
+          strategy_attempts:
         )
       end
 
@@ -42,7 +46,11 @@ module Html2rss
     # @param dedup_dropped [Integer]
     # @param selected_strategy [Symbol, nil]
     # @param attempt_count [Integer]
-    def initialize(version:, scraper_tallies:, dedup_dropped:, selected_strategy: nil, attempt_count: 0)
+    # @param strategy_attempts [Array<Hash>]
+    # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength -- Status Data.define members
+    def initialize(
+      version:, scraper_tallies:, dedup_dropped:, selected_strategy: nil, attempt_count: 0, strategy_attempts: []
+    )
       dedup = Integer(dedup_dropped)
       attempts = Integer(attempt_count)
       validate_counters!(dedup:, attempts:, selected_strategy:)
@@ -52,24 +60,28 @@ module Html2rss
         scraper_tallies: freeze_tallies(scraper_tallies),
         dedup_dropped: dedup,
         selected_strategy:,
-        attempt_count: attempts
+        attempt_count: attempts,
+        strategy_attempts: freeze_attempts(strategy_attempts)
       )
     end
+    # rubocop:enable Metrics/ParameterLists, Metrics/MethodLength
 
     ##
     # Observability hash for web (+scraper_status+). Omits empty/absent optional keys:
-    # +:scraper_tallies+ when empty, +:selected_strategy+ when +nil+, +:attempt_count+ when zero.
+    # +:scraper_tallies+ when empty, +:selected_strategy+ when +nil+, +:attempt_count+ when zero,
+    # +:strategy_attempts+ when empty.
     # Data members remain available via readers even when omitted here.
     #
     # @return [Hash{Symbol => Object}] always +:version+ (String), +:dedup_dropped+ (Integer);
-    #   optionally +:scraper_tallies+, +:selected_strategy+, +:attempt_count+
+    #   optionally +:scraper_tallies+, +:selected_strategy+, +:attempt_count+, +:strategy_attempts+
     def to_h
       {
         version:,
         dedup_dropped:,
         **(scraper_tallies.any? ? { scraper_tallies: } : {}),
         **(selected_strategy.nil? ? {} : { selected_strategy: }),
-        **(attempt_count.positive? ? { attempt_count: } : {})
+        **(attempt_count.positive? ? { attempt_count: } : {}),
+        **(strategy_attempts.any? ? { strategy_attempts: } : {})
       }
     end
 
@@ -88,14 +100,20 @@ module Html2rss
 
     private
 
-    def marshal_dump = [version, scraper_tallies, dedup_dropped, selected_strategy, attempt_count]
+    def marshal_dump
+      [version, scraper_tallies, dedup_dropped, selected_strategy, attempt_count, strategy_attempts]
+    end
 
-    def marshal_load((version, scraper_tallies, dedup_dropped, selected_strategy, attempt_count))
-      initialize(version:, scraper_tallies:, dedup_dropped:, selected_strategy:, attempt_count:)
+    def marshal_load((version, scraper_tallies, dedup_dropped, selected_strategy, attempt_count, strategy_attempts))
+      initialize(version:, scraper_tallies:, dedup_dropped:, selected_strategy:, attempt_count:, strategy_attempts:)
     end
 
     def freeze_tallies(tallies)
       tallies.to_h.transform_keys(&:to_s).transform_values { |count| Integer(count) }.freeze
+    end
+
+    def freeze_attempts(attempts)
+      Array(attempts).map { |attempt| attempt.to_h.freeze }.freeze
     end
 
     def validate_counters!(dedup:, attempts:, selected_strategy:)

--- a/spec/lib/html2rss/cli_spec.rb
+++ b/spec/lib/html2rss/cli_spec.rb
@@ -282,8 +282,7 @@ RSpec.describe Html2rss::CLI do
           Html2rss::NoFeedItemsExtracted.new(
             attempts: [
               { strategy: :faraday, items_count: 0, error_class: nil },
-              { strategy: :botasaurus, items_count: 0, error_class: nil },
-              { strategy: :browserless, items_count: 0, error_class: nil }
+              { strategy: :botasaurus, items_count: 0, error_class: nil }
             ]
           )
         )

--- a/spec/lib/html2rss/feed_pipeline_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline_spec.rb
@@ -311,12 +311,22 @@ RSpec.describe Html2rss::FeedPipeline do
         end
       end
 
-      it 'puts selected_strategy and attempt_count on status', :aggregate_failures do
+      it 'puts selected_strategy, attempt_count, and strategy_attempts on status', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
         result = described_class.new(config).to_result
 
         expect(result.status.selected_strategy).to eq(:botasaurus)
         expect(result.status.attempt_count).to eq(2)
-        expect(result.status.to_h).to include(selected_strategy: :botasaurus, attempt_count: 2)
+        expect(result.status.strategy_attempts).to eq(
+          [
+            { strategy: :faraday, items_count: 0, error_class: nil },
+            { strategy: :botasaurus, items_count: 1, error_class: nil }
+          ]
+        )
+        expect(result.status.to_h).to include(
+          selected_strategy: :botasaurus,
+          attempt_count: 2,
+          strategy_attempts: result.status.strategy_attempts
+        )
         expect(result.status.to_generator_comment).not_to include('botasaurus')
       end
     end

--- a/spec/lib/html2rss/feed_pipeline_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline_spec.rb
@@ -71,9 +71,6 @@ RSpec.describe Html2rss::FeedPipeline do
       let(:item_response) do
         build_response.call(body: '<html><body><article><h1>bota</h1></article></body></html>')
       end
-      let(:browserless_response) do
-        build_response.call(body: '<html><body><article><h1>browser</h1></article></body></html>')
-      end
       let(:strategy_results) do
         {
           faraday: empty_response,
@@ -136,16 +133,16 @@ RSpec.describe Html2rss::FeedPipeline do
         expect(Html2rss::Log).not_to have_received(:info)
       end
 
-      it 'continues auto fallback when botasaurus is not configured', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      it 'raises when botasaurus is not configured (no browserless hop)', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
         strategy_results[:botasaurus] = Html2rss::RequestService::BotasaurusConfigurationError.new('missing url')
-        strategy_results[:browserless] = browserless_response
 
-        result = pipeline.to_result
-        rss = result.to_rss
-
-        expect(rss.items.map(&:title)).to eq(['browser'])
+        expect { pipeline.to_result }.to raise_error(Html2rss::NoFeedItemsExtracted) do |error|
+          expect(error.attempts).to include(
+            hash_including(strategy: :botasaurus, error_class: 'Html2rss::RequestService::BotasaurusConfigurationError')
+          )
+        end
         expect(Html2rss::RequestService).to have_received(:execute).with(anything, strategy: :botasaurus).once
-        expect(Html2rss::RequestService).to have_received(:execute).with(anything, strategy: :browserless).once
+        expect(Html2rss::RequestService).not_to have_received(:execute).with(anything, strategy: :browserless)
       end
 
       context 'when first strategy fails but fallback strategy succeeds' do # rubocop:disable RSpec/MultipleMemoizedHelpers, RSpec/NestedGroups

--- a/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
       expect(JSON.parse(body)).to eq(
         'url' => 'https://example.com/',
         'navigation_mode' => 'auto',
-        'max_retries' => 2,
+        'max_retries' => 1,
         'headless' => false
       )
     end

--- a/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
@@ -98,7 +98,8 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
         'url' => 'https://example.com/',
         'navigation_mode' => 'auto',
         'max_retries' => 1,
-        'headless' => false
+        'headless' => false,
+        'wait_timeout_seconds' => 28
       )
     end
 
@@ -144,6 +145,42 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
         expect(payload).not_to have_key('ignored_key')
       end
     end
+
+    # rubocop:disable RSpec/NestedGroups -- budget clamp matrix stays with request contract
+    context 'when remaining budget is tight' do
+      [
+        { remaining: 12, max_retries: 0, wait_timeout_seconds: 10 },
+        { remaining: 10.5, max_retries: 0, wait_timeout_seconds: 8 },
+        { remaining: 20, max_retries: 1, wait_timeout_seconds: 18 }
+      ].each do |example|
+        context "with remaining=#{example[:remaining]}" do
+          before do
+            allow(budget).to receive(:effective_timeout_seconds).and_return(example[:remaining])
+          end
+
+          it 'clamps max_retries and wait_timeout_seconds', :aggregate_failures do
+            execute
+
+            payload = JSON.parse(captured_post_args.first.fetch(1))
+            expect(payload['max_retries']).to eq(example[:max_retries])
+            expect(payload['wait_timeout_seconds']).to eq(example[:wait_timeout_seconds])
+          end
+        end
+      end
+
+      context 'when configured wait_timeout_seconds is below the budget cap' do
+        let(:request_config) { { botasaurus: { wait_timeout_seconds: 5 } } }
+
+        before { allow(budget).to receive(:effective_timeout_seconds).and_return(20) }
+
+        it 'keeps the lower configured wait timeout' do
+          execute
+
+          expect(JSON.parse(captured_post_args.first.fetch(1))['wait_timeout_seconds']).to eq(5)
+        end
+      end
+    end
+    # rubocop:enable RSpec/NestedGroups
   end
 
   describe 'response mapping' do
@@ -155,6 +192,15 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
       expect(result.status).to eq(200)
       expect(result.headers.fetch('content-type')).to include('text/html')
       expect(result.body).to include('ok')
+      expect(result.transport_meta).to eq(
+        'request_id' => 'request-id',
+        'strategy_used' => 'google_get_bypass',
+        'render_ms' => 5000,
+        'blocked_detected' => false,
+        'challenge_detected' => false,
+        'attempts' => 2
+      )
+      expect(result.transport_meta).to be_frozen
     end
 
     context 'when response omits headers and url metadata' do

--- a/spec/lib/html2rss/status_spec.rb
+++ b/spec/lib/html2rss/status_spec.rb
@@ -30,12 +30,19 @@ RSpec.describe Html2rss::Status do
         articles:,
         dedup_dropped: 0,
         selected_strategy: :botasaurus,
-        attempt_count: 2
+        attempt_count: 2,
+        strategy_attempts: [
+          { strategy: :faraday, items_count: 0, error_class: nil },
+          { strategy: :botasaurus, items_count: 1, error_class: nil,
+            transport_meta: { 'request_id' => 'abc', 'render_ms' => 12 } }
+        ]
       )
 
       expect(status.selected_strategy).to eq(:botasaurus)
       expect(status.attempt_count).to eq(2)
+      expect(status.strategy_attempts.size).to eq(2)
       expect(status.to_h).to include(selected_strategy: :botasaurus, attempt_count: 2)
+      expect(status.to_h[:strategy_attempts].last[:transport_meta]).to include('request_id' => 'abc')
       expect(status.to_generator_comment).not_to include('botasaurus')
     end
     # rubocop:enable RSpec/ExampleLength
@@ -72,14 +79,21 @@ RSpec.describe Html2rss::Status do
       expect { status.scraper_tallies['Selectors'] = 2 }.to raise_error(FrozenError)
     end
 
-    # rubocop:disable RSpec/ExampleLength -- Marshal freeze contract for tallies
-    it 're-freezes tallies after Marshal round-trip', :aggregate_failures do
-      status = described_class.build(articles: [], dedup_dropped: 1)
+    # rubocop:disable RSpec/ExampleLength -- Marshal freeze contract for tallies + attempts
+    it 're-freezes tallies and strategy_attempts after Marshal round-trip', :aggregate_failures do
+      status = described_class.build(
+        articles: [],
+        dedup_dropped: 1,
+        strategy_attempts: [{ strategy: :faraday, items_count: 0, error_class: nil }]
+      )
       restored = Marshal.load(Marshal.dump(status))
 
       expect(restored).to be_frozen
       expect(restored.scraper_tallies).to be_frozen
+      expect(restored.strategy_attempts).to be_frozen
+      expect(restored.strategy_attempts.first).to be_frozen
       expect(restored.dedup_dropped).to eq(1)
+      expect(restored.strategy_attempts).to eq([{ strategy: :faraday, items_count: 0, error_class: nil }])
       expect { restored.scraper_tallies['x'] = 1 }.to raise_error(FrozenError)
     end
     # rubocop:enable RSpec/ExampleLength
@@ -103,7 +117,7 @@ RSpec.describe Html2rss::Status do
         dedup_dropped: 0,
         scraper_tallies: { 'AutoSource::Html' => 1, 'Selectors' => 1 }
       )
-      expect(status.to_h).not_to include(:selected_strategy, :attempt_count)
+      expect(status.to_h).not_to include(:selected_strategy, :attempt_count, :strategy_attempts)
     end
     # rubocop:enable RSpec/ExampleLength
 
@@ -120,11 +134,12 @@ RSpec.describe Html2rss::Status do
     end
     # rubocop:enable RSpec/ExampleLength
 
-    it 'omits nil selected_strategy and zero attempt_count from the hash', :aggregate_failures do
+    it 'omits nil selected_strategy, zero attempt_count, and empty strategy_attempts', :aggregate_failures do
       status = described_class.build(articles: [], dedup_dropped: 3)
 
       expect(status.selected_strategy).to be_nil
       expect(status.attempt_count).to eq(0)
+      expect(status.strategy_attempts).to eq([])
       expect(status.to_h.keys).to contain_exactly(:version, :dedup_dropped)
     end
   end

--- a/spec/lib/html2rss_spec.rb
+++ b/spec/lib/html2rss_spec.rb
@@ -470,13 +470,6 @@ RSpec.describe Html2rss do
           headers: { 'content-type' => 'text/html' }
         )
       end
-      let(:browserless_item_response) do
-        Html2rss::RequestService::Response.new(
-          body: '<html><body><article><h1>browser</h1></article></body></html>',
-          url: Html2rss::Url.from_absolute('https://example.com/news'),
-          headers: { 'content-type' => 'text/html' }
-        )
-      end
       let(:strategy_results) do
         {
           faraday: faraday_empty_response,
@@ -508,17 +501,16 @@ RSpec.describe Html2rss do
         expect(Html2rss::RequestService).to have_received(:execute).with(anything, strategy: :botasaurus).once
       end
 
-      it 'falls back through browserless when first two strategies return zero items', :aggregate_failures do
+      it 'does not call browserless under auto when botasaurus also yields zero items', :aggregate_failures do
         strategy_results[:botasaurus] = faraday_empty_response
-        strategy_results[:browserless] = browserless_item_response
 
-        expect(feed.items.map(&:title)).to eq(['browser'])
-        expect(Html2rss::RequestService).to have_received(:execute).with(anything, strategy: :browserless).once
+        expect { feed }
+          .to raise_error(Html2rss::NoFeedItemsExtracted, /No feed items extracted after auto fallback/)
+        expect(Html2rss::RequestService).not_to have_received(:execute).with(anything, strategy: :browserless)
       end
 
       it 'raises a specific zero-items error when all concrete strategies return zero items' do
         strategy_results[:botasaurus] = faraday_empty_response
-        strategy_results[:browserless] = faraday_empty_response
 
         expect { feed }
           .to raise_error(Html2rss::NoFeedItemsExtracted, /No feed items extracted after auto fallback/)
@@ -528,7 +520,6 @@ RSpec.describe Html2rss do
         before do
           strategy_results[:faraday] = Html2rss::RequestService::RequestTimedOut.new('timed out')
           strategy_results[:botasaurus] = faraday_empty_response
-          strategy_results[:browserless] = faraday_empty_response
         end
 
         it 'raises NoFeedItemsExtracted' do
@@ -544,17 +535,17 @@ RSpec.describe Html2rss do
               items_count: nil,
               error_class: 'Html2rss::RequestService::RequestTimedOut'
             },
-            { strategy: :botasaurus, items_count: 0, error_class: nil },
-            { strategy: :browserless, items_count: 0, error_class: nil }
+            { strategy: :botasaurus, items_count: 0, error_class: nil }
           ]
 
           expect { feed }.to raise_error(Html2rss::NoFeedItemsExtracted) { |error| expect(error.attempts).to eq(expected_attempts) }
         end
 
-        it 'tries browserless as the final fallback strategy' do
+        it 'stops at botasaurus without calling browserless', :aggregate_failures do
           feed
         rescue Html2rss::NoFeedItemsExtracted
-          expect(Html2rss::RequestService).to have_received(:execute).with(anything, strategy: :browserless).once
+          expect(Html2rss::RequestService).to have_received(:execute).with(anything, strategy: :botasaurus).once
+          expect(Html2rss::RequestService).not_to have_received(:execute).with(anything, strategy: :browserless)
         end
       end
 
@@ -562,7 +553,6 @@ RSpec.describe Html2rss do
         config[:request][:max_requests] = 1
 
         strategy_results[:botasaurus] = faraday_empty_response
-        strategy_results[:browserless] = faraday_empty_response
 
         expect { feed }.to raise_error(Html2rss::RequestService::RequestBudgetExceeded, /Request budget exhausted/)
         expect(Html2rss::RequestService).to have_received(:execute).with(anything, strategy: :faraday).once


### PR DESCRIPTION
## Summary
- Shorten `:auto` fallback to `faraday → botasaurus` (Browserless is explicit-only); default Botasaurus `max_retries` is `1`.
- Clamp Botasaurus retries/wait to remaining request budget; slice allowlisted `transport_meta` onto `Response`; expose AutoFallback attempts as `Status#strategy_attempts`.
- Web follow-up lands on `html2rss-web` `feat/feed-result-cutover` (PR #1068) to emit `strategy_attempts` on empty `feed.render`.

## Test plan
- [x] `make quick` (gem) after Phase 1 and Phase 2 — exit 0
- [x] Focused botasaurus / status / feed_pipeline / auto-fallback specs — exit 0
- [ ] CI green on this PR
- [ ] After merge: bump/pin `html2rss-web` Gemfile off master once this ships (currently `github: … branch: 'master'`)