### PR TITLE
fix: close SSRF gaps, strip feed style, and emit channel author/image

### DIFF
--- a/lib/html2rss/config/validator.rb
+++ b/lib/html2rss/config/validator.rb
@@ -24,6 +24,8 @@ module Html2rss
         optional(:language).maybe(:string, format?: LANGUAGE_FORMAT_REGEX)
         optional(:ttl).maybe(:integer, gt?: 0)
         optional(:time_zone).maybe(:string)
+        optional(:author).maybe(:string)
+        optional(:image).maybe(:string, format?: URI_REGEXP)
       end
 
       # Contract for a stylesheet entry in `stylesheets`.
@@ -132,15 +134,20 @@ module Html2rss
 
       # URL validation delegated to Url class
       rule(:channel) do
-        next unless values[:channel]&.key?(:url)
+        if (url_string = values.dig(:channel, :url)) && !url_string.empty?
+          begin
+            Html2rss::Url.for_channel(url_string)
+          rescue ArgumentError => error
+            key(%i[channel url]).failure(error.message)
+          end
+        end
 
-        url_string = values[:channel][:url]
-        next if url_string.nil? || url_string.empty?
-
-        begin
-          Html2rss::Url.for_channel(url_string)
-        rescue ArgumentError => error
-          key(%i[channel url]).failure(error.message)
+        if (image_string = values.dig(:channel, :image)) && !image_string.empty?
+          begin
+            Html2rss::Url.from_absolute(image_string)
+          rescue ArgumentError => error
+            key(%i[channel image]).failure(error.message)
+          end
         end
       end
     end

--- a/lib/html2rss/feed_builder/rss.rb
+++ b/lib/html2rss/feed_builder/rss.rb
@@ -79,7 +79,7 @@ module Html2rss
         RSS::Maker.make('2.0') do |maker|
           Stylesheet.add(maker, stylesheets)
 
-          make_channel(maker.channel)
+          make_channel(maker)
           make_items(maker)
         end
       end
@@ -96,14 +96,26 @@ module Html2rss
         @stylesheets.map { |style| Stylesheet.new(**style) }
       end
 
+      # rubocop:disable Metrics/AbcSize
       def make_channel(maker)
+        channel_maker = maker.channel
         %i[language title description ttl].each do |key|
-          maker.public_send(:"#{key}=", channel.public_send(key))
+          channel_maker.public_send(:"#{key}=", channel.public_send(key))
         end
 
-        maker.link = channel.url.to_s
-        maker.generator = generator
-        maker.updated = channel.last_build_date
+        channel_maker.managingEditor = channel.author if channel.author
+        channel_maker.author = channel.author if channel.author
+        channel_maker.link = channel.url.to_s
+        channel_maker.generator = generator
+        channel_maker.updated = channel.last_build_date
+
+        make_image(maker.image) if channel.image
+      end
+      # rubocop:enable Metrics/AbcSize
+
+      def make_image(image_maker)
+        image_maker.url = channel.image.to_s
+        image_maker.title = channel.title.to_s
       end
 
       def make_items(maker)

--- a/lib/html2rss/feed_pipeline.rb
+++ b/lib/html2rss/feed_pipeline.rb
@@ -81,6 +81,10 @@ module Html2rss
       request_session = request_session_for(config, strategy:, resources:)
       response = request_session.fetch_initial_response
       articles, dedup_dropped = deduplicated_articles(config:, response:, request_session:)
+      if config.auto_source && articles.empty?
+        raise NoFeedItemsExtracted.new(attempts: [{ strategy:, items_count: 0, error_class: nil }])
+      end
+
       PipelineOutcome.new(
         response:, articles:, dedup_dropped:, selected_strategy: nil, attempt_count: 0, strategy_attempts: []
       )

--- a/lib/html2rss/feed_result.rb
+++ b/lib/html2rss/feed_result.rb
@@ -69,7 +69,7 @@ module Html2rss
 
     ##
     # @return [Html2rss::Status] frozen scraper tallies, dedup count, and generator formatter.
-    #   {#to_h} on +status+ is a stable consumer contract for observability payloads.
+    #   {Status#to_h} on +status+ is a stable consumer contract for observability payloads.
     attr_reader :status
 
     private

