### PR TITLE
feat(request): support header/cookie forwarding and multi-tier botasaurus options

### DIFF
--- a/lib/html2rss/config/validator.rb
+++ b/lib/html2rss/config/validator.rb
@@ -64,18 +64,22 @@ module Html2rss
       BotasaurusRequestConfig = Dry::Schema.Params do
         config.validate_keys = true
 
+        optional(:execution_mode).filled(:string, included_in?: %w[auto request browser])
         optional(:navigation_mode).filled(:string, included_in?: %w[auto get google_get google_get_bypass])
         optional(:max_retries).filled(:integer, gteq?: 0, lteq?: 3)
         optional(:wait_for_selector).maybe(:string)
         optional(:wait_timeout_seconds).filled(:integer, gt?: 0)
         optional(:block_images).filled(:bool)
         optional(:block_images_and_css).filled(:bool)
+        optional(:block_trackers).filled(:bool)
         optional(:wait_for_complete_page_load).filled(:bool)
         optional(:headless).filled(:bool)
         optional(:proxy).filled(:string)
         optional(:user_agent).filled(:string)
         optional(:window_size).value(:array, min_size?: 2, max_size?: 2).each(:integer, gt?: 0)
         optional(:lang).filled(:string)
+        optional(:cookies).hash
+        optional(:headers).hash
       end
 
       # Contract for the top-level `request` section.

--- a/lib/html2rss/request_service/botasaurus_contract.rb
+++ b/lib/html2rss/request_service/botasaurus_contract.rb
@@ -64,7 +64,7 @@ module Html2rss
 
         # @return [Boolean] true when upstream returned non-200 or an error payload
         def upstream_failure?
-          status != 200 || error_message?
+          transport_status != 200 || status != 200 || error_message?
         end
 
         # @return [String] normalized challenge error message

