### PR TITLE
feat(auto_source): tiered extract, lazy SST, and --limit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SHELL_SCRIPTS = \
 	bin/ready \
 	bin/setup
 
-.PHONY: help lint-changed test-fast test lint lint-yard shellcheck schema validate-fixtures docs quick ready clean
+.PHONY: help lint-changed test-fast test lint lint-yard shellcheck schema validate-fixtures docs quick ready clean perf-baseline
 
 help: ## Show available commands
 	@echo "Available commands:"
@@ -21,6 +21,7 @@ help: ## Show available commands
 	@echo "  make schema  - Regenerate and verify the config schema"
 	@echo "  make validate-fixtures - Validate fixture configs"
 	@echo "  make docs    - Generate documentation"
+	@echo "  make perf-baseline - Record auto-source wall/alloc baseline"
 	@echo "  make ready   - Run the local PR readiness checks"
 	@echo "  make clean   - Clean build artifacts"
 
@@ -59,6 +60,9 @@ validate-fixtures: ## Validate fixture configs
 
 docs: ## Generate documentation
 	$(RUBY_RUNNER)bundle exec yard doc
+
+perf-baseline: ## Record auto-source wall/alloc baseline markdown
+	$(RUBY_RUNNER)bin/heuristic-perf-baseline --write spec/perf/baseline-auto-source.md
 
 ready: ## Run the local PR readiness checks
 	bin/ready

--- a/bin/heuristic-perf-baseline
+++ b/bin/heuristic-perf-baseline
@@ -19,7 +19,7 @@ WARMUP = 1
 RUNS = 5
 BASE_URL = 'https://example.com/'
 
-def run_heuristics(parsed_body)
+def run_heuristics(parsed_body) # rubocop:disable Metrics/MethodLength
   semantic = Html2rss::AutoSource::Scraper::SemanticHtml.new(
     parsed_body, url: BASE_URL, fallback_anchorless: true
   )

--- a/bin/heuristic-perf-baseline
+++ b/bin/heuristic-perf-baseline
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Captures wall time + allocation baseline for the heuristic auto-source path.
+# Captures wall time + allocation baseline for auto-source paths.
 # Usage: mise exec -- bin/heuristic-perf-baseline [--write PATH]
 
 require 'bundler/setup'
@@ -17,21 +17,15 @@ FIXTURES = [
 
 WARMUP = 1
 RUNS = 5
+BASE_URL = 'https://example.com/'
 
-def parse_fixture(path)
-  html = File.read(File.expand_path(path, File.join(__dir__, '..')))
-  Nokogiri::HTML(html)
-end
-
-def run_heuristics(parsed_body, url:) # rubocop:disable Metrics/MethodLength
+def run_heuristics(parsed_body)
   semantic = Html2rss::AutoSource::Scraper::SemanticHtml.new(
-    parsed_body,
-    url:,
-    fallback_anchorless: true
+    parsed_body, url: BASE_URL, fallback_anchorless: true
   )
   html = Html2rss::AutoSource::Scraper::Html.new(
     parsed_body,
-    url:,
+    url: BASE_URL,
     fallback_anchorless: true,
     minimum_selector_frequency: 2,
     use_top_selectors: 5
@@ -39,14 +33,26 @@ def run_heuristics(parsed_body, url:) # rubocop:disable Metrics/MethodLength
   [semantic.to_a.size, html.to_a.size]
 end
 
-def measure(parsed_bodies)
+def run_auto_source(parsed_body, body)
+  url = Html2rss::Url.from_absolute(BASE_URL)
+  response = Html2rss::RequestService::Response.new(
+    body:,
+    headers: { 'content-type' => 'text/html' },
+    url:
+  )
+  response.instance_variable_set(:@parsed_body, parsed_body)
+  Html2rss::AutoSource.new(response).articles.size
+end
+
+def measure(parsed_bodies, bodies)
   GC.start
   before_alloc = GC.stat[:total_allocated_objects]
   started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-  counts = parsed_bodies.map { |body| run_heuristics(body, url: 'https://example.com/') }
+  heuristic_counts = parsed_bodies.map { run_heuristics(_1) }
+  auto_counts = parsed_bodies.zip(bodies).map { |doc, body| run_auto_source(doc, body) }
   wall = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
   allocs = GC.stat[:total_allocated_objects] - before_alloc
-  [wall, allocs, counts]
+  [wall, allocs, heuristic_counts, auto_counts]
 end
 
 options = { write: nil }
@@ -55,18 +61,21 @@ OptionParser.new do |opts|
 end.parse!
 
 root = File.expand_path('..', __dir__)
-parsed_bodies = FIXTURES.map { |rel| parse_fixture(File.join(root, rel)) }
+bodies = FIXTURES.map { |rel| File.read(File.join(root, rel)) }
+parsed_bodies = bodies.map { Nokogiri::HTML(_1) }
 
-WARMUP.times { measure(parsed_bodies) }
+WARMUP.times { measure(parsed_bodies, bodies) }
 
 walls = []
 allocs = []
-article_counts = nil
+heuristic_counts = nil
+auto_counts = nil
 RUNS.times do
-  wall, alloc, counts = measure(parsed_bodies)
+  wall, alloc, h_counts, a_counts = measure(parsed_bodies, bodies)
   walls << wall
   allocs << alloc
-  article_counts = counts
+  heuristic_counts = h_counts
+  auto_counts = a_counts
 end
 
 median = ->(arr) { arr.sort[arr.size / 2] }
@@ -74,7 +83,7 @@ wall_med = median.call(walls)
 alloc_med = median.call(allocs)
 
 lines = []
-lines << '# Heuristic auto-source performance baseline'
+lines << '# Auto-source performance baseline'
 lines << ''
 lines << "Captured: #{Time.now.utc.iso8601}"
 lines << "Ruby: #{RUBY_VERSION}"
@@ -88,9 +97,10 @@ lines << "| allocations (median) | #{alloc_med} |"
 lines << "| wall_budget_1_1x | #{format('%.6f', wall_med * 1.1)} |"
 lines << "| alloc_budget_1_15x | #{(alloc_med * 1.15).ceil} |"
 lines << ''
-lines << 'Article counts per fixture (semantic, html):'
-article_counts.each_with_index do |(semantic_n, html_n), idx|
-  lines << "- #{FIXTURES[idx]}: semantic=#{semantic_n}, html=#{html_n}"
+lines << 'Article counts per fixture (semantic, html | AutoSource#articles):'
+FIXTURES.each_with_index do |fixture, idx|
+  semantic_n, html_n = heuristic_counts[idx]
+  lines << "- #{fixture}: semantic=#{semantic_n}, html=#{html_n}, auto_source=#{auto_counts[idx]}"
 end
 lines << ''
 

--- a/lib/html2rss.rb
+++ b/lib/html2rss.rb
@@ -81,14 +81,17 @@ module Html2rss
   # @param max_redirects [Integer, nil] optional redirect limit override
   # @param max_requests [Integer] optional request budget override (default: 4 for sitemap sub-fetches)
   # @param local_file_path [String, nil] optional local HTML file path
+  # @param limit [Integer, nil] max articles to keep (default: {AutoSource::DEFAULT_LIMIT})
   # @return [RSS::Rss] generated RSS feed
   def self.auto_source(url,
                        strategy: :auto,
                        items_selector: nil,
                        max_redirects: nil,
                        max_requests: 4,
-                       local_file_path: nil)
-    feed(build_auto_source_config(url:, strategy:, items_selector:, max_redirects:, max_requests:, local_file_path:))
+                       local_file_path: nil,
+                       limit: nil)
+    feed(build_auto_source_config(url:, strategy:, items_selector:, max_redirects:, max_requests:,
+                                  local_file_path:, limit:))
   end
 
   ##
@@ -102,15 +105,17 @@ module Html2rss
   # @param max_redirects [Integer, nil] optional redirect limit override
   # @param max_requests [Integer] optional request budget override (default: 4 for sitemap sub-fetches)
   # @param local_file_path [String, nil] optional local HTML file path
+  # @param limit [Integer, nil] max articles to keep (default: {AutoSource::DEFAULT_LIMIT})
   # @return [Hash] JSONFeed-compliant hash
   def self.auto_json_feed(url,
                           strategy: :auto,
                           items_selector: nil,
                           max_redirects: nil,
                           max_requests: 4,
-                          local_file_path: nil)
+                          local_file_path: nil,
+                          limit: nil)
     json_feed(build_auto_source_config(url:, strategy:, items_selector:, max_redirects:, max_requests:,
-                                       local_file_path:))
+                                       local_file_path:, limit:))
   end
 
   # rubocop:enable Metrics/ParameterLists
@@ -162,11 +167,14 @@ module Html2rss
   class << self
     private
 
-    def build_auto_source_config(url:, strategy:, items_selector:, max_redirects:, max_requests:, local_file_path: nil) # rubocop:disable Metrics/ParameterLists
+    # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
+    def build_auto_source_config(url:, strategy:, items_selector:, max_redirects:, max_requests:,
+                                 local_file_path: nil, limit: nil)
       config = Config.auto_source_config(
         url:,
         items_selector:,
-        request_controls: shortcut_request_controls(strategy:, max_redirects:, max_requests:)
+        request_controls: shortcut_request_controls(strategy:, max_redirects:, max_requests:),
+        limit:
       )
       if local_file_path
         config[:request] ||= {}
@@ -174,6 +182,7 @@ module Html2rss
       end
       config
     end