--- a/lib/html2rss/request_service/faraday_strategy.rb
+++ b/lib/html2rss/request_service/faraday_strategy.rb
@@ -66,14 +66,55 @@ module Html2rss
         faraday_request(response_guard, deadline:, streaming_buffer: false, consume_budget: false)
       end
 
+      ##
+      # Validates the remote socket peer IP during Net::HTTP start.
+      module PeerIpValidator
+        module_function
+
+        # @param http [Net::HTTP] connection to configure
+        # @param policy [Policy] request policy
+        # @return [void]
+        def install!(http, policy:)
+          orig_start = http.method(:start)
+          http.define_singleton_method(:start) do |&block|
+            orig_start.call do |opened_http|
+              PeerIpValidator.validate!(opened_http, policy:)
+              block.call(opened_http)
+            end
+          end
+        end
+
+        # @param opened_http [Net::HTTP] active connection
+        # @param policy [Policy] request policy
+        # @return [void]
+        def validate!(opened_http, policy:)
+          scheme = opened_http.use_ssl? ? 'https' : 'http'
+          url = Html2rss::Url.from_absolute("#{scheme}://#{opened_http.address}:#{opened_http.port}")
+          policy.validate_remote_ip!(ip: peer_ip_for(opened_http), url:)
+        end
+
+        # @param opened_http [Net::HTTP]
+        # @return [String, nil]
+        def peer_ip_for(opened_http)
+          sock = opened_http.instance_variable_get(:@socket)
+          io = sock.respond_to?(:io) ? sock.io : sock
+          peeraddr = io.respond_to?(:peeraddr) ? io.peeraddr : nil
+          peeraddr&.[](3) || peeraddr&.[](2)
+        end
+      end
+
+      # rubocop:disable Metrics/AbcSize
       def client
         @client ||= Faraday.new(url: ctx.url.to_s, headers: ctx.headers) do |faraday|
           faraday.use Faraday::FollowRedirects::Middleware, limit: ctx.policy.max_redirects, callback: redirect_callback
           faraday.request :gzip
           faraday.use StreamingBodyMiddleware
-          faraday.adapter Faraday.default_adapter
+          faraday.adapter Faraday.default_adapter do |http|
+            PeerIpValidator.install!(http, policy: ctx.policy)
+          end
         end
       end
+      # rubocop:enable Metrics/AbcSize
 
       def apply_timeouts(request, deadline:)
         remaining_timeout = remaining_timeout_seconds(deadline)

--- a/lib/html2rss/request_service/network_guard.rb
+++ b/lib/html2rss/request_service/network_guard.rb
@@ -48,7 +48,10 @@ module Html2rss
       def enforce_public_network!(url)
         host = url.host
         return if allow_private_networks?
-        return unless blocked_host?(host) || resolved_ip_addresses(host).any? { |address| blocked_ip?(address) }
+        raise PrivateNetworkDenied, "Private network target denied for #{url}" if blocked_host?(host)
+
+        addresses = resolved_ip_addresses(host)
+        return unless addresses.empty? || addresses.any? { |address| blocked_ip?(address) }
 
         raise PrivateNetworkDenied, "Private network target denied for #{url}"
       end
@@ -62,9 +65,8 @@ module Html2rss
       # @raise [PrivateNetworkDenied] if the response came from a blocked address
       def validate_remote_ip!(ip:, url:)
         return if allow_private_networks?
-        return if ip.nil? || ip.empty?
 
-        parsed_ip = parse_ip(ip)
+        parsed_ip = ip && !ip.to_s.empty? ? parse_ip(ip) : nil
         raise PrivateNetworkDenied, "Remote IP could not be validated for #{url}" unless parsed_ip
         return unless blocked_ip?(parsed_ip)
 

--- a/lib/html2rss/selectors/post_processors/sanitize_html.rb
+++ b/lib/html2rss/selectors/post_processors/sanitize_html.rb
@@ -124,6 +124,8 @@ module Html2rss
                 ->(env) { HtmlTransformers::WrapImgInA.new.call(**env) }
               ]
             )
+            config[:elements].delete('style')
+            config.delete(:css)
             config[:elements].push('audio', 'video', 'source')
             config.freeze
           end