--- a/lib/html2rss/request_service/botasaurus_contract.rb
+++ b/lib/html2rss/request_service/botasaurus_contract.rb
@@ -9,6 +9,7 @@ module Html2rss
     class BotasaurusContract
       # Default Botasaurus scrape options when no explicit config is provided.
       DEFAULT_OPTIONS = {
+        execution_mode: 'auto',
         navigation_mode: 'auto',
         max_retries: 1,
         headless: false
@@ -16,23 +17,28 @@ module Html2rss
 
       # Allowlisted request.botasaurus keys forwarded to upstream.
       OPTION_KEYS = %i[
+        execution_mode
         navigation_mode
         max_retries
         wait_for_selector
         wait_timeout_seconds
         block_images
         block_images_and_css
+        block_trackers
         wait_for_complete_page_load
         headless
         proxy
         user_agent
         window_size
         lang
+        headers
+        cookies
       ].freeze
 
       # Allowlisted upstream response keys exposed as Response#transport_meta.
       META_KEYS = %w[
         request_id strategy_used render_ms challenge_detected blocked_detected attempts error_category
+        execution_tier detected_challenge
       ].freeze
 
       # Remaining seconds at or below which Botasaurus retries are disabled.
@@ -122,29 +128,38 @@ module Html2rss
 
       ##
       # @param url [Html2rss::Url] canonical URL to scrape
+      # @param headers [Hash] request headers from context
       # @param options [Hash] validated request.botasaurus options
       # @param remaining_timeout_seconds [Numeric, nil] shared request budget remainder for clamps
+      # @option options [String] :execution_mode
       # @option options [String] :navigation_mode
       # @option options [Integer] :max_retries
       # @option options [String] :wait_for_selector
       # @option options [Integer] :wait_timeout_seconds
       # @option options [Boolean] :block_images
       # @option options [Boolean] :block_images_and_css
+      # @option options [Boolean] :block_trackers
       # @option options [Boolean] :wait_for_complete_page_load
       # @option options [Boolean] :headless
       # @option options [String] :proxy
       # @option options [String] :user_agent
       # @option options [Array<Integer>] :window_size
       # @option options [String] :lang
-      def initialize(url:, options: {}, remaining_timeout_seconds: nil)
+      # @option options [Hash] :cookies
+      # @option options [Hash] :headers
+      def initialize(url:, headers: {}, options: {}, remaining_timeout_seconds: nil)
         @url = url
+        @headers = headers
         @options = options
         @remaining_timeout_seconds = remaining_timeout_seconds
       end
 
       # @return [Hash] payload for POST /scrape (budget-clamped when remaining is known)
       def request_payload
-        DEFAULT_OPTIONS.merge(filtered_options).merge(url: url.to_s).then { clamp_for_budget(_1) }
+        payload = DEFAULT_OPTIONS.merge(filtered_options)
+        forwarded_headers = merged_headers
+        payload[:headers] = forwarded_headers if forwarded_headers&.any?
+        payload.merge(url: url.to_s).then { clamp_for_budget(_1) }
       end
 
       # @param transport_response [Faraday::Response] upstream HTTP response
@@ -161,7 +176,14 @@ module Html2rss
 
       private
 
-      attr_reader :url, :options, :remaining_timeout_seconds
+      attr_reader :url, :headers, :options, :remaining_timeout_seconds
+
+      def merged_headers
+        explicit = options[:headers] || {}
+        base = headers.is_a?(Hash) ? headers : {}
+        merged = base.merge(explicit).transform_keys(&:to_s).compact
+        merged.empty? ? nil : merged
+      end
 
       def filtered_options
         OPTION_KEYS.each_with_object({}) do |key, normalized|

--- a/lib/html2rss/request_service/botasaurus_strategy.rb
+++ b/lib/html2rss/request_service/botasaurus_strategy.rb
@@ -55,6 +55,7 @@ module Html2rss
       def contract
         @contract ||= BotasaurusContract.new(
           url: ctx.url,
+          headers: ctx.headers,
           options: ctx.request.fetch(:botasaurus, {}),
           remaining_timeout_seconds: attempt_timeout_seconds
         )

--- a/schema/html2rss-config.schema.json
+++ b/schema/html2rss-config.schema.json
@@ -591,6 +591,15 @@
         "botasaurus": {
           "type": "object",
           "properties": {
+            "execution_mode": {
+              "type": "string",
+              "minLength": 1,
+              "enum": [
+                "auto",
+                "request",
+                "browser"
+              ]
+            },
             "navigation_mode": {
               "type": "string",
               "minLength": 1,
@@ -634,6 +643,12 @@
                 "type": "null"
               }
             },
+            "block_trackers": {
+              "type": "boolean",
+              "not": {
+                "type": "null"
+              }
+            },
             "wait_for_complete_page_load": {
               "type": "boolean",
               "not": {
@@ -666,6 +681,12 @@
             "lang": {
               "type": "string",
               "minLength": 1
+            },
+            "cookies": {
+              "type": "object"
+            },
+            "headers": {
+              "type": "object"
             }
           },
           "required": []

--- a/spec/lib/html2rss/config/schema_spec.rb
+++ b/spec/lib/html2rss/config/schema_spec.rb
@@ -100,11 +100,16 @@ RSpec.describe Html2rss::Config::Schema do
       min_window_size = window_size['minItems'] || window_size.dig('items', 'minLength')
       max_window_size = window_size['maxItems'] || window_size.dig('items', 'maxLength')
 
+      expect(botasaurus.fetch('execution_mode').fetch('enum'))
+        .to contain_exactly('auto', 'request', 'browser')
       expect(botasaurus.fetch('navigation_mode').fetch('enum'))
         .to contain_exactly('auto', 'get', 'google_get', 'google_get_bypass')
       expect(botasaurus.dig('max_retries', 'minimum')).to eq(0)
       expect(botasaurus.dig('max_retries', 'maximum')).to eq(3)
       expect(botasaurus.dig('wait_timeout_seconds', 'exclusiveMinimum')).to eq(0)
+      expect(botasaurus).to have_key('block_trackers')
+      expect(botasaurus).to have_key('cookies')
+      expect(botasaurus).to have_key('headers')
       expect(min_window_size).to eq(2)
       expect(max_window_size).to eq(2)
     end

--- a/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
@@ -96,6 +96,7 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
       expect(headers).to eq('Content-Type' => 'application/json')
       expect(JSON.parse(body)).to eq(
         'url' => 'https://example.com/',
+        'execution_mode' => 'auto',
         'navigation_mode' => 'auto',
         'max_retries' => 1,
         'headless' => false,
@@ -103,44 +104,65 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
       )
     end
 
-    context 'when request includes optional botasaurus fields' do
+    context 'when request includes optional botasaurus fields and headers' do
+      let(:ctx) do
+        Html2rss::RequestService::Context.new(
+          url: 'https://example.com',
+          headers: { 'Accept-Language' => 'en-US,en;q=0.9', 'X-Context-Header' => 'BaseVal' },
+          request: request_config,
+          policy:,
+          budget:
+        )
+      end
       let(:request_config) do
         {
           botasaurus: {
+            execution_mode: 'request',
             navigation_mode: 'google_get_bypass',
             max_retries: 3,
             wait_for_selector: 'h1',
             wait_timeout_seconds: 15,
             block_images: true,
             block_images_and_css: false,
+            block_trackers: true,
             wait_for_complete_page_load: true,
             headless: true,
             proxy: 'http://proxy.local:8080',
             user_agent: 'Agent/1.0',
             window_size: [1920, 1080],
             lang: 'en-US',
+            cookies: { 'session' => 'test-session-token' },
+            headers: { 'X-Override' => 'Overridden' },
             ignored_key: 'drop-me'
           }
         }
       end
 
-      it 'forwards allowlisted fields and drops unknown keys', :aggregate_failures do
+      it 'forwards allowlisted fields, merged headers, cookies, and drops unknown keys', :aggregate_failures do
         execute
 
         payload = JSON.parse(captured_post_args.first.fetch(1))
         expect(payload).to include(
+          'execution_mode' => 'request',
           'navigation_mode' => 'google_get_bypass',
           'max_retries' => 3,
           'wait_for_selector' => 'h1',
           'wait_timeout_seconds' => 15,
           'block_images' => true,
           'block_images_and_css' => false,
+          'block_trackers' => true,
           'wait_for_complete_page_load' => true,
           'headless' => true,
           'proxy' => 'http://proxy.local:8080',
           'user_agent' => 'Agent/1.0',
           'window_size' => [1920, 1080],
-          'lang' => 'en-US'
+          'lang' => 'en-US',
+          'cookies' => { 'session' => 'test-session-token' },
+          'headers' => {
+            'Accept-Language' => 'en-US,en;q=0.9',
+            'X-Context-Header' => 'BaseVal',
+            'X-Override' => 'Overridden'
+          }
         )
         expect(payload).not_to have_key('ignored_key')
       end


### PR DESCRIPTION
## What changed

- **Contract Serialization**: Updated `BotasaurusContract` to serialize `execution_mode`, `block_trackers`, `cookies`, and merged `headers` into `/scrape` payloads.
- **Header Forwarding**: Forwarded `ctx.headers` and config-specified headers through `BotasaurusStrategy` to `BotasaurusContract`.
- **Validation & Schema**: Added `execution_mode` (enum: `auto`, `request`, `browser`), `block_trackers` (boolean), `cookies` (hash), and `headers` (hash) to `BotasaurusRequestConfig`.
- **Schema Artifact**: Regenerated and synchronized `schema/html2rss-config.schema.json`.
- **Telemetry & Error Classification**: Exposed `execution_tier` and `detected_challenge` in `Response#transport_meta`, and enforced `transport_status != 200` in `ParsedResponse#upstream_failure?`.

## Why

Upstream scraping pipelines previously dropped request headers and session cookies when routing to Botasaurus. Supporting `execution_mode` allows html2rss to leverage Botasaurus's fast anti-detect HTTP tier for sitemaps, JSON APIs, and simple HTML pages.

## Risk

- Low — defaults (`execution_mode: 'auto'`, `block_trackers: true`) preserve full compatibility with existing feed configurations.

## Review map

1. `lib/html2rss/request_service/botasaurus_contract.rb` — Contract serialization, header merging, and response mapping.
2. `lib/html2rss/request_service/botasaurus_strategy.rb` — Context header forwarding.
3. `lib/html2rss/config/validator.rb` & `schema.rb` — Schema validation and export.
4. `spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb` — RSpec contract test suite.

## Validation

- `make ready` (1244 RSpec examples / 0 failures, 306 RuboCop files / 0 offenses, 100% YARD documentation, valid schemas & fixtures, clean ShellCheck).
- Downstream verification: 286 RSpec examples in `html2rss-web` / 0 failures; 56 YAML configs in `html2rss-configs` validated.