+    # rubocop:enable Metrics/ParameterLists, Metrics/MethodLength
 
     def shortcut_request_controls(strategy:, max_redirects:, max_requests:)
       Config::RequestControls.new(

--- a/lib/html2rss/auto_source.rb
+++ b/lib/html2rss/auto_source.rb
@@ -15,6 +15,7 @@ module Html2rss
   # @see Html2rss::AutoSource::Scraper::Schema
   # @see Html2rss::AutoSource::Scraper::SemanticHtml
   # @see Html2rss::AutoSource::Scraper::Html
+  # rubocop:disable Metrics/ClassLength -- defaults + tiered extract stay on the contributor entry type
   class AutoSource
     # Minimum articles with url+title before later scraper tiers are skipped.
     SUFFICIENT_ARTICLE_COUNT = 5
@@ -113,6 +114,7 @@ module Html2rss
 
     attr_reader :url, :parsed_body, :body, :request_session
 
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
     def extract_articles
       articles = []
       matched = false
@@ -134,12 +136,12 @@ module Html2rss
           instance = Scraper.build_instance(
             scraper_class,
             parsed_body,
+            opts: scraper_opts,
             url:,
             request_session:,
             body:,
             document:,
-            link_resolver:,
-            opts: scraper_opts
+            link_resolver:
           )
           next unless instance
           next unless Scraper.extractable_instance?(instance, parsed_body)
@@ -153,6 +155,7 @@ module Html2rss
 
       Cleanup.call(articles, url:, **cleanup_options)
     end
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
     def sufficient?(articles)
       articles.count { |article| article.url && !article.title.to_s.empty? } >= SUFFICIENT_ARTICLE_COUNT
@@ -175,4 +178,5 @@ module Html2rss
       @opts.fetch(:cleanup, {})
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/lib/html2rss/auto_source.rb
+++ b/lib/html2rss/auto_source.rb
@@ -17,12 +17,12 @@ module Html2rss
   # @see Html2rss::AutoSource::Scraper::Html
   # rubocop:disable Metrics/ClassLength -- defaults + tiered extract stay on the contributor entry type
   class AutoSource
-    # Default minimum articles with url+title (post-Cleanup) before later scraper tiers are skipped.
-    SUFFICIENT_ARTICLE_COUNT = 25
+    # Default max articles to keep (also the short-circuit floor across scraper tiers).
+    DEFAULT_LIMIT = 25
 
     # Default auto-source configuration shipped for scraper and cleanup behavior.
     DEFAULT_CONFIG = {
-      sufficient_article_count: SUFFICIENT_ARTICLE_COUNT,
+      limit: DEFAULT_LIMIT,
       scraper: {
         wordpress_api: {
           enabled: true
@@ -85,7 +85,7 @@ module Html2rss
     # @param response [Html2rss::RequestService::Response] initial page response
     # @param opts [Hash] validated auto-source options
     # @param request_session [Html2rss::RequestSession, nil] shared request session for follow-up fetches
-    # @option opts [Integer] :sufficient_article_count stop later tiers after this many cleaned articles
+    # @option opts [Integer] :limit max articles to keep; later tiers stop once this many survive Cleanup
     # @option opts [Hash] :scraper scraper configuration map
     # @option opts [Hash] :cleanup cleanup configuration map
     # @return [void]
@@ -102,7 +102,7 @@ module Html2rss
     #
     # Tiers: in-page structured → follow-up IO → SemanticHtml → Html.
     # SST is built only when a heuristic tier runs. Later tiers are skipped once
-    # +sufficient_article_count+ articles with url+title remain after Cleanup.
+    # +limit+ articles with url+title remain after Cleanup; the result is capped to +limit+.
     #
     # @return [Array<Html2rss::Article>] extracted articles
     def articles
@@ -125,7 +125,7 @@ module Html2rss
       scraper_opts = @opts.fetch(:scraper, {})
 
       Scraper::SCRAPER_TIERS.each do |tier|
-        break if sufficient_cleaned?(articles)
+        break if enough_articles?(articles)
 
         if Scraper.heuristic_tier?(tier)
           document ||= Scraper.normalize_sst(parsed_body)
@@ -155,20 +155,20 @@ module Html2rss
 
       raise Scraper.no_scraper_found_for(parsed_body, body:) unless matched
 
-      Cleanup.call(articles, url:, **cleanup_options)
+      Cleanup.call(articles, url:, **cleanup_options).first(article_limit)
     end
     # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
-    def sufficient_cleaned?(articles)
-      threshold = sufficient_article_count
+    def enough_articles?(articles)
+      threshold = article_limit
       return false if articles.size < threshold
 
       cleaned = Cleanup.call(articles.dup, url:, **cleanup_options)
       cleaned.count { |article| article.url && !article.title.to_s.empty? } >= threshold
     end
 
-    def sufficient_article_count
-      @opts.fetch(:sufficient_article_count, SUFFICIENT_ARTICLE_COUNT)
+    def article_limit
+      @opts.fetch(:limit, DEFAULT_LIMIT)
     end
 
     def run_scraper(instance)

--- a/lib/html2rss/auto_source.rb
+++ b/lib/html2rss/auto_source.rb
@@ -123,7 +123,7 @@ module Html2rss
       scraper_opts = @opts.fetch(:scraper, {})
 
       Scraper::SCRAPER_TIERS.each do |tier|
-        break if sufficient?(articles)
+        break if sufficient_cleaned?(articles)
 
         if Scraper.heuristic_tier?(tier)
           document ||= Scraper.normalize_sst(parsed_body)
@@ -157,8 +157,11 @@ module Html2rss
     end
     # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
-    def sufficient?(articles)
-      articles.count { |article| article.url && !article.title.to_s.empty? } >= SUFFICIENT_ARTICLE_COUNT
+    def sufficient_cleaned?(articles)
+      return false if articles.size < SUFFICIENT_ARTICLE_COUNT
+
+      cleaned = Cleanup.call(articles.dup, url:, **cleanup_options)
+      cleaned.count { |article| article.url && !article.title.to_s.empty? } >= SUFFICIENT_ARTICLE_COUNT
     end
 
     def run_scraper(instance)

--- a/lib/html2rss/auto_source.rb
+++ b/lib/html2rss/auto_source.rb
@@ -17,11 +17,12 @@ module Html2rss
   # @see Html2rss::AutoSource::Scraper::Html
   # rubocop:disable Metrics/ClassLength -- defaults + tiered extract stay on the contributor entry type
   class AutoSource
-    # Minimum articles with url+title before later scraper tiers are skipped.
-    SUFFICIENT_ARTICLE_COUNT = 5
+    # Default minimum articles with url+title (post-Cleanup) before later scraper tiers are skipped.
+    SUFFICIENT_ARTICLE_COUNT = 25
 
     # Default auto-source configuration shipped for scraper and cleanup behavior.
     DEFAULT_CONFIG = {
+      sufficient_article_count: SUFFICIENT_ARTICLE_COUNT,
       scraper: {
         wordpress_api: {
           enabled: true
@@ -84,6 +85,7 @@ module Html2rss
     # @param response [Html2rss::RequestService::Response] initial page response
     # @param opts [Hash] validated auto-source options
     # @param request_session [Html2rss::RequestSession, nil] shared request session for follow-up fetches
+    # @option opts [Integer] :sufficient_article_count stop later tiers after this many cleaned articles
     # @option opts [Hash] :scraper scraper configuration map
     # @option opts [Hash] :cleanup cleanup configuration map
     # @return [void]
@@ -100,7 +102,7 @@ module Html2rss
     #
     # Tiers: in-page structured → follow-up IO → SemanticHtml → Html.
     # SST is built only when a heuristic tier runs. Later tiers are skipped once
-    # {SUFFICIENT_ARTICLE_COUNT} articles with url+title are collected.
+    # +sufficient_article_count+ articles with url+title remain after Cleanup.
     #
     # @return [Array<Html2rss::Article>] extracted articles
     def articles
@@ -158,10 +160,15 @@ module Html2rss
     # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
     def sufficient_cleaned?(articles)
-      return false if articles.size < SUFFICIENT_ARTICLE_COUNT
+      threshold = sufficient_article_count
+      return false if articles.size < threshold
 
       cleaned = Cleanup.call(articles.dup, url:, **cleanup_options)
-      cleaned.count { |article| article.url && !article.title.to_s.empty? } >= SUFFICIENT_ARTICLE_COUNT
+      cleaned.count { |article| article.url && !article.title.to_s.empty? } >= threshold
+    end
+
+    def sufficient_article_count
+      @opts.fetch(:sufficient_article_count, SUFFICIENT_ARTICLE_COUNT)
     end
 
     def run_scraper(instance)

--- a/lib/html2rss/auto_source.rb
+++ b/lib/html2rss/auto_source.rb
@@ -16,6 +16,9 @@ module Html2rss
   # @see Html2rss::AutoSource::Scraper::SemanticHtml
   # @see Html2rss::AutoSource::Scraper::Html
   class AutoSource
+    # Minimum articles with url+title before later scraper tiers are skipped.
+    SUFFICIENT_ARTICLE_COUNT = 5
+
     # Default auto-source configuration shipped for scraper and cleanup behavior.
     DEFAULT_CONFIG = {
       scraper: {
@@ -92,17 +95,11 @@ module Html2rss
     end
 
     ##
-    # Extracts article candidates by selecting every scraper that can explain the
-    # page shape, running those scrapers, and normalizing the resulting hashes
-    # into `Article` objects.
+    # Extracts articles by running scraper tiers until a sufficient set is found.
     #
-    # The contributor-facing flow is:
-    # 1. choose scraper instances that match the page
-    # 2. let each scraper collect its own candidates
-    # 3. clean and deduplicate the merged article list
-    #
-    # Scrapers with expensive precomputation, such as `SemanticHtml`, keep that
-    # state on the instance so detection and extraction can reuse the same work.
+    # Tiers: in-page structured → follow-up IO → SemanticHtml → Html.
+    # SST is built only when a heuristic tier runs. Later tiers are skipped once
+    # {SUFFICIENT_ARTICLE_COUNT} articles with url+title are collected.
     #
     # @return [Array<Html2rss::Article>] extracted articles
     def articles
@@ -117,16 +114,48 @@ module Html2rss
     attr_reader :url, :parsed_body, :body, :request_session
 
     def extract_articles
-      scraper_instances = Scraper.instances_for(
-        parsed_body, url:, request_session:, body:, opts: @opts[:scraper]
-      )
-      return [] if scraper_instances.empty?
+      articles = []
+      matched = false
+      document = nil
+      link_resolver = nil
+      scraper_opts = @opts.fetch(:scraper, {})
 
-      # Scrapers are run sequentially.
-      articles = scraper_instances.flat_map do |instance|
-        run_scraper(instance)
+      Scraper::SCRAPER_TIERS.each do |tier|
+        break if sufficient?(articles)
+
+        if Scraper.heuristic_tier?(tier)
+          document ||= Scraper.normalize_sst(parsed_body)
+          next unless document
+
+          link_resolver ||= ::Html2rss::Scoring::LinkResolver.new(url)
+        end
+
+        tier.each do |scraper_class|
+          instance = Scraper.build_instance(
+            scraper_class,
+            parsed_body,
+            url:,
+            request_session:,
+            body:,
+            document:,
+            link_resolver:,
+            opts: scraper_opts
+          )
+          next unless instance
+          next unless Scraper.extractable_instance?(instance, parsed_body)
+
+          matched = true
+          articles.concat(run_scraper(instance))
+        end
       end
+
+      raise Scraper.no_scraper_found_for(parsed_body, body:) unless matched
+
       Cleanup.call(articles, url:, **cleanup_options)
+    end
+
+    def sufficient?(articles)
+      articles.count { |article| article.url && !article.title.to_s.empty? } >= SUFFICIENT_ARTICLE_COUNT
     end
 
     def run_scraper(instance)

--- a/lib/html2rss/auto_source/scraper.rb
+++ b/lib/html2rss/auto_source/scraper.rb
@@ -19,18 +19,17 @@ module Html2rss
       # Maximum visible text length tolerated for app-shell classification.
       APP_SHELL_MAX_VISIBLE_TEXT_LENGTH = 220
 
-      # Ordered scraper classes considered during auto-source extraction.
-      SCRAPERS = [
-        WordpressApi,
-        Sitemap,
-        Schema,
-        Microdata,
-        Microformats2,
-        JsonState,
-        MetaOembed,
-        SemanticHtml,
-        Html
+      # Extraction tiers: merge within a tier, then stop when AutoSource has enough articles.
+      # Heuristic scrapers are separate tiers so SemanticHtml can satisfy before Html runs.
+      SCRAPER_TIERS = [
+        [Schema, Microdata, Microformats2, JsonState].freeze,
+        [WordpressApi, Sitemap, MetaOembed].freeze,
+        [SemanticHtml].freeze,
+        [Html].freeze
       ].freeze
+
+      # Flat ordered list (request slot accounting, detection helpers).
+      SCRAPERS = SCRAPER_TIERS.flatten.freeze
 
       # Heuristic scrapers that share one memoized SST::Document per page.
       HEURISTIC_SCRAPERS = [SemanticHtml, Html].freeze
@@ -77,14 +76,6 @@ module Html2rss
       # Returns an array of scraper classes that claim to find articles in the parsed body.
       # @param parsed_body [Nokogiri::HTML::Document] The parsed HTML document.
       # @param opts [Hash] The options hash.
-      # @option opts [Hash] :wordpress_api scraper toggle and configuration
-      # @option opts [Hash] :schema scraper toggle and configuration
-      # @option opts [Hash] :microdata scraper toggle and configuration
-      # @option opts [Hash] :microformats2 scraper toggle and configuration
-      # @option opts [Hash] :json_state scraper toggle and configuration
-      # @option opts [Hash] :meta_oembed scraper toggle and configuration
-      # @option opts [Hash] :semantic_html scraper toggle and configuration
-      # @option opts [Hash] :html scraper toggle and configuration
       # @return [Array<Class>] An array of scraper classes that can handle the parsed body.
       def self.from(parsed_body, opts = Html2rss::AutoSource::DEFAULT_CONFIG[:scraper])
         scrapers = SCRAPERS.select { |scraper| opts.dig(scraper.options_key, :enabled) }
@@ -95,87 +86,84 @@ module Html2rss
         scrapers
       end
 
-      # Returns scraper instances ready for extraction.
-      # @param parsed_body [Nokogiri::HTML::Document] The parsed HTML document.
-      # @param url [String, Html2rss::Url] The page url.
-      # @param request_session [Html2rss::RequestSession, nil] Shared follow-up session.
-      # @param body [String, nil] raw response body (XML for direct sitemap pages).
-      # @param opts [Hash] The options hash.
-      # @option opts [Hash] :wordpress_api scraper toggle and configuration
-      # @option opts [Hash] :sitemap scraper toggle and configuration
-      # @option opts [Hash] :schema scraper toggle and configuration
-      # @option opts [Hash] :microdata scraper toggle and configuration
-      # @option opts [Hash] :microformats2 scraper toggle and configuration
-      # @option opts [Hash] :json_state scraper toggle and configuration
-      # @option opts [Hash] :meta_oembed scraper toggle and configuration
-      # @option opts [Hash] :semantic_html scraper toggle and configuration
-      # @option opts [Hash] :html scraper toggle and configuration
-      # @return [Array<Object>] An array of scraper instances that can handle the parsed body.
-      #
-      # `instances_for` is the main entrypoint for extraction. It lets a scraper
-      # decide whether it matches using the same instance that will later yield
-      # article hashes, which keeps precomputed state close to the scraper that
-      # owns it. Heuristic scrapers share one +SST::Document+ normalized from
-      # +parsed_body+.
-      def self.instances_for(parsed_body, url:, request_session: nil, body: nil, # rubocop:disable Metrics/MethodLength
-                             opts: Html2rss::AutoSource::DEFAULT_CONFIG[:scraper])
-        document = shared_sst_document(parsed_body, opts)
-        instances = SCRAPERS.filter_map do |scraper|
-          next unless opts.dig(scraper.options_key, :enabled)
-          next if HEURISTIC_SCRAPERS.include?(scraper) && document.nil?
-
-          scraper_opts = opts.fetch(scraper.options_key, {}).except(:enabled)
-          instance = scraper.new(
-            parsed_body, url:, **construction_kwargs(scraper, request_session:, body:, document:), **scraper_opts
-          )
-          instance if extractable_instance?(instance, parsed_body)
-        end
-        raise no_scraper_found_for(parsed_body) if instances.empty?
-
-        instances
+      ##
+      # @param tier [Array<Class>]
+      # @return [Boolean]
+      def self.heuristic_tier?(tier)
+        tier.any? { HEURISTIC_SCRAPERS.include?(_1) }
       end
 
-      def self.construction_kwargs(scraper, request_session:, body:, document:)
-        return { document: } if HEURISTIC_SCRAPERS.include?(scraper)
-
-        {}.tap do |kwargs|
-          kwargs[:request_session] = request_session if REQUEST_SESSION_SCRAPERS.include?(scraper)
-          kwargs[:body] = body if scraper == Sitemap
-        end
-      end
-      private_class_method :construction_kwargs
-
-      def self.shared_sst_document(parsed_body, scraper_config)
-        return unless HEURISTIC_SCRAPERS.any? { scraper_config.dig(_1.options_key, :enabled) }
-
+      ##
+      # @param parsed_body [Nokogiri::HTML::Document]
+      # @return [SST::Document, nil]
+      def self.normalize_sst(parsed_body)
         SST::Normalizer.call(parsed_body)
       rescue ArgumentError
         nil
       end
-      private_class_method :shared_sst_document
 
+      ##
+      # Builds a scraper when enabled; returns nil when disabled.
+      #
+      # @param scraper [Class]
+      # @param parsed_body [Nokogiri::HTML::Document]
+      # @param url [Html2rss::Url, String]
+      # @param request_session [Html2rss::RequestSession, nil]
+      # @param body [String, nil]
+      # @param document [SST::Document, nil]
+      # @param link_resolver [Scoring::LinkResolver, nil]
+      # @param opts [Hash] full scraper options map
+      # @return [Object, nil]
+      def self.build_instance(scraper, parsed_body, url:, request_session: nil, body: nil, document: nil,
+                              link_resolver: nil, opts:)
+        return unless opts.dig(scraper.options_key, :enabled)
+        return if HEURISTIC_SCRAPERS.include?(scraper) && document.nil?
+
+        scraper_opts = opts.fetch(scraper.options_key, {}).except(:enabled)
+        kwargs = construction_kwargs(scraper, request_session:, body:, document:, link_resolver:)
+        scraper.new(parsed_body, url:, **kwargs, **scraper_opts)
+      end
+
+      ##
+      # @param instance [Object]
+      # @param parsed_body [Nokogiri::HTML::Document]
+      # @return [Boolean]
       def self.extractable_instance?(instance, parsed_body)
         return instance.extractable? if instance.respond_to?(:extractable?)
 
         instance.class.articles?(parsed_body)
       end
-      private_class_method :extractable_instance?
 
-      def self.no_scraper_found_for(parsed_body)
-        NoScraperFound.new(category: classify_no_scraper_surface(parsed_body))
+      ##
+      # @param parsed_body [Nokogiri::HTML::Document]
+      # @param body [String, nil] raw response body (preferred for blocked-surface checks)
+      # @return [NoScraperFound]
+      def self.no_scraper_found_for(parsed_body, body: nil)
+        NoScraperFound.new(category: classify_no_scraper_surface(parsed_body, body:))
       end
-      private_class_method :no_scraper_found_for
 
-      def self.classify_no_scraper_surface(parsed_body)
-        return :blocked_surface if blocked_surface?(parsed_body)
+      def self.construction_kwargs(scraper, request_session:, body:, document:, link_resolver:)
+        if HEURISTIC_SCRAPERS.include?(scraper)
+          { document:, link_resolver: }.compact
+        else
+          {}.tap do |kwargs|
+            kwargs[:request_session] = request_session if REQUEST_SESSION_SCRAPERS.include?(scraper)
+            kwargs[:body] = body if scraper == Sitemap
+          end
+        end
+      end
+      private_class_method :construction_kwargs
+
+      def self.classify_no_scraper_surface(parsed_body, body: nil)
+        return :blocked_surface if blocked_surface?(parsed_body, body:)
         return :app_shell if app_shell_surface?(parsed_body)
 
         :unsupported_surface
       end
       private_class_method :classify_no_scraper_surface
 
-      def self.blocked_surface?(parsed_body)
-        Html2rss::RequestService::BlockedSurface.interstitial?(parsed_body.to_html)
+      def self.blocked_surface?(parsed_body, body: nil)
+        Html2rss::RequestService::BlockedSurface.interstitial?(body || parsed_body.to_html)
       end
       private_class_method :blocked_surface?
 

--- a/lib/html2rss/auto_source/scraper.rb
+++ b/lib/html2rss/auto_source/scraper.rb
@@ -11,7 +11,7 @@ module Html2rss
     # Detection is intentionally shallow for most scrapers, but instance-based
     # matching is available for scrapers that need to carry expensive selection
     # state forward into extraction.
-    module Scraper # rubocop:disable Metrics/ModuleLength -- registry + surface classification stay colocated
+    module Scraper
       # Root markers indicating likely app-shell/client-rendered surfaces.
       APP_SHELL_ROOT_SELECTORS = '#app, #root, #__next, [data-reactroot], [ng-app], [id*="app-shell"]'
       # Maximum anchors tolerated before app-shell detection is considered unlikely.
@@ -76,6 +76,15 @@ module Html2rss
       # Returns an array of scraper classes that claim to find articles in the parsed body.
       # @param parsed_body [Nokogiri::HTML::Document] The parsed HTML document.
       # @param opts [Hash] The options hash.
+      # @option opts [Hash] :wordpress_api scraper toggle and configuration
+      # @option opts [Hash] :schema scraper toggle and configuration
+      # @option opts [Hash] :microdata scraper toggle and configuration
+      # @option opts [Hash] :microformats2 scraper toggle and configuration
+      # @option opts [Hash] :json_state scraper toggle and configuration
+      # @option opts [Hash] :meta_oembed scraper toggle and configuration
+      # @option opts [Hash] :semantic_html scraper toggle and configuration
+      # @option opts [Hash] :html scraper toggle and configuration
+      # @option opts [Hash] :sitemap scraper toggle and configuration
       # @return [Array<Class>] An array of scraper classes that can handle the parsed body.
       def self.from(parsed_body, opts = Html2rss::AutoSource::DEFAULT_CONFIG[:scraper])
         scrapers = SCRAPERS.select { |scraper| opts.dig(scraper.options_key, :enabled) }
@@ -90,7 +99,7 @@ module Html2rss
       # @param tier [Array<Class>]
       # @return [Boolean]
       def self.heuristic_tier?(tier)
-        tier.any? { HEURISTIC_SCRAPERS.include?(_1) }
+        tier.intersect?(HEURISTIC_SCRAPERS)
       end
 
       ##
@@ -107,15 +116,25 @@ module Html2rss
       #
       # @param scraper [Class]
       # @param parsed_body [Nokogiri::HTML::Document]
+      # @param opts [Hash] full scraper options map
       # @param url [Html2rss::Url, String]
       # @param request_session [Html2rss::RequestSession, nil]
       # @param body [String, nil]
       # @param document [SST::Document, nil]
       # @param link_resolver [Scoring::LinkResolver, nil]
-      # @param opts [Hash] full scraper options map
+      # @option opts [Hash] :wordpress_api scraper toggle and configuration
+      # @option opts [Hash] :schema scraper toggle and configuration
+      # @option opts [Hash] :microdata scraper toggle and configuration
+      # @option opts [Hash] :microformats2 scraper toggle and configuration
+      # @option opts [Hash] :json_state scraper toggle and configuration
+      # @option opts [Hash] :meta_oembed scraper toggle and configuration
+      # @option opts [Hash] :semantic_html scraper toggle and configuration
+      # @option opts [Hash] :html scraper toggle and configuration
+      # @option opts [Hash] :sitemap scraper toggle and configuration
       # @return [Object, nil]
-      def self.build_instance(scraper, parsed_body, url:, request_session: nil, body: nil, document: nil,
-                              link_resolver: nil, opts:)
+      # rubocop:disable Metrics/ParameterLists -- construction context for structured and heuristic scrapers
+      def self.build_instance(scraper, parsed_body, opts:, url:, request_session: nil, body: nil, document: nil,
+                              link_resolver: nil)
         return unless opts.dig(scraper.options_key, :enabled)
         return if HEURISTIC_SCRAPERS.include?(scraper) && document.nil?
 
@@ -123,6 +142,7 @@ module Html2rss
         kwargs = construction_kwargs(scraper, request_session:, body:, document:, link_resolver:)
         scraper.new(parsed_body, url:, **kwargs, **scraper_opts)
       end
+      # rubocop:enable Metrics/ParameterLists
 
       ##
       # @param instance [Object]

--- a/lib/html2rss/auto_source/scraper/html.rb
+++ b/lib/html2rss/auto_source/scraper/html.rb
@@ -28,7 +28,7 @@ module Html2rss
         def self.articles?(parsed_body)
           return false unless parsed_body
 
-          new(parsed_body, url: DETECTION_BASE_URL).any?
+          new(parsed_body, url: DETECTION_BASE_URL).extractable?
         rescue ArgumentError
           false
         end
@@ -62,44 +62,53 @@ module Html2rss
         ##
         # @return [Boolean]
         def extractable?
-          articles.any?
+          ranked_segments.any?
+        rescue ArgumentError
+          false
         end
 
         private
 
         def articles
           @articles ||= begin
-            extracted = list_articles
-            extracted += cluster_articles if @fallback_anchorless && extracted.empty?
-            extracted
+            ranked = list_ranked
+            if ranked.empty? && @fallback_anchorless
+              materialize(cluster_ranked, fallback_anchorless: true)
+            else
+              materialize(ranked)
+            end
           end
         rescue ArgumentError
           []
         end
 
-        def list_articles
+        def ranked_segments
+          @ranked_segments ||= begin
+            ranked = list_ranked
+            ranked = cluster_ranked if @fallback_anchorless && ranked.empty?
+            ranked
+          end
+        end
+
+        def list_ranked
+          @list_ranked ||= rank_strategy(:list, permit_unanchored: false)
+        end
+
+        def cluster_ranked
+          @cluster_ranked ||= rank_strategy(:cluster, permit_unanchored: true)
+        end
+
+        def rank_strategy(strategy, permit_unanchored:)
           segments = Segmenter.call(
             document,
             base_url: @url,
-            strategy: :list,
-            permit_unanchored: false,
+            strategy:,
+            permit_unanchored:,
             minimum_selector_frequency:,
             use_top_selectors:,
             link_resolver:
           )
-          materialize(engine.select_eligible(segments, limit: TOP_K))
-        end
-
-        def cluster_articles
-          segments = Segmenter.call(
-            document,
-            base_url: @url,
-            strategy: :cluster,
-            permit_unanchored: true,
-            minimum_selector_frequency:,
-            link_resolver:
-          )
-          materialize(engine.select_eligible(segments, limit: TOP_K), fallback_anchorless: true)
+          engine.select_eligible(segments, limit: TOP_K)
         end
 
         def materialize(ranked, fallback_anchorless: false)

--- a/lib/html2rss/auto_source/scraper/html.rb
+++ b/lib/html2rss/auto_source/scraper/html.rb
@@ -36,13 +36,15 @@ module Html2rss
         # @param parsed_body [Nokogiri::HTML::Document, nil] parsed HTML (when +document:+ omitted)
         # @param url [String, Html2rss::Url]
         # @param document [SST::Document, nil] memoized SST document from AutoSource
+        # @param link_resolver [Scoring::LinkResolver, nil] shared page-scoped resolver
         # @param opts [Hash]
         # @option opts [Boolean] :fallback_anchorless keep anchorless cluster cards
         # @option opts [Integer] :minimum_selector_frequency list frequency floor
         # @option opts [Integer] :use_top_selectors list selector budget
-        def initialize(parsed_body = nil, url:, document: nil, **opts)
+        def initialize(parsed_body = nil, url:, document: nil, link_resolver: nil, **opts)
           @parsed_body = parsed_body
           @provided_document = document
+          @provided_link_resolver = link_resolver
           @url = url
           @opts = opts
           @fallback_anchorless = opts.fetch(:fallback_anchorless, false)
@@ -111,7 +113,7 @@ module Html2rss
         end
 
         def link_resolver
-          @link_resolver ||= Scoring::LinkResolver.new(@url)
+          @link_resolver ||= @provided_link_resolver || Scoring::LinkResolver.new(@url)
         end
 
         def document

--- a/lib/html2rss/auto_source/scraper/semantic_html.rb
+++ b/lib/html2rss/auto_source/scraper/semantic_html.rb
@@ -28,11 +28,13 @@ module Html2rss
         # @param parsed_body [Nokogiri::HTML::Document, nil] parsed HTML (when +document:+ omitted)
         # @param url [String, Html2rss::Url] base url
         # @param document [SST::Document, nil] memoized SST document from AutoSource
+        # @param link_resolver [Scoring::LinkResolver, nil] shared page-scoped resolver
         # @param opts [Hash] scraper-specific options
         # @option opts [Boolean] :fallback_anchorless whether to keep containers without a primary anchor
-        def initialize(parsed_body = nil, url:, document: nil, **opts)
+        def initialize(parsed_body = nil, url:, document: nil, link_resolver: nil, **opts)
           @parsed_body = parsed_body
           @provided_document = document
+          @provided_link_resolver = link_resolver
           @url = url
           @permit_unanchored = opts.fetch(:fallback_anchorless, false)
         end
@@ -80,7 +82,7 @@ module Html2rss
         end
 
         def link_resolver
-          @link_resolver ||= Scoring::LinkResolver.new(@url)
+          @link_resolver ||= @provided_link_resolver || Scoring::LinkResolver.new(@url)
         end
 
         def document

--- a/lib/html2rss/auto_source/segmenter/cluster.rb
+++ b/lib/html2rss/auto_source/segmenter/cluster.rb
@@ -81,17 +81,22 @@ module Html2rss
         ##
         # Filters layout wrapper groups and resolves 1-to-1 nested card wrappers.
         class OverlapResolver
+          # Cap pairwise work on dense class grids.
+          MAX_GROUPS = 40
+
           # @param index [SST::Index]
           def initialize(index:)
             @index = index
             @layout_tags = SST::Tags::LAYOUT_NAMES
+            @scorer = Scoring::ClusterScorer.new
           end
 
           # @param groups [Hash{String => Array<SST::Node>}]
           # @return [Hash{String => Array<SST::Node>}]
           def filter_containers(groups)
-            groups.reject do |cls_a, nodes_a|
-              groups.any? { |cls_b, nodes_b| cls_a != cls_b && container_of?(nodes_a, nodes_b) }
+            capped = cap_groups(groups)
+            capped.reject do |cls_a, nodes_a|
+              capped.any? { |cls_b, nodes_b| cls_a != cls_b && container_of?(nodes_a, nodes_b) }
             end
           end
 
@@ -110,6 +115,12 @@ module Html2rss
           end
 
           private
+
+          def cap_groups(groups)
+            return groups if groups.size <= MAX_GROUPS
+
+            groups.sort_by { |_key, nodes| -nodes.size }.first(MAX_GROUPS).to_h
+          end
 
           # rubocop:disable Metrics/MethodLength
           def container_of?(nodes_a, nodes_b)
@@ -142,8 +153,7 @@ module Html2rss
           end
 
           def keep_descendant?(nodes_a, nodes_b)
-            scorer = Scoring::ClusterScorer.new
-            scorer.avg_words(nodes_b) >= 0.8 * scorer.avg_words(nodes_a) &&
+            @scorer.avg_words(nodes_b) >= 0.8 * @scorer.avg_words(nodes_a) &&
               @layout_tags.include?(nodes_b.first.name)
           end
         end

--- a/lib/html2rss/auto_source/segmenter/list.rb
+++ b/lib/html2rss/auto_source/segmenter/list.rb
@@ -30,45 +30,40 @@ module Html2rss
         end
 
         def article_pairs(segmenter)
-          selectors(segmenter).flat_map do |path|
-            article_pairs_for_path(segmenter, path)
+          by_path = relevant_links_by_path(segmenter)
+          top_paths(segmenter, by_path).flat_map do |path|
+            by_path.fetch(path, []).filter_map do |node|
+              article_tag = parent_until_boundary(segmenter, node)
+              next unless article_tag
+
+              [article_tag, node]
+            end
           end
         end
         module_function :article_pairs
         private_class_method :article_pairs
 
-        def article_pairs_for_path(segmenter, path)
-          segmenter.index.each_node.filter_map do |node|
-            next unless node.link?
-            next unless node.tag_path == path
-            next if segmenter.index.ignored_chrome?(node)
-            next unless relevant_anchor?(segmenter, node)
-
-            article_tag = parent_until_boundary(segmenter, node)
-            next unless article_tag
-
-            [article_tag, node]
-          end
-        end
-        module_function :article_pairs_for_path
-        private_class_method :article_pairs_for_path
-
-        def selectors(segmenter)
-          counts = Hash.new(0)
+        def relevant_links_by_path(segmenter)
+          by_path = Hash.new { |hash, path| hash[path] = [] }
           segmenter.index.each_node do |node|
             next unless node.link?
             next if segmenter.index.ignored_chrome?(node)
             next unless relevant_anchor?(segmenter, node)
 
-            counts[node.tag_path] += 1
+            by_path[node.tag_path] << node
           end
+          by_path
+        end
+        module_function :relevant_links_by_path
+        private_class_method :relevant_links_by_path
 
-          counts.select { |_path, count| count >= segmenter.minimum_selector_frequency }
-                .max_by(segmenter.use_top_selectors, &:last)
+        def top_paths(segmenter, by_path)
+          by_path.select { |_path, nodes| nodes.size >= segmenter.minimum_selector_frequency }
+                .max_by(segmenter.use_top_selectors) { |_path, nodes| nodes.size }
                 .map(&:first)
         end
-        module_function :selectors
-        private_class_method :selectors
+        module_function :top_paths
+        private_class_method :top_paths
 
         def relevant_anchor?(segmenter, node)
           facts = segmenter.link_resolver.destination_facts(node)
@@ -82,14 +77,14 @@ module Html2rss
 
         def parent_until_boundary(segmenter, node)
           index = segmenter.index
-          anchor_counts = Hash.new { |h, n| h[n] = count_links(n) }
+          link_counts = Hash.new { |hash, curr| hash[curr] = count_links(curr) }
 
           index.parent_until(node, lambda { |curr|
             return true if %i[body html].include?(curr.name)
             return false if index.ignored_chrome?(curr)
 
             parent = index.parent_of(curr)
-            parent && anchor_counts[parent] > anchor_counts[curr]
+            parent && link_counts[parent] > link_counts[curr]
           })
         end
         module_function :parent_until_boundary

--- a/lib/html2rss/auto_source/segmenter/list.rb
+++ b/lib/html2rss/auto_source/segmenter/list.rb
@@ -59,8 +59,8 @@ module Html2rss
 
         def top_paths(segmenter, by_path)
           by_path.select { |_path, nodes| nodes.size >= segmenter.minimum_selector_frequency }
-                .max_by(segmenter.use_top_selectors) { |_path, nodes| nodes.size }
-                .map(&:first)
+                 .max_by(segmenter.use_top_selectors) { |_path, nodes| nodes.size }
+                 .map(&:first)
         end
         module_function :top_paths
         private_class_method :top_paths

--- a/lib/html2rss/cli.rb
+++ b/lib/html2rss/cli.rb
@@ -79,6 +79,9 @@ module Html2rss
     method_option :max_requests,
                   type: :numeric,
                   desc: 'Maximum requests to allow for this feed build'
+    method_option :limit,
+                  type: :numeric,
+                  desc: 'Maximum number of articles to keep (default: 25)'
     method_option :input,
                   type: :string,
                   desc: 'Local HTML file path to read input from'
@@ -249,7 +252,8 @@ module Html2rss
         items_selector: options[:items_selector],
         max_redirects: options[:max_redirects],
         max_requests: options[:max_requests],
-        local_file_path:
+        local_file_path:,
+        limit: options[:limit]&.to_i
       )
     end
 

--- a/lib/html2rss/config.rb
+++ b/lib/html2rss/config.rb
@@ -120,11 +120,15 @@ module Html2rss
       # @param url [String] source page URL
       # @param items_selector [String, nil] optional selector hint for item extraction
       # @param request_controls [Html2rss::Config::RequestControls, nil] explicit request controls to write
+      # @param limit [Integer, nil] max articles to keep in the auto-sourced feed
       # @return [Hash{Symbol => Object}] feed config hash ready for {from_hash}
-      def auto_source_config(url:, items_selector: nil, request_controls: nil)
+      def auto_source_config(url:, items_selector: nil, request_controls: nil, limit: nil)
+        auto_source = AutoSource::DEFAULT_CONFIG
+        auto_source = auto_source.merge(limit:) unless limit.nil?
+
         config = {
           channel: default_config[:channel].merge(url:),
-          auto_source: AutoSource::DEFAULT_CONFIG
+          auto_source:
         }
 
         request_controls ||= RequestControls.new

--- a/lib/html2rss/config/auto_source_contract.rb
+++ b/lib/html2rss/config/auto_source_contract.rb
@@ -6,6 +6,8 @@ module Html2rss
   class Config
     # Runtime source of truth for validating auto-source config values.
     AutoSourceContract = Dry::Schema.Params do # rubocop:disable Metrics/BlockLength
+      optional(:sufficient_article_count).filled(:integer, gt?: 0)
+
       optional(:scraper).hash do # rubocop:disable Metrics/BlockLength
         optional(:wordpress_api).hash do
           optional(:enabled).filled(:bool)

--- a/lib/html2rss/config/auto_source_contract.rb
+++ b/lib/html2rss/config/auto_source_contract.rb
@@ -6,7 +6,7 @@ module Html2rss
   class Config
     # Runtime source of truth for validating auto-source config values.
     AutoSourceContract = Dry::Schema.Params do # rubocop:disable Metrics/BlockLength
-      optional(:sufficient_article_count).filled(:integer, gt?: 0)
+      optional(:limit).filled(:integer, gt?: 0)
 
       optional(:scraper).hash do # rubocop:disable Metrics/BlockLength
         optional(:wordpress_api).hash do

--- a/lib/html2rss/selectors/post_processors/sanitize_html.rb
+++ b/lib/html2rss/selectors/post_processors/sanitize_html.rb
@@ -92,12 +92,19 @@ module Html2rss
         # @param html [String]
         # @param url [String, Html2rss::Url]
         # @return [String, nil]
+        # rubocop:disable ThreadSafety/ClassInstanceVariable
         def self.get(html, url)
           return nil if String(html).empty?
 
+          @fragment_cache ||= {}
+          key = [html, url.to_s]
+          return @fragment_cache[key] if @fragment_cache.key?(key)
+
+          @fragment_cache.clear if @fragment_cache.size > 256
           context = Selectors::Context.new(config: { channel: { url: } }, options: {})
-          new(html, context).get
+          @fragment_cache[key] = new(html, context).get
         end
+        # rubocop:enable ThreadSafety/ClassInstanceVariable
 
         ##
         # @param channel_url [String, Html2rss::Url]

--- a/lib/html2rss/sst/index.rb
+++ b/lib/html2rss/sst/index.rb
@@ -10,6 +10,11 @@ module Html2rss
       NODE_BINDINGS = ObjectSpace::WeakMap.new
 
       ##
+      # @param node [Node]
+      # @return [Index, nil]
+      def self.for_node(node) = NODE_BINDINGS[node]
+
+      ##
       # @param root [Node]
       # @param parents [Hash{Node => Node, nil}]
       # @param depths [Hash{Node => Integer}]
@@ -25,11 +30,6 @@ module Html2rss
       end
 
       attr_reader :root
-
-      ##
-      # @param node [Node]
-      # @return [Index, nil]
-      def self.for_node(node) = NODE_BINDINGS[node]
 
       ##
       # @param node [Node]

--- a/lib/html2rss/sst/index.rb
+++ b/lib/html2rss/sst/index.rb
@@ -6,6 +6,9 @@ module Html2rss
     # Parent/depth indices for an SST tree. Built once by the Normalizer so
     # Scoring/Segmenter never need Nokogiri ancestor walks.
     class Index
+      # Weak node→index bindings so +Node#visible_text+ can memoize without call-site churn.
+      NODE_BINDINGS = ObjectSpace::WeakMap.new
+
       ##
       # @param root [Node]
       # @param parents [Hash{Node => Node, nil}]
@@ -16,9 +19,17 @@ module Html2rss
         @parents = parents
         @depths = depths
         @ignored_chrome = ignored_chrome
+        @visible_text = {}.compare_by_identity
+        @word_count = {}.compare_by_identity
+        bind_tree(root)
       end
 
       attr_reader :root
+
+      ##
+      # @param node [Node]
+      # @return [Index, nil]
+      def self.for_node(node) = NODE_BINDINGS[node]
 
       ##
       # @param node [Node]
@@ -34,6 +45,26 @@ module Html2rss
       # @param node [Node]
       # @return [Boolean]
       def ignored_chrome?(node) = @ignored_chrome.fetch(node, false)
+
+      ##
+      # Memoized default visible text (separator space, no excludes).
+      #
+      # @param node [Node]
+      # @return [String, nil]
+      def memo_visible_text(node)
+        return @visible_text[node] if @visible_text.key?(node)
+
+        @visible_text[node] = Text.extract(node)
+      end
+
+      ##
+      # @param node [Node]
+      # @return [Integer]
+      def memo_word_count(node)
+        return @word_count[node] if @word_count.key?(node)
+
+        @word_count[node] = memo_visible_text(node).to_s.scan(/\p{Alnum}+/).size
+      end
 
       ##
       # @param child [Node]
@@ -68,6 +99,13 @@ module Html2rss
       # @return [Enumerator]
       def each_node(&)
         root.each_node(&)
+      end
+
+      private
+
+      def bind_tree(node)
+        NODE_BINDINGS[node] = self
+        node.children.each { bind_tree(_1) }
       end
     end
   end

--- a/lib/html2rss/sst/node.rb
+++ b/lib/html2rss/sst/node.rb
@@ -118,12 +118,20 @@ module Html2rss
       # @param exclude [Array<Node>, nil]
       # @return [String, nil]
       def visible_text(separator: ' ', exclude: nil)
+        if exclude.nil? && separator == ' ' && (index = Index.for_node(self))
+          return index.memo_visible_text(self)
+        end
+
         Text.extract(self, separator:, exclude:)
       end
 
       ##
       # @return [Integer] alphanumeric word count of visible text
       def word_count
+        if (index = Index.for_node(self))
+          return index.memo_word_count(self)
+        end
+
         visible_text.to_s.scan(/\p{Alnum}+/).size
       end
 

--- a/schema/html2rss-config.schema.json
+++ b/schema/html2rss-config.schema.json
@@ -94,6 +94,13 @@
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
       "properties": {
+        "sufficient_article_count": {
+          "type": "integer",
+          "not": {
+            "type": "null"
+          },
+          "exclusiveMinimum": 0
+        },
         "scraper": {
           "type": "object",
           "properties": {
@@ -269,6 +276,7 @@
       },
       "required": [],
       "default": {
+        "sufficient_article_count": 25,
         "scraper": {
           "wordpress_api": {
             "enabled": true

--- a/schema/html2rss-config.schema.json
+++ b/schema/html2rss-config.schema.json
@@ -94,7 +94,7 @@
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
       "properties": {
-        "sufficient_article_count": {
+        "limit": {
           "type": "integer",
           "not": {
             "type": "null"
@@ -276,7 +276,7 @@
       },
       "required": [],
       "default": {
-        "sufficient_article_count": 25,
+        "limit": 25,
         "scraper": {
           "wordpress_api": {
             "enabled": true

--- a/spec/lib/html2rss/auto_source/scraper_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Html2rss::AutoSource::Scraper do
 
       [Html2rss::AutoSource::Scraper::SemanticHtml, Html2rss::AutoSource::Scraper::Html].each do |klass|
         instance = described_class.build_instance(
-          klass, parsed_body, url:, document:, link_resolver:, opts:
+          klass, parsed_body, opts:, url:, document:, link_resolver:
         )
         captured << [instance.instance_variable_get(:@provided_document),
                      instance.instance_variable_get(:@provided_link_resolver)]

--- a/spec/lib/html2rss/auto_source/scraper_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper_spec.rb
@@ -6,6 +6,27 @@ RSpec.describe Html2rss::AutoSource::Scraper do
   it { is_expected.to be_a(Module) }
   it { expect(described_class::SCRAPERS).to be_an(Array) }
 
+  describe '::SCRAPER_TIERS' do
+    it 'runs in-page structured scrapers before follow-up IO and heuristics', :aggregate_failures do
+      expect(described_class::SCRAPER_TIERS[0]).to eq(
+        [
+          Html2rss::AutoSource::Scraper::Schema,
+          Html2rss::AutoSource::Scraper::Microdata,
+          Html2rss::AutoSource::Scraper::Microformats2,
+          Html2rss::AutoSource::Scraper::JsonState
+        ]
+      )
+      expect(described_class::SCRAPER_TIERS[1]).to include(
+        Html2rss::AutoSource::Scraper::WordpressApi,
+        Html2rss::AutoSource::Scraper::Sitemap,
+        Html2rss::AutoSource::Scraper::MetaOembed
+      )
+      expect(described_class::SCRAPER_TIERS[2]).to eq([Html2rss::AutoSource::Scraper::SemanticHtml])
+      expect(described_class::SCRAPER_TIERS[3]).to eq([Html2rss::AutoSource::Scraper::Html])
+      expect(described_class::SCRAPERS).to eq(described_class::SCRAPER_TIERS.flatten)
+    end
+  end
+
   describe '.from(parsed_body, opts)' do
     context 'when suitable scraper is found' do
       let(:parsed_body) do
@@ -104,46 +125,35 @@ RSpec.describe Html2rss::AutoSource::Scraper do
     end
   end
 
-  describe '.instances_for(parsed_body, url:, opts:)' do
+  describe '.normalize_sst / .build_instance' do
     let(:parsed_body) do
       Nokogiri::HTML('<html><body><article><a href="/article-1">Article 1</a></article></body></html>')
     end
     let(:url) { Html2rss::Url.from_absolute('https://example.com') }
-
-    it 'returns scraper instances that can extract articles' do
-      expect(described_class.instances_for(parsed_body, url:)).to all(respond_to(:each))
+    let(:opts) do
+      Html2rss::AutoSource::DEFAULT_CONFIG[:scraper].transform_values do |config|
+        config.merge(enabled: false)
+      end.merge(
+        semantic_html: { enabled: true },
+        html: { enabled: true }
+      )
     end
 
-    context 'when SemanticHtml and Html are both enabled' do
-      let(:opts) do
-        Html2rss::AutoSource::DEFAULT_CONFIG[:scraper].transform_values do |config|
-          config.merge(enabled: false)
-        end.merge(
-          semantic_html: { enabled: true },
-          html: { enabled: true }
+    it 'shares one SST::Document and LinkResolver across heuristic scrapers', :aggregate_failures do
+      document = described_class.normalize_sst(parsed_body)
+      link_resolver = Html2rss::Scoring::LinkResolver.new(url)
+      captured = []
+
+      [Html2rss::AutoSource::Scraper::SemanticHtml, Html2rss::AutoSource::Scraper::Html].each do |klass|
+        instance = described_class.build_instance(
+          klass, parsed_body, url:, document:, link_resolver:, opts:
         )
-      end
-      let(:captured_documents) { [] }
-
-      before do
-        allow(Html2rss::SST::Normalizer).to receive(:call).and_call_original
-
-        [Html2rss::AutoSource::Scraper::SemanticHtml, Html2rss::AutoSource::Scraper::Html].each do |klass|
-          allow(klass).to receive(:new).and_wrap_original do |original, *args, **kwargs|
-            captured_documents << kwargs.fetch(:document)
-            original.call(*args, **kwargs)
-          end
-        end
+        captured << [instance.instance_variable_get(:@provided_document),
+                     instance.instance_variable_get(:@provided_link_resolver)]
       end
 
-      it 'normalizes once and shares the same SST::Document', :aggregate_failures do
-        described_class.instances_for(parsed_body, url:, opts:)
-
-        expect(Html2rss::SST::Normalizer).to have_received(:call).once
-        expect(captured_documents.size).to eq(2)
-        expect(captured_documents).to all(be_a(Html2rss::SST::Document))
-        expect(captured_documents[0]).to equal(captured_documents[1])
-      end
+      expect(captured.map(&:first)).to all(equal(document))
+      expect(captured.map(&:last)).to all(equal(link_resolver))
     end
   end
 

--- a/spec/lib/html2rss/auto_source/scraper_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper_spec.rb
@@ -7,22 +7,20 @@ RSpec.describe Html2rss::AutoSource::Scraper do
   it { expect(described_class::SCRAPERS).to be_an(Array) }
 
   describe '::SCRAPER_TIERS' do
-    it 'runs in-page structured scrapers before follow-up IO and heuristics', :aggregate_failures do
-      expect(described_class::SCRAPER_TIERS[0]).to eq(
-        [
-          Html2rss::AutoSource::Scraper::Schema,
-          Html2rss::AutoSource::Scraper::Microdata,
-          Html2rss::AutoSource::Scraper::Microformats2,
-          Html2rss::AutoSource::Scraper::JsonState
-        ]
+    it 'starts with in-page structured scrapers' do
+      expect(described_class::SCRAPER_TIERS.first).to include(
+        Html2rss::AutoSource::Scraper::Schema,
+        Html2rss::AutoSource::Scraper::JsonState
       )
-      expect(described_class::SCRAPER_TIERS[1]).to include(
-        Html2rss::AutoSource::Scraper::WordpressApi,
-        Html2rss::AutoSource::Scraper::Sitemap,
-        Html2rss::AutoSource::Scraper::MetaOembed
+    end
+
+    it 'ends with SemanticHtml then Html' do
+      expect(described_class::SCRAPER_TIERS.last(2)).to eq(
+        [[Html2rss::AutoSource::Scraper::SemanticHtml], [Html2rss::AutoSource::Scraper::Html]]
       )
-      expect(described_class::SCRAPER_TIERS[2]).to eq([Html2rss::AutoSource::Scraper::SemanticHtml])
-      expect(described_class::SCRAPER_TIERS[3]).to eq([Html2rss::AutoSource::Scraper::Html])
+    end
+
+    it 'flattens tiers into SCRAPERS' do
       expect(described_class::SCRAPERS).to eq(described_class::SCRAPER_TIERS.flatten)
     end
   end
@@ -138,22 +136,23 @@ RSpec.describe Html2rss::AutoSource::Scraper do
         html: { enabled: true }
       )
     end
+    let(:document) { described_class.normalize_sst(parsed_body) }
+    let(:link_resolver) { Html2rss::Scoring::LinkResolver.new(url) }
 
-    it 'shares one SST::Document and LinkResolver across heuristic scrapers', :aggregate_failures do
-      document = described_class.normalize_sst(parsed_body)
-      link_resolver = Html2rss::Scoring::LinkResolver.new(url)
-      captured = []
-
-      [Html2rss::AutoSource::Scraper::SemanticHtml, Html2rss::AutoSource::Scraper::Html].each do |klass|
-        instance = described_class.build_instance(
-          klass, parsed_body, opts:, url:, document:, link_resolver:
-        )
-        captured << [instance.instance_variable_get(:@provided_document),
-                     instance.instance_variable_get(:@provided_link_resolver)]
+    it 'shares one SST::Document across heuristic scrapers' do
+      docs = described_class::HEURISTIC_SCRAPERS.map do |klass|
+        described_class.build_instance(klass, parsed_body, opts:, url:, document:)
+                       .instance_variable_get(:@provided_document)
       end
+      expect(docs).to all(equal(document))
+    end
 
-      expect(captured.map(&:first)).to all(equal(document))
-      expect(captured.map(&:last)).to all(equal(link_resolver))
+    it 'shares one LinkResolver across heuristic scrapers' do
+      resolvers = described_class::HEURISTIC_SCRAPERS.map do |klass|
+        described_class.build_instance(klass, parsed_body, opts:, url:, document:, link_resolver:)
+                       .instance_variable_get(:@provided_link_resolver)
+      end
+      expect(resolvers).to all(equal(link_resolver))
     end
   end
 

--- a/spec/lib/html2rss/auto_source_spec.rb
+++ b/spec/lib/html2rss/auto_source_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe Html2rss::AutoSource do
   end
 
   describe '::SUFFICIENT_ARTICLE_COUNT' do
-    it 'stops later tiers after five url+title articles' do
-      expect(described_class::SUFFICIENT_ARTICLE_COUNT).to eq(5)
+    it 'defaults to twenty-five cleaned articles before skipping later tiers' do
+      expect(described_class::SUFFICIENT_ARTICLE_COUNT).to eq(25)
     end
   end
 
@@ -42,6 +42,12 @@ RSpec.describe Html2rss::AutoSource do
 
     it 'validates the default config' do
       expect(schema.call(Html2rss::AutoSource::DEFAULT_CONFIG)).to be_success
+    end
+
+    it 'allows overriding sufficient_article_count' do
+      toggled_config = Html2rss::AutoSource::DEFAULT_CONFIG.merge(sufficient_article_count: 10)
+
+      expect(schema.call(toggled_config)).to be_success
     end
 
     it 'allows toggling the json_state scraper' do
@@ -145,12 +151,13 @@ RSpec.describe Html2rss::AutoSource do
     context 'when structured scrapers already yield enough articles' do # rubocop:disable RSpec/MultipleMemoizedHelpers
       let(:config) do
         described_class::DEFAULT_CONFIG.merge(
+          sufficient_article_count: 5,
           scraper: described_class::DEFAULT_CONFIG[:scraper].transform_values { |cfg| cfg.merge(enabled: false) }
                                                             .merge(schema: { enabled: true })
         )
       end
       let(:schema_articles) do
-        Array.new(described_class::SUFFICIENT_ARTICLE_COUNT) do |index|
+        Array.new(5) do |index|
           {
             id: "schema-#{index}",
             title: "Schema Story #{index} Extra Words Here",
@@ -177,7 +184,7 @@ RSpec.describe Html2rss::AutoSource do
       end
 
       it 'skips SST and heuristic scrapers', :aggregate_failures do
-        expect(articles.size).to eq(described_class::SUFFICIENT_ARTICLE_COUNT)
+        expect(articles.size).to eq(5)
         expect(Html2rss::SST::Normalizer).not_to have_received(:call)
         expect(Html2rss::AutoSource::Scraper::SemanticHtml).not_to have_received(:new)
         expect(Html2rss::AutoSource::Scraper::Html).not_to have_received(:new)
@@ -187,6 +194,7 @@ RSpec.describe Html2rss::AutoSource do
     context 'when structured articles fail Cleanup title floor' do # rubocop:disable RSpec/MultipleMemoizedHelpers
       let(:config) do
         described_class::DEFAULT_CONFIG.merge(
+          sufficient_article_count: 5,
           scraper: described_class::DEFAULT_CONFIG[:scraper].transform_values { |cfg| cfg.merge(enabled: false) }
                                                             .merge(
                                                               schema: { enabled: true },
@@ -196,7 +204,7 @@ RSpec.describe Html2rss::AutoSource do
         )
       end
       let(:schema_articles) do
-        Array.new(described_class::SUFFICIENT_ARTICLE_COUNT) do |index|
+        Array.new(5) do |index|
           {
             id: "thin-#{index}",
             title: 'News',
@@ -206,7 +214,7 @@ RSpec.describe Html2rss::AutoSource do
         end
       end
       let(:semantic_articles) do
-        Array.new(described_class::SUFFICIENT_ARTICLE_COUNT) do |index|
+        Array.new(5) do |index|
           Html2rss::Article.new(
             id: "sem-#{index}",
             title: "Semantic Story #{index} Extra Words",
@@ -235,7 +243,7 @@ RSpec.describe Html2rss::AutoSource do
       end
 
       it 'continues into heuristics so Cleanup does not empty the feed', :aggregate_failures do
-        expect(articles.size).to eq(described_class::SUFFICIENT_ARTICLE_COUNT)
+        expect(articles.size).to eq(5)
         expect(articles.map(&:title)).to all(include('Semantic Story'))
         expect(Html2rss::AutoSource::Scraper::SemanticHtml).to have_received(:new)
       end
@@ -244,6 +252,7 @@ RSpec.describe Html2rss::AutoSource do
     context 'when SemanticHtml is sufficient before Html' do # rubocop:disable RSpec/MultipleMemoizedHelpers
       let(:config) do
         described_class::DEFAULT_CONFIG.merge(
+          sufficient_article_count: 5,
           scraper: described_class::DEFAULT_CONFIG[:scraper].transform_values { |cfg| cfg.merge(enabled: false) }
                                                             .merge(
                                                               semantic_html: { enabled: true,
@@ -258,7 +267,7 @@ RSpec.describe Html2rss::AutoSource do
         )
       end
       let(:semantic_articles) do
-        Array.new(described_class::SUFFICIENT_ARTICLE_COUNT) do |index|
+        Array.new(5) do |index|
           Html2rss::Article.new(
             id: "sem-#{index}",
             title: "Semantic Story #{index} Extra Words",
@@ -281,7 +290,7 @@ RSpec.describe Html2rss::AutoSource do
       end
 
       it 'does not instantiate Html when SemanticHtml is sufficient', :aggregate_failures do
-        expect(articles.size).to eq(described_class::SUFFICIENT_ARTICLE_COUNT)
+        expect(articles.size).to eq(5)
         expect(Html2rss::AutoSource::Scraper::Html).not_to have_received(:new)
       end
     end

--- a/spec/lib/html2rss/auto_source_spec.rb
+++ b/spec/lib/html2rss/auto_source_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe Html2rss::AutoSource do
     end
   end
 
-  describe '::SUFFICIENT_ARTICLE_COUNT' do
-    it 'defaults to twenty-five cleaned articles before skipping later tiers' do
-      expect(described_class::SUFFICIENT_ARTICLE_COUNT).to eq(25)
+  describe '::DEFAULT_LIMIT' do
+    it 'defaults to twenty-five articles' do
+      expect(described_class::DEFAULT_LIMIT).to eq(25)
     end
   end
 
@@ -44,8 +44,8 @@ RSpec.describe Html2rss::AutoSource do
       expect(schema.call(Html2rss::AutoSource::DEFAULT_CONFIG)).to be_success
     end
 
-    it 'allows overriding sufficient_article_count' do
-      toggled_config = Html2rss::AutoSource::DEFAULT_CONFIG.merge(sufficient_article_count: 10)
+    it 'allows overriding limit' do
+      toggled_config = Html2rss::AutoSource::DEFAULT_CONFIG.merge(limit: 10)
 
       expect(schema.call(toggled_config)).to be_success
     end
@@ -151,7 +151,7 @@ RSpec.describe Html2rss::AutoSource do
     context 'when structured scrapers already yield enough articles' do # rubocop:disable RSpec/MultipleMemoizedHelpers
       let(:config) do
         described_class::DEFAULT_CONFIG.merge(
-          sufficient_article_count: 5,
+          limit: 5,
           scraper: described_class::DEFAULT_CONFIG[:scraper].transform_values { |cfg| cfg.merge(enabled: false) }
                                                             .merge(schema: { enabled: true })
         )
@@ -194,7 +194,7 @@ RSpec.describe Html2rss::AutoSource do
     context 'when structured articles fail Cleanup title floor' do # rubocop:disable RSpec/MultipleMemoizedHelpers
       let(:config) do
         described_class::DEFAULT_CONFIG.merge(
-          sufficient_article_count: 5,
+          limit: 5,
           scraper: described_class::DEFAULT_CONFIG[:scraper].transform_values { |cfg| cfg.merge(enabled: false) }
                                                             .merge(
                                                               schema: { enabled: true },
@@ -252,7 +252,7 @@ RSpec.describe Html2rss::AutoSource do
     context 'when SemanticHtml is sufficient before Html' do # rubocop:disable RSpec/MultipleMemoizedHelpers
       let(:config) do
         described_class::DEFAULT_CONFIG.merge(
-          sufficient_article_count: 5,
+          limit: 5,
           scraper: described_class::DEFAULT_CONFIG[:scraper].transform_values { |cfg| cfg.merge(enabled: false) }
                                                             .merge(
                                                               semantic_html: { enabled: true,

--- a/spec/lib/html2rss/auto_source_spec.rb
+++ b/spec/lib/html2rss/auto_source_spec.rb
@@ -9,20 +9,6 @@ RSpec.describe Html2rss::AutoSource do
   let(:url) { Html2rss::Url.from_absolute('https://example.com') }
   let(:response) { Html2rss::RequestService::Response.new(body:, headers: { 'content-type' => 'text/html' }, url:) }
   let(:request_session) { nil }
-  let(:instances_for_arguments) do
-    [
-      instance_of(Nokogiri::HTML::Document),
-      {
-        url:,
-        request_session: nil,
-        body:,
-        opts: hash_including(
-          schema: hash_including(enabled: false),
-          html: hash_including(enabled: false)
-        )
-      }
-    ]
-  end
   let(:body) do
     <<~HTML
       <html>
@@ -42,6 +28,12 @@ RSpec.describe Html2rss::AutoSource do
 
     it 'is a frozen Hash' do
       expect(default_config).to be_a(Hash).and be_frozen
+    end
+  end
+
+  describe '::SUFFICIENT_ARTICLE_COUNT' do
+    it 'stops later tiers after five url+title articles' do
+      expect(described_class::SUFFICIENT_ARTICLE_COUNT).to eq(5)
     end
   end
 
@@ -114,17 +106,14 @@ RSpec.describe Html2rss::AutoSource do
     end
 
     context 'when no scrapers are found' do
-      before do
-        allow(Html2rss::AutoSource::Scraper)
-          .to receive(:instances_for)
-          .and_raise(Html2rss::AutoSource::Scraper::NoScraperFound, 'no scrapers')
-        allow(Html2rss::Log).to receive(:warn)
-      end
+      let(:body) { '<html><body></body></html>' }
+
+      before { allow(Html2rss::Log).to receive(:warn) }
 
       it 'logs a warning and returns an empty array', :aggregate_failures do
         expect(articles).to eq([])
         expect(Html2rss::Log).to have_received(:warn)
-          .with("#{described_class}: no scraper matched #{url} (no scrapers)")
+          .with(a_string_including("#{described_class}: no scraper matched #{url}"))
       end
     end
 
@@ -138,82 +127,105 @@ RSpec.describe Html2rss::AutoSource do
       end
     end
 
-    context 'with custom configuration' do
+    context 'with custom configuration that disables matching scrapers' do
       let(:config) do
         described_class::DEFAULT_CONFIG.merge(
-          scraper: { schema: { enabled: false }, html: { enabled: false } },
+          scraper: described_class::DEFAULT_CONFIG[:scraper].transform_values { |cfg| cfg.merge(enabled: false) },
           cleanup: { keep_different_domain: true, min_words_title: 5 }
-        ) { |_key, old_val, new_val| old_val.is_a?(Hash) ? old_val.merge(new_val) : new_val }
-      end
-
-      before do
-        allow(Html2rss::AutoSource::Scraper).to receive(:instances_for).and_raise(
-          Html2rss::AutoSource::Scraper::NoScraperFound, 'No scrapers found for URL.'
         )
-        articles
       end
 
-      it 'returns no articles when the custom scraper configuration matches nothing' do
+      before { allow(Html2rss::Log).to receive(:warn) }
+
+      it 'returns no articles when every scraper is disabled' do
         expect(articles).to eq([])
       end
-
-      it 'passes the overrides to the scraper lookup' do
-        expect(Html2rss::AutoSource::Scraper).to have_received(:instances_for).with(*instances_for_arguments)
-      end
     end
 
-    context 'when multiple scrapers emit overlapping articles' do # rubocop:disable RSpec/MultipleMemoizedHelpers
-      let(:first_scraper_articles) do
-        [
-          { id: 'shared-first', title: 'Shared Article Title', description: 'Same url',
-            url: 'https://example.com/shared' },
-          { id: 'first-only', title: 'First Exclusive Story', description: 'Only first', url: 'https://example.com/first' }
-        ]
+    context 'when structured scrapers already yield enough articles' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      let(:config) do
+        described_class::DEFAULT_CONFIG.merge(
+          scraper: described_class::DEFAULT_CONFIG[:scraper].transform_values { |cfg| cfg.merge(enabled: false) }
+                   .merge(schema: { enabled: true })
+        )
       end
-      let(:second_scraper_articles) do
-        [
-          { id: 'shared-second', title: 'Shared Article Title', description: 'Same url',
-            url: 'https://example.com/shared' },
-          { id: 'second-only', title: 'Second Exclusive Story', description: 'Only second', url: 'https://example.com/second' }
-        ]
+      let(:schema_articles) do
+        Array.new(described_class::SUFFICIENT_ARTICLE_COUNT) do |index|
+          {
+            id: "schema-#{index}",
+            title: "Schema Story #{index} Extra Words Here",
+            description: 'summary',
+            url: "https://example.com/schema-#{index}"
+          }
+        end
       end
-      let(:semantic_scraper_instance) do
-        instance_double(Html2rss::AutoSource::Scraper::SemanticHtml, each: first_scraper_articles.each)
-      end
-      let(:html_scraper_instance) do
-        instance_double(Html2rss::AutoSource::Scraper::Html, each: second_scraper_articles.each)
-      end
-      let(:semantic_scraper_class) do
-        class_double(Html2rss::AutoSource::Scraper::SemanticHtml,
-                     options_key: :semantic_html,
-                     new: semantic_scraper_instance)
-      end
-      let(:html_scraper_class) do
-        class_double(Html2rss::AutoSource::Scraper::Html,
-                     options_key: :html,
-                     new: html_scraper_instance)
+      let(:schema_instance) do
+        instance = instance_double(Html2rss::AutoSource::Scraper::Schema, each: schema_articles.each)
+        allow(instance).to receive(:class).and_return(Html2rss::AutoSource::Scraper::Schema)
+        instance
       end
 
       before do
-        allow(Html2rss::AutoSource::Scraper)
-          .to receive(:instances_for)
-          .and_return([semantic_scraper_instance, html_scraper_instance])
-        allow(Html2rss::AutoSource::Cleanup).to receive(:call).and_call_original
+        allow(Html2rss::AutoSource::Scraper::Schema).to receive_messages(
+          options_key: :schema,
+          articles?: true,
+          new: schema_instance
+        )
+        allow(Html2rss::SST::Normalizer).to receive(:call)
+        allow(Html2rss::AutoSource::Scraper::SemanticHtml).to receive(:new)
+        allow(Html2rss::AutoSource::Scraper::Html).to receive(:new)
+        allow(Html2rss::AutoSource::Cleanup).to receive(:call) { |arts, **| arts }
       end
 
-      it 'deduplicates aggregated articles by url' do
-        expect(articles.map { |article| article.url.to_s })
-          .to match_array(%w[https://example.com/shared https://example.com/first https://example.com/second])
+      it 'skips SST and heuristic scrapers', :aggregate_failures do
+        expect(articles.size).to eq(described_class::SUFFICIENT_ARTICLE_COUNT)
+        expect(Html2rss::SST::Normalizer).not_to have_received(:call)
+        expect(Html2rss::AutoSource::Scraper::SemanticHtml).not_to have_received(:new)
+        expect(Html2rss::AutoSource::Scraper::Html).not_to have_received(:new)
       end
     end
 
-    context 'when scraper lookup raises an error' do
-      before do
-        allow(Html2rss::AutoSource::Scraper).to receive(:instances_for).and_raise(StandardError, 'Test error')
+    context 'when SemanticHtml is sufficient before Html' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      let(:config) do
+        described_class::DEFAULT_CONFIG.merge(
+          scraper: described_class::DEFAULT_CONFIG[:scraper].transform_values { |cfg| cfg.merge(enabled: false) }
+                   .merge(
+                     semantic_html: { enabled: true, fallback_anchorless: true },
+                     html: {
+                       enabled: true,
+                       minimum_selector_frequency: 2,
+                       use_top_selectors: 5,
+                       fallback_anchorless: true
+                     }
+                   )
+        )
+      end
+      let(:semantic_articles) do
+        Array.new(described_class::SUFFICIENT_ARTICLE_COUNT) do |index|
+          Html2rss::Article.new(
+            id: "sem-#{index}",
+            title: "Semantic Story #{index} Extra Words",
+            description: 'summary',
+            url: "https://example.com/sem-#{index}",
+            scraper: Html2rss::AutoSource::Scraper::SemanticHtml
+          )
+        end
+      end
+      let(:document) { instance_double(Html2rss::SST::Document) }
+      let(:semantic_instance) do
+        instance_double(Html2rss::AutoSource::Scraper::SemanticHtml, each: semantic_articles.each, extractable?: true)
       end
 
-      it 're-raises the error' do
-        expect { articles }.to raise_error(StandardError, 'Test error')
+      before do
+        allow(Html2rss::AutoSource::Scraper).to receive(:normalize_sst).and_return(document)
+        allow(Html2rss::AutoSource::Scraper::SemanticHtml).to receive(:new).and_return(semantic_instance)
+        allow(Html2rss::AutoSource::Scraper::Html).to receive(:new)
+        allow(Html2rss::AutoSource::Cleanup).to receive(:call) { |arts, **| arts }
+      end
+
+      it 'does not instantiate Html when SemanticHtml is sufficient', :aggregate_failures do
+        expect(articles.size).to eq(described_class::SUFFICIENT_ARTICLE_COUNT)
+        expect(Html2rss::AutoSource::Scraper::Html).not_to have_received(:new)
       end
     end
 
@@ -239,6 +251,10 @@ RSpec.describe Html2rss::AutoSource do
             schema: { enabled: false },
             microdata: { enabled: true },
             json_state: { enabled: false },
+            wordpress_api: { enabled: false },
+            sitemap: { enabled: false },
+            microformats2: { enabled: false },
+            meta_oembed: { enabled: false },
             semantic_html: { enabled: false },
             html: {
               enabled: false,

--- a/spec/lib/html2rss/auto_source_spec.rb
+++ b/spec/lib/html2rss/auto_source_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Html2rss::AutoSource do
       let(:config) do
         described_class::DEFAULT_CONFIG.merge(
           scraper: described_class::DEFAULT_CONFIG[:scraper].transform_values { |cfg| cfg.merge(enabled: false) }
-                   .merge(schema: { enabled: true })
+                                                            .merge(schema: { enabled: true })
         )
       end
       let(:schema_articles) do
@@ -189,15 +189,16 @@ RSpec.describe Html2rss::AutoSource do
       let(:config) do
         described_class::DEFAULT_CONFIG.merge(
           scraper: described_class::DEFAULT_CONFIG[:scraper].transform_values { |cfg| cfg.merge(enabled: false) }
-                   .merge(
-                     semantic_html: { enabled: true, fallback_anchorless: true },
-                     html: {
-                       enabled: true,
-                       minimum_selector_frequency: 2,
-                       use_top_selectors: 5,
-                       fallback_anchorless: true
-                     }
-                   )
+                                                            .merge(
+                                                              semantic_html: { enabled: true,
+                                                                               fallback_anchorless: true },
+                                                              html: {
+                                                                enabled: true,
+                                                                minimum_selector_frequency: 2,
+                                                                use_top_selectors: 5,
+                                                                fallback_anchorless: true
+                                                              }
+                                                            )
         )
       end
       let(:semantic_articles) do

--- a/spec/lib/html2rss/auto_source_spec.rb
+++ b/spec/lib/html2rss/auto_source_spec.rb
@@ -174,7 +174,6 @@ RSpec.describe Html2rss::AutoSource do
         allow(Html2rss::SST::Normalizer).to receive(:call)
         allow(Html2rss::AutoSource::Scraper::SemanticHtml).to receive(:new)
         allow(Html2rss::AutoSource::Scraper::Html).to receive(:new)
-        allow(Html2rss::AutoSource::Cleanup).to receive(:call) { |arts, **| arts }
       end
 
       it 'skips SST and heuristic scrapers', :aggregate_failures do
@@ -182,6 +181,63 @@ RSpec.describe Html2rss::AutoSource do
         expect(Html2rss::SST::Normalizer).not_to have_received(:call)
         expect(Html2rss::AutoSource::Scraper::SemanticHtml).not_to have_received(:new)
         expect(Html2rss::AutoSource::Scraper::Html).not_to have_received(:new)
+      end
+    end
+
+    context 'when structured articles fail Cleanup title floor' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      let(:config) do
+        described_class::DEFAULT_CONFIG.merge(
+          scraper: described_class::DEFAULT_CONFIG[:scraper].transform_values { |cfg| cfg.merge(enabled: false) }
+                                                            .merge(
+                                                              schema: { enabled: true },
+                                                              semantic_html: { enabled: true,
+                                                                               fallback_anchorless: true }
+                                                            )
+        )
+      end
+      let(:schema_articles) do
+        Array.new(described_class::SUFFICIENT_ARTICLE_COUNT) do |index|
+          {
+            id: "thin-#{index}",
+            title: 'News',
+            description: 'summary',
+            url: "https://example.com/thin-#{index}"
+          }
+        end
+      end
+      let(:semantic_articles) do
+        Array.new(described_class::SUFFICIENT_ARTICLE_COUNT) do |index|
+          Html2rss::Article.new(
+            id: "sem-#{index}",
+            title: "Semantic Story #{index} Extra Words",
+            description: 'summary',
+            url: "https://example.com/sem-#{index}",
+            scraper: Html2rss::AutoSource::Scraper::SemanticHtml
+          )
+        end
+      end
+      let(:schema_instance) do
+        instance = instance_double(Html2rss::AutoSource::Scraper::Schema, each: schema_articles.each)
+        allow(instance).to receive(:class).and_return(Html2rss::AutoSource::Scraper::Schema)
+        instance
+      end
+      let(:semantic_instance) do
+        instance_double(Html2rss::AutoSource::Scraper::SemanticHtml, each: semantic_articles.each, extractable?: true)
+      end
+      let(:document) { instance_double(Html2rss::SST::Document) }
+
+      before do
+        allow(Html2rss::AutoSource::Scraper::Schema).to receive_messages(
+          options_key: :schema, articles?: true, new: schema_instance
+        )
+        allow(Html2rss::AutoSource::Scraper).to receive(:normalize_sst).and_return(document)
+        allow(Html2rss::AutoSource::Scraper::SemanticHtml).to receive(:new).and_return(semantic_instance)
+      end
+
+      it 'continues into heuristics so Cleanup does not empty the feed', :aggregate_failures do
+        expect(articles.size).to eq(described_class::SUFFICIENT_ARTICLE_COUNT)
+        expect(articles.map(&:title)).to all(include('Semantic Story'))
+        expect(Html2rss::AutoSource::Scraper::SemanticHtml).to have_received(:new)
       end
     end
 

--- a/spec/lib/html2rss/cli_spec.rb
+++ b/spec/lib/html2rss/cli_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Html2rss::CLI do
 
       expect(Html2rss).to have_received(:auto_source)
         .with('https://example.com', strategy: :browserless, items_selector: nil, max_redirects: nil,
-                                     max_requests: nil, local_file_path: nil)
+                                     max_requests: nil, local_file_path: nil, limit: nil)
     end
 
     it 'passes botasaurus strategy option to Html2rss.auto_source' do
@@ -151,7 +151,7 @@ RSpec.describe Html2rss::CLI do
 
       expect(Html2rss).to have_received(:auto_source)
         .with('https://example.com', strategy: :botasaurus, items_selector: nil, max_redirects: nil,
-                                     max_requests: nil, local_file_path: nil)
+                                     max_requests: nil, local_file_path: nil, limit: nil)
     end
 
     it 'passes the rss format option to Html2rss.auto_source' do
@@ -159,7 +159,7 @@ RSpec.describe Html2rss::CLI do
 
       expect(Html2rss).to have_received(:auto_source)
         .with('https://example.com', strategy: :auto, items_selector: nil, max_redirects: nil,
-                                     max_requests: nil, local_file_path: nil)
+                                     max_requests: nil, local_file_path: nil, limit: nil)
     end
 
     it 'passes the jsonfeed format option to Html2rss.auto_json_feed' do
@@ -167,7 +167,7 @@ RSpec.describe Html2rss::CLI do
 
       expect(Html2rss).to have_received(:auto_json_feed)
         .with('https://example.com', strategy: :auto, items_selector: nil, max_redirects: nil,
-                                     max_requests: nil, local_file_path: nil)
+                                     max_requests: nil, local_file_path: nil, limit: nil)
     end
 
     it 'prints the jsonfeed output when requested' do
@@ -182,7 +182,7 @@ RSpec.describe Html2rss::CLI do
 
       expect(Html2rss).to have_received(:auto_source)
         .with('https://example.com', strategy: :auto, items_selector: '.item', max_redirects: nil,
-                                     max_requests: nil, local_file_path: nil)
+                                     max_requests: nil, local_file_path: nil, limit: nil)
     end
 
     it 'passes the max_redirects option to Html2rss.auto_source' do
@@ -190,7 +190,7 @@ RSpec.describe Html2rss::CLI do
 
       expect(Html2rss).to have_received(:auto_source)
         .with('https://example.com', strategy: :auto, items_selector: nil, max_redirects: 8, max_requests: nil,
-                                     local_file_path: nil)
+                                     local_file_path: nil, limit: nil)
     end
 
     it 'passes the max_requests option to Html2rss.auto_source' do
@@ -198,7 +198,15 @@ RSpec.describe Html2rss::CLI do
 
       expect(Html2rss).to have_received(:auto_source)
         .with('https://example.com', strategy: :auto, items_selector: nil, max_redirects: nil, max_requests: 8,
-                                     local_file_path: nil)
+                                     local_file_path: nil, limit: nil)
+    end
+
+    it 'passes the limit option to Html2rss.auto_source' do
+      cli.invoke(:auto, ['https://example.com'], { limit: 10 })
+
+      expect(Html2rss).to have_received(:auto_source)
+        .with('https://example.com', strategy: :auto, items_selector: nil, max_redirects: nil, max_requests: nil,
+                                     local_file_path: nil, limit: 10)
     end
 
     it 'passes auto strategy option to Html2rss.auto_source' do
@@ -206,7 +214,7 @@ RSpec.describe Html2rss::CLI do
 
       expect(Html2rss).to have_received(:auto_source)
         .with('https://example.com', strategy: :auto, items_selector: nil, max_redirects: nil,
-                                     max_requests: nil, local_file_path: nil)
+                                     max_requests: nil, local_file_path: nil, limit: nil)
     end
 
     context 'when the redirect limit is hit' do
@@ -304,7 +312,8 @@ RSpec.describe Html2rss::CLI do
           items_selector: nil,
           max_redirects: nil,
           max_requests: nil,
-          local_file_path: File.expand_path('spec/fixtures/local_feed_test.html')
+          local_file_path: File.expand_path('spec/fixtures/local_feed_test.html'),
+          limit: nil
         )
       end
 
@@ -317,7 +326,8 @@ RSpec.describe Html2rss::CLI do
           items_selector: nil,
           max_redirects: nil,
           max_requests: nil,
-          local_file_path: File.expand_path('spec/fixtures/local_feed_test.html')
+          local_file_path: File.expand_path('spec/fixtures/local_feed_test.html'),
+          limit: nil
         )
       end
 

--- a/spec/lib/html2rss/config_spec.rb
+++ b/spec/lib/html2rss/config_spec.rb
@@ -491,6 +491,7 @@ RSpec.describe Html2rss::Config do
 
       let(:expected_auto_source_config) do
         {
+          sufficient_article_count: 25,
           scraper: {
             semantic_html: { enabled: true, fallback_anchorless: true }, # wasn't explicitly set -> default
             schema: { enabled: false },       # keeps the value from the config

--- a/spec/lib/html2rss/config_spec.rb
+++ b/spec/lib/html2rss/config_spec.rb
@@ -491,7 +491,7 @@ RSpec.describe Html2rss::Config do
 
       let(:expected_auto_source_config) do
         {
-          sufficient_article_count: 25,
+          limit: 25,
           scraper: {
             semantic_html: { enabled: true, fallback_anchorless: true }, # wasn't explicitly set -> default
             schema: { enabled: false },       # keeps the value from the config

--- a/spec/lib/html2rss_spec.rb
+++ b/spec/lib/html2rss_spec.rb
@@ -742,13 +742,13 @@ RSpec.describe Html2rss do
 
   describe '.auto_source' do
     let(:url) { 'https://www.welt.de/' }
-    let(:feed_return) { VCR.use_cassette('welt') { described_class.auto_source(url) } }
+    let(:feed_return) { VCR.use_cassette('welt') { described_class.auto_source(url, limit: 10_000) } }
 
     it 'returns a RSS::Rss instance with channel and items', :aggregate_failures, :slow do
       expect(feed_return).to be_a(RSS::Rss)
       expect(feed_return.channel.title).to eq 'WELT - Aktuelle Nachrichten, News, Hintergründe & Videos'
       expect(feed_return.channel.link).to eq 'https://www.welt.de/'
-      expect(feed_return.items.size >= 29).to be true
+      expect(feed_return.items.size).to eq(143)
     end
 
     context 'with items_selector' do
@@ -813,7 +813,7 @@ RSpec.describe Html2rss do
 
   describe '.auto_json_feed' do
     let(:url) { 'https://www.welt.de/' }
-    let(:feed_return) { VCR.use_cassette('welt') { described_class.auto_json_feed(url) } }
+    let(:feed_return) { VCR.use_cassette('welt') { described_class.auto_json_feed(url, limit: 10_000) } }
 
     it 'returns the channel metadata', :aggregate_failures, :slow do
       expect(feed_return).to include(
@@ -824,7 +824,7 @@ RSpec.describe Html2rss do
     end
 
     it 'returns items', :slow do
-      expect(feed_return[:items].size >= 29).to be true
+      expect(feed_return[:items].size).to eq(143)
     end
 
     context 'with items_selector' do


### PR DESCRIPTION
## What changed

- Auto-source runs scrapers in tiers (in-page structured → follow-up IO → SemanticHtml → Html) and stops once Cleanup leaves enough items; SST is built only when heuristics run.
- Shared page-scoped `LinkResolver`; `SST::Index` memos `visible_text` / `word_count`; List builds links by `tag_path` once; Cluster overlap work is capped.
- End-user `auto_source.limit` (default 25) short-circuits tiers and caps the feed; CLI `html2rss auto --limit N`.
- `Html#extractable?` uses ranked segments without full materialization; `SanitizeHtml.get` uses a bounded fragment cache; blocked-surface checks prefer raw response body.
- Perf baseline harness + `make perf-baseline` (`spec/perf/baseline-auto-source.md`).

## Why

Auto-source paid every matching scraper (and eager SST) even when structured data already filled a feed, then threw overlap away in Cleanup. Goal: cut wasted CPU/allocations with a simpler contract—no shims—while exposing a clear item count knob for CLI/YAML users.

## Risk

- **Breaking:** scrapers no longer always merge; feed item sets/order can change vs pre-tier behavior.
- Short-circuit is gated on **post-Cleanup** counts so thin titles cannot empty the feed; still possible to under-fill if no later tier recovers.
- `docs/` is gitignored here—contributor docs that still describe `instances_for` / merge-all need a separate refresh if tracked elsewhere.
- `SanitizeHtml` process-global fragment cache is fine for CLI; concurrent web hosts may want a follow-up.

## Review map

1. `lib/html2rss/auto_source.rb` — tier loop, post-Cleanup `limit`, cap via `.first(limit)`.
2. `lib/html2rss/auto_source/scraper.rb` — `SCRAPER_TIERS`, lazy SST, `build_instance`.
3. `lib/html2rss/sst/index.rb` + `node.rb` — text/word_count memo bindings.
4. `lib/html2rss/cli.rb` + `lib/html2rss.rb` — `--limit` / API `limit:` wiring.
5. `spec/lib/html2rss/auto_source_spec.rb` — short-circuit, Cleanup interaction, limit override.

## Validation

- `make ready` (1236 examples, 0 failures) after phase commits
- `make perf-baseline` / `bin/heuristic-perf-baseline` (fixture medians: wall and allocations down vs pre-change baseline)
- Targeted: `auto_source_spec`, `scraper_spec`, `cli_spec`, RuboCop/YARD on touched files