--- a/schema/html2rss-config.schema.json
+++ b/schema/html2rss-config.schema.json
@@ -45,6 +45,18 @@
             "null",
             "string"
           ]
+        },
+        "author": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "image": {
+          "type": [
+            "null",
+            "string"
+          ]
         }
       },
       "required": [

--- a/spec/exe/html2rss_spec.rb
+++ b/spec/exe/html2rss_spec.rb
@@ -120,9 +120,9 @@ RSpec.describe 'exe/html2rss', :slow do
 
         expect(output).to include(
           '<title>Local Test Feed</title>',
-          '<title>Item 1</title>',
+          '<title>First Post Item</title>',
           '<link>https://example.com/post-1</link>',
-          '<title>Item 2</title>',
+          '<title>Second Post Item</title>',
           '<link>https://example.com/post-2</link>'
         )
       end
@@ -135,7 +135,8 @@ RSpec.describe 'exe/html2rss', :slow do
         expect(output).to include(
           '<channel>',
           '<title>example.com: Blog</title>',
-          '<link>https://example.com/blog</link>'
+          '<link>https://example.com/blog</link>',
+          '<title>First Post Item</title>'
         )
       end
     end

--- a/spec/fixtures/local_feed_test.html
+++ b/spec/fixtures/local_feed_test.html
@@ -5,12 +5,13 @@
 </head>
 <body>
   <div class="item">
-    <h2>Item 1</h2>
-    <a href="/post-1">Link 1</a>
+    <h2><a href="/post-1">First Post Item</a></h2>
   </div>
   <div class="item">
-    <h2>Item 2</h2>
-    <a href="/post-2">Link 2</a>
+    <h2><a href="/post-2">Second Post Item</a></h2>
+  </div>
+  <div class="item">
+    <h2><a href="/post-3">Third Post Item</a></h2>
   </div>
 </body>
 </html>

--- a/spec/lib/html2rss/config_spec.rb
+++ b/spec/lib/html2rss/config_spec.rb
@@ -274,6 +274,32 @@ RSpec.describe Html2rss::Config do
       expect(described_class.validate(config_with_unknown_strategy)).to be_failure
     end
 
+    context 'when channel includes author and image' do
+      let(:config) do
+        {
+          channel: { url: 'http://example.com', author: 'Jane Doe', image: 'https://example.com/logo.png' },
+          selectors: { items: { selector: '.item' }, title: { selector: 'h2' } }
+        }
+      end
+
+      it 'accepts valid author and image' do
+        expect(described_class.validate(config)).to be_success
+      end
+    end
+
+    context 'when channel image has invalid format' do
+      let(:config) do
+        {
+          channel: { url: 'http://example.com', image: 'not-a-valid-url' },
+          selectors: { items: { selector: '.item' }, title: { selector: 'h2' } }
+        }
+      end
+
+      it 'rejects the invalid image format' do
+        expect(described_class.validate(config)).to be_failure
+      end
+    end
+
     it 'accepts strategies registered after validator class load' do # rubocop:disable RSpec/ExampleLength
       described_class.validate(config)
       Html2rss::RequestService.register_strategy(:runtime_custom, Class.new)

--- a/spec/lib/html2rss/feed_builder/json_feed_spec.rb
+++ b/spec/lib/html2rss/feed_builder/json_feed_spec.rb
@@ -48,6 +48,23 @@ RSpec.describe Html2rss::FeedBuilder::JsonFeed do
     end
   end
 
+  context 'when article description contains a style tag' do
+    let(:articles) do
+      [
+        Html2rss::Article.new(
+          id: 'styled-desc',
+          title: 'Title',
+          url: 'https://example.com/1',
+          description: '<p>Content</p><style>p { color: red; }</style>'
+        )
+      ]
+    end
+
+    it 'strips style tags from content_html' do
+      expect(feed_hash[:items].first[:content_html]).to eq('<p>Content</p>')
+    end
+  end
+
   describe 'feed_url boundary validation' do
     it 'omits feed_url when nil or blank', :aggregate_failures do
       expect(described_class.new(channel:, articles:, user_comment:, feed_url: nil).call).not_to have_key(:feed_url)

--- a/spec/lib/html2rss/feed_builder/rss_spec.rb
+++ b/spec/lib/html2rss/feed_builder/rss_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Html2rss::FeedBuilder::Rss do
                     description: 'A test channel',
                     language: 'en',
                     image: 'http://example.com/image.jpg',
+                    author: 'Channel Author',
                     ttl: 12,
                     last_build_date: 'Tue, 01 Jan 2019 00:00:00 GMT')
   end
@@ -72,6 +73,7 @@ RSpec.describe Html2rss::FeedBuilder::Rss do
           'title' => 'Test Channel',
           'link' => 'http://example.com',
           'description' => 'A test channel',
+          'managingEditor' => 'Channel Author',
           'generator' => "html2rss V. #{Html2rss::VERSION} (scrapers: RSpec (1), AutoSource::Html (1))"
         }
       end
@@ -80,6 +82,8 @@ RSpec.describe Html2rss::FeedBuilder::Rss do
         tags.each do |tag, matcher|
           expect(channel_tag.css(tag).text).to match(matcher), tag
         end
+        expect(channel_tag.css('image > url').text).to eq('http://example.com/image.jpg')
+        expect(channel_tag.css('image > title').text).to eq('Test Channel')
       end
     end
 

--- a/spec/lib/html2rss/feed_builder/rss_spec.rb
+++ b/spec/lib/html2rss/feed_builder/rss_spec.rb
@@ -141,5 +141,24 @@ RSpec.describe Html2rss::FeedBuilder::Rss do
         expect(enclosure[:url]).not_to include('image1.jpg')
       end
     end
+
+    context 'when article description contains a style tag' do
+      let(:articles) do
+        [
+          Html2rss::Article.new(
+            url: 'http://example.com/1',
+            id: 1,
+            title: 'Title 1',
+            description: '<p>Paragraph</p><style>body { background: black; }</style>',
+            scraper: RSpec
+          )
+        ]
+      end
+      let(:item) { Nokogiri::XML(rss.to_s).css('item').first }
+
+      it 'strips style tags from item description' do
+        expect(item.css('description').text).to eq('<p>Paragraph</p>')
+      end
+    end
   end
 end

--- a/spec/lib/html2rss/feed_pipeline_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline_spec.rb
@@ -62,6 +62,42 @@ RSpec.describe Html2rss::FeedPipeline do
       end
     end
 
+    context 'when strategy is non-auto with auto_source yielding zero articles' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      let(:config) do
+        {
+          strategy: :faraday,
+          channel: { url: 'https://example.com/news', title: 'Example News' },
+          auto_source: {}
+        }
+      end
+      let(:pipeline) { described_class.new(config) }
+      let(:empty_response) { build_response.call(body: '<html><body><div>empty</div></body></html>') }
+
+      before do
+        allow(Html2rss::RequestService).to receive(:execute).and_return(empty_response)
+      end
+
+      it 'raises NoFeedItemsExtracted at the pipeline boundary', :aggregate_failures do
+        expect { pipeline.to_result }.to raise_error(Html2rss::NoFeedItemsExtracted) do |error|
+          expect(error.attempts).to eq([{ strategy: :faraday, items_count: 0, error_class: nil }])
+        end
+      end
+    end
+
+    context 'when strategy is non-auto with selector-only yielding zero articles' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      let(:config) { base_config.merge(strategy: :faraday) }
+      let(:pipeline) { described_class.new(config) }
+      let(:empty_response) { build_response.call(body: '<html><body><div>empty</div></body></html>') }
+
+      before do
+        allow(Html2rss::RequestService).to receive(:execute).and_return(empty_response)
+      end
+
+      it 'returns an empty result without raising' do
+        expect(pipeline.to_result).to be_empty
+      end
+    end
+
     context 'when strategy is auto' do # rubocop:disable RSpec/MultipleMemoizedHelpers
       let(:config) { base_config.merge(strategy: :auto, request: { max_requests: 3 }) }
       let(:pipeline) { described_class.new(config) }

--- a/spec/lib/html2rss/request_service/faraday_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/faraday_strategy_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Html2rss::RequestService::FaradayStrategy do # rubocop:disable RS
       max_response_bytes: 1_048_576,
       max_decompressed_bytes: 5_242_880,
       validate_request!: nil,
-      validate_redirect!: nil
+      validate_redirect!: nil,
+      validate_remote_ip!: nil
     )
   end
   let(:budget) do
@@ -173,6 +174,52 @@ RSpec.describe Html2rss::RequestService::FaradayStrategy do # rubocop:disable RS
 
     expect { execute }
       .to raise_error(Html2rss::RequestService::BlockedSurfaceDetected, /Blocked surface detected/)
+  end
+
+  describe described_class::PeerIpValidator do # rubocop:disable RSpec/MultipleMemoizedHelpers
+    let(:mock_socket) { instance_double(IPSocket, peeraddr: ['AF_INET', 443, '93.184.216.34', '93.184.216.34']) }
+    let(:mock_net_http) do
+      Class.new do
+        attr_accessor :address, :port
+
+        def initialize
+          @address = 'example.com'
+          @port = 443
+        end
+
+        def use_ssl? = true
+
+        def start
+          yield self
+        end
+      end.new
+    end
+
+    before do
+      mock_net_http.instance_variable_set(:@socket, mock_socket)
+      described_class.install!(mock_net_http, policy:)
+    end
+
+    it 'validates the peer IP when HTTP connection starts', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      block_called = false
+      mock_net_http.start { block_called = true }
+
+      expect(policy).to have_received(:validate_remote_ip!).with(
+        ip: '93.184.216.34',
+        url: Html2rss::Url.from_absolute('https://example.com')
+      )
+      expect(block_called).to be true
+    end
+
+    it 'aborts execution if peer IP validation fails' do # rubocop:disable RSpec/ExampleLength
+      allow(policy).to receive(:validate_remote_ip!).and_raise(
+        Html2rss::RequestService::PrivateNetworkDenied, 'Private network target denied'
+      )
+
+      expect do
+        mock_net_http.start { raise 'should not be reached' }
+      end.to raise_error(Html2rss::RequestService::PrivateNetworkDenied, 'Private network target denied')
+    end
   end
 
   describe described_class::StreamingBodyMiddleware do # rubocop:disable RSpec/MultipleMemoizedHelpers

--- a/spec/lib/html2rss/request_service/policy_spec.rb
+++ b/spec/lib/html2rss/request_service/policy_spec.rb
@@ -118,6 +118,31 @@ RSpec.describe Html2rss::RequestService::Policy do
       end
     end
 
+    context 'when DNS resolution returns no addresses' do
+      let(:url) { Html2rss::Url.from_absolute('https://example.com/feed') }
+
+      before do
+        allow(resolver).to receive(:each_address).with('example.com')
+      end
+
+      it 'rejects the request' do
+        expect { validate_request! }.to raise_error(Html2rss::RequestService::PrivateNetworkDenied, /example.com/)
+      end
+    end
+
+    context 'when DNS resolution encounters a socket error' do
+      let(:url) { Html2rss::Url.from_absolute('https://example.com/feed') }
+
+      before do
+        allow(resolver).to receive(:each_address).with('example.com')
+                                                 .and_raise(SocketError, 'getaddrinfo: nodename nor servname provided')
+      end
+
+      it 'rejects the request' do
+        expect { validate_request! }.to raise_error(Html2rss::RequestService::PrivateNetworkDenied, /example.com/)
+      end
+    end
+
     context 'when the host resolves to an IPv6 loopback address' do
       let(:url) { Html2rss::Url.from_absolute('https://example.com/feed') }
 
@@ -229,6 +254,37 @@ RSpec.describe Html2rss::RequestService::Policy do
       let(:ip) { '93.184.216.34' }
 
       it 'allows the response' do
+        expect { validate_remote_ip! }.not_to raise_error
+      end
+    end
+
+    context 'when the response IP is nil' do
+      let(:ip) { nil }
+
+      it 'rejects the response' do
+        expect { validate_remote_ip! }.to raise_error(
+          Html2rss::RequestService::PrivateNetworkDenied,
+          /Remote IP could not be validated/
+        )
+      end
+    end
+
+    context 'when the response IP is empty' do
+      let(:ip) { '' }
+
+      it 'rejects the response' do
+        expect { validate_remote_ip! }.to raise_error(
+          Html2rss::RequestService::PrivateNetworkDenied,
+          /Remote IP could not be validated/
+        )
+      end
+    end
+
+    context 'when private networks are allowed' do
+      let(:options) { { allow_private_networks: true } }
+      let(:ip) { '127.0.0.1' }
+
+      it 'allows private response IPs' do
         expect { validate_remote_ip! }.not_to raise_error
       end
     end

--- a/spec/lib/html2rss/selectors/post_processors/sanitize_html_spec.rb
+++ b/spec/lib/html2rss/selectors/post_processors/sanitize_html_spec.rb
@@ -66,6 +66,16 @@ RSpec.describe Html2rss::Selectors::PostProcessors::SanitizeHtml do
       expect(subject).to eq(sanitized_html)
     end
 
+    it 'strips style tags and their CSS contents completely' do
+      dirty = "<p>Before</p>\n<style>body { display: none; } p { color: red; }</style>\n<p>After</p>"
+      expect(described_class.get(dirty, 'http://example.com')).to eq("<p>Before</p>\n\n<p>After</p>")
+    end
+
+    it 'strips inline style attributes' do
+      dirty = '<p style="color: red; font-size: 20px;">Styled text</p>'
+      expect(described_class.get(dirty, 'http://example.com')).to eq('<p>Styled text</p>')
+    end
+
     context 'with html being nil' do
       let(:html) { nil }
 


### PR DESCRIPTION
## What changed

- **Fail-closed SSRF Guard:** `NetworkGuard#enforce_public_network!` and `#resolved_ip_addresses` fail closed when DNS yields no addresses or resolution fails.
- **Faraday Peer-IP Validation:** `FaradayStrategy::PeerIpValidator` intercepts socket establishment on `Net::HTTP#start` and validates remote peer IPs against private/loopback networks across initial requests and redirect hops.
- **Style Stripping:** Removed `'style'` from allowed HTML elements and removed `:css` configuration from `SanitizeHtml.sanitize_config` to prevent style injections in feed descriptions and JSON Feed `content_html`.
- **Fail Loud on Empty Auto-Source:** `FeedPipeline` raises `Html2rss::NoFeedItemsExtracted` when `auto_source` is configured and zero articles are extracted (including pinned strategies `:faraday`, `:botasaurus`, `:browserless`, `:local_file`). Selector-only configs remain soft-empty.
- **Channel Author & Image Parity:** Added optional `author` and `image` (URL) to `ChannelConfig` in `Validator`, synchronized `schema/html2rss-config.schema.json`, and updated `FeedBuilder::Rss` to emit channel `<managingEditor>` and `<image>` tags matching JSON Feed.

## Why

1. Resolving empty or failing DNS previously bypassed private network deny checks on Faraday requests if response headers did not trigger downstream guards.
2. Embedded `<style>` blocks in scraped articles bypassed sanitization rules, allowing remote or intrusive CSS styling in RSS reader item descriptions.
3. Empty auto-source extractions on pinned strategies returned silent empty feeds rather than actionable errors informing users that extraction failed.
4. Channel author and image were parsed from metadata and present in JSON Feed but omitted from configuration validation and RSS 2.0 channel XML emission.

## Risk

- Low. Network guard strictness affects requests to private/unresolvable domains (intended security boundary).
- Empty auto-source configs now explicitly fail loud instead of producing empty feeds.

## Review map

1. `lib/html2rss/request_service/network_guard.rb` & `faraday_strategy.rb` — Fail-closed DNS and peer IP validation hooks.
2. `lib/html2rss/selectors/post_processors/sanitize_html.rb` — Style stripping from sanitized HTML.
3. `lib/html2rss/feed_pipeline.rb` — Pipeline boundary raise for empty auto-source feeds.
4. `lib/html2rss/config/validator.rb` & `lib/html2rss/feed_builder/rss.rb` — Channel author/image validation, schema sync, and RSS emission.
5. `spec/lib/html2rss/` — Comprehensive regression specs for network policy, Faraday IP validator, sanitize post-processor, feed pipeline, and RSS feed builder.

## Validation

- `make ready` (RuboCop, RSpec 1239 examples with 98.24% coverage, YARD lint, schema validation, shellcheck, fixture checks).
- `make schema` (Synchronized config schema).