### PR TITLE
feat(capture): add Html2rss.capture for automatic config derivation

### DIFF
--- a/docs/capture.md
+++ b/docs/capture.md
@@ -1,0 +1,78 @@
+# Capture — Automatic Feed Config Derivation
+
+The `Html2rss.capture` method (and its CLI alias `html2rss capture`) analyzes
+any URL through the auto-source pipeline and produces a reusable feed config
+hash with derived CSS selectors.
+
+## Use Case
+
+Speed up writing feed configs. Instead of manually inspecting HTML to craft CSS
+selectors, point `capture` at your target URL and let it produce a first draft.
+Tweak the output as needed.
+
+## Gem API
+
+```ruby
+config = Html2rss.capture('https://example.com/articles')
+
+# config contains a hash with :channel and :selectors keys:
+# {
+#   channel: { url: "https://example.com/articles", time_zone: "UTC" },
+#   selectors: {
+#     items: { selector: "div.post" },
+#     title: { selector: "h2 > a" },
+#     link: { selector: "a.more", extractor: "href" },
+#     description: { selector: "div.excerpt" }
+#   }
+# }
+
+# Save to YAML for reuse
+File.write('my-feed.yml', config.to_yaml)
+
+# Use immediately
+feed = Html2rss.feed(config)
+```
+
+### Options
+
+```ruby
+# Pin a specific request strategy
+Html2rss.capture('https://spa-site.com', strategy: :botasaurus)
+
+# Provide a CSS selector hint for items
+Html2rss.capture('https://example.com', items_selector: '.article-card')
+```
+
+## CLI
+
+```bash
+# Print a reusable YAML config
+html2rss capture https://example.com/articles
+
+# With Botasaurus strategy
+html2rss capture https://example.com --strategy botasaurus
+
+# Save to file
+html2rss capture https://example.com/articles > my-feed.yml
+
+# Read from a local HTML file
+html2rss capture https://example.com --input ./page.html
+```
+
+## How It Works
+
+1. **Request** — fetches the page using the configured strategy
+2. **Discover** — runs the AutoSource pipeline to extract articles
+3. **Analyze** — normalizes the page into an SST document, segments it, and
+   maps segment positions back to extracted articles
+4. **Derive** — builds CSS selectors from SST tag_paths for items, title, link,
+   and description attributes
+5. **Assemble** — returns a complete config hash ready for serialization
+
+## Limitations
+
+- Selector quality depends on the page structure and auto-source detection.
+  Complex layouts may produce imperfect selectors that need manual adjustment.
+- The capture only derives items, title, link, and description selectors.
+  Additional attributes (author, published_at, categories, enclosures) can be
+  added manually.

--- a/lib/html2rss.rb
+++ b/lib/html2rss.rb
@@ -118,6 +118,33 @@ module Html2rss
                                        local_file_path:, limit:))
   end
 
+  ##
+  # Analyzes a URL and produces a reusable YAML-ready feed config hash.
+  #
+  # Uses auto-source discovery to extract articles, then derives CSS selectors
+  # from the structural analysis.
+  #
+  # @param url [String] source page URL
+  # @param strategy [Symbol] request strategy (+:auto+, +:faraday+, +:botasaurus+)
+  # @param items_selector [String, nil] optional CSS selector hint for items
+  # @param max_redirects [Integer, nil] optional redirect limit override
+  # @param max_requests [Integer, nil] optional request budget override
+  # @param limit [Integer, nil] max articles to keep
+  # @return [Hash] feed config hash with +:channel+ and +:selectors+
+  def self.capture(url,
+                   strategy: :auto,
+                   items_selector: nil,
+                   max_redirects: nil,
+                   max_requests: nil,
+                   limit: nil)
+    Capture.build(url,
+                  strategy:,
+                  items_selector:,
+                  max_redirects:,
+                  max_requests:,
+                  limit:).config
+  end
+
   # rubocop:enable Metrics/ParameterLists
 
   # rubocop:disable ThreadSafety/ClassInstanceVariable

--- a/lib/html2rss/capture.rb
+++ b/lib/html2rss/capture.rb
@@ -1,0 +1,259 @@
+# frozen_string_literal: true
+
+module Html2rss
+  ##
+  # Analyzes a URL and produces a reusable feed config hash with derived CSS selectors.
+  #
+  # Uses the auto-source pipeline to extract articles, then traces back through
+  # SST segments to build items + attribute selectors suitable for a static feed config.
+  class Capture
+    ##
+    # Result of a capture operation.
+    # @!attribute config [Hash] feed config hash with +:channel+ and +:selectors+
+    # @!attribute articles_count [Integer] number of articles extracted
+    # @!attribute channel_title [String] derived channel title
+    CaptureResult = Data.define(:config, :articles_count, :channel_title)
+
+    class << self
+      ##
+      # Analyzes a URL and builds a reusable feed config.
+      #
+      # @param url [String] source page URL
+      # @param strategy [Symbol] request strategy (+:auto+, +:faraday+, +:botasaurus+)
+      # @param options [Hash] additional options
+      # @option options [String, nil] :items_selector optional selector hint
+      # @option options [Integer, nil] :max_redirects optional redirect limit override
+      # @option options [Integer, nil] :max_requests optional request budget override
+      # @option options [Integer, nil] :limit max articles to keep
+      # @return [CaptureResult]
+      def build(url, strategy: :auto, **options)
+        new(url, strategy:, **options).build
+      end
+    end
+
+    ##
+    # @param url [String] source page URL
+    # @param strategy [Symbol] request strategy
+    # @param options [Hash] additional options
+    def initialize(url, strategy: :auto, **options)
+      @url = url
+      @strategy = strategy
+      @items_selector_hint = options.delete(:items_selector)
+      @max_redirects = options.delete(:max_redirects)
+      @max_requests = options.delete(:max_requests)
+      @limit = options.delete(:limit)
+    end
+
+    ##
+    # Runs the capture pipeline.
+    #
+    # @return [CaptureResult]
+    def build
+      response = fetch_response
+      articles = extract_articles(response)
+      selectors = derive_selectors(response, articles)
+
+      config = {
+        channel: build_channel(response),
+        selectors: selectors.empty? ? nil : selectors
+      }.compact
+
+      CaptureResult.new(
+        config:,
+        articles_count: articles.size,
+        channel_title: channel_title_from(response)
+      )
+    end
+
+    private
+
+    def raw_config
+      @raw_config ||= build_raw_config
+    end
+
+    def build_raw_config
+      Config.auto_source_config(
+        url: @url,
+        items_selector: @items_selector_hint,
+        request_controls: Config::RequestControls.from_shortcut(
+          strategy: @strategy,
+          max_redirects: @max_redirects,
+          max_requests: @max_requests
+        ),
+        limit: @limit
+      ).tap do |config|
+        config[:strategy] = resolve_strategy(config[:strategy] || @strategy)
+      end
+    end
+
+    def resolve_strategy(strategy)
+      plan = FeedPipeline::StrategyPlan.resolve(strategy)
+      plan.is_a?(FeedPipeline::StrategyPlan::Auto) ? :faraday : plan.strategy
+    end
+
+    def fetch_response
+      config = Config.from_hash(raw_config)
+      resources = FeedPipeline::RuntimePolicy.resources_for(config)
+      session = RequestSession.build(
+        config:,
+        strategy: config.strategy,
+        budget: resources.budget,
+        policy: resources.policy
+      )
+      session.fetch_initial_response
+    end
+
+    def extract_articles(response)
+      auto_source_opts = raw_config[:auto_source] || AutoSource::DEFAULT_CONFIG
+      AutoSource.new(response, auto_source_opts).articles
+    rescue AutoSource::Scraper::NoScraperFound
+      []
+    end
+
+    def derive_selectors(response, articles)
+      return {} if articles.empty? || !response.html_response?
+
+      sst = normalize_sst(response)
+      return {} unless sst
+
+      segments = discover_segments(sst)
+      return {} if segments.empty?
+
+      matched = match_segments_to_articles(segments, articles)
+      return {} if matched.empty?
+
+      build_selector_hash(matched, sst)
+    rescue ArgumentError
+      {}
+    end
+
+    def normalize_sst(response)
+      SST::Normalizer.call(response.body)
+    end
+
+    def discover_segments(sst)
+      link_resolver = Scoring::LinkResolver.new(@url)
+
+      AutoSource::Segmenter.call(
+        sst,
+        base_url: @url,
+        strategy: :list,
+        permit_unanchored: false,
+        link_resolver:
+      )
+    end
+
+    def match_segments_to_articles(segments, articles)
+      articles_by_url = articles.each_with_object({}) do |article, hash|
+        url_str = article.url.to_s
+        hash[url_str] = article unless url_str.empty?
+      end
+
+      segments.filter_map do |segment|
+        next unless segment.primary_link
+
+        article = find_matching_article(segment, articles_by_url)
+        { segment:, article: } if article
+      end
+    end
+
+    def find_matching_article(segment, articles_by_url)
+      href = segment.primary_link.attrs.href.to_s
+      return articles_by_url.values.find { |a| a.title == title_from_segment(segment) } if href.empty?
+
+      resolved = Url.from_relative(href, @url)
+      articles_by_url[resolved.to_s] || articles_by_url.values.find { |a| fuzzy_url_match?(a.url, resolved) }
+    end
+
+    def fuzzy_url_match?(article_url, resolved)
+      article_url.to_s.end_with?(resolved.path.to_s)
+    rescue StandardError
+      false
+    end
+
+    def title_from_segment(segment)
+      segment.root_node.visible_text.to_s.strip
+    end
+
+    def build_selector_hash(matched, sst)
+      items_sel = items_selector(matched)
+      return {} unless items_sel
+
+      first = matched.first
+      root = first[:segment].root_node
+
+      attrs = {}.tap do |a|
+        a[:title] = title_selector(root)
+        a[:link] = link_selector(first[:segment])
+        a[:description] = description_selector(root, first[:segment])
+      end.compact
+
+      { items: { selector: items_sel }, **attrs }
+    end
+
+    def items_selector(matched)
+      paths = matched.map { |m| m[:segment].root_node.tag_path }
+      common = common_path_prefix(paths)
+      return paths.first.tr('/', ' ').strip.gsub(' ', ' > ') if common.empty?
+
+      common.tr('/', ' ').strip.gsub(' ', ' > ')
+    end
+
+    def common_path_prefix(paths)
+      return '' if paths.empty?
+
+      segments = paths.map { |p| p.split('/').reject(&:empty?) }
+      prefix = segments.first
+      segments.each do |seg|
+        i = 0
+        while i < prefix.length && i < seg.length && prefix[i] == seg[i]
+          i += 1
+        end
+        prefix = prefix[0...i]
+      end
+      "/#{prefix.join('/')}"
+    end
+
+    def title_selector(root)
+      heading = root.find(&:heading?)
+      return css_for_path(heading.tag_path, root.tag_path) if heading
+
+      link = root.find { |n| n.link? && n.visible_text.to_s.strip.length > 3 }
+      return css_for_path(link.tag_path, root.tag_path) if link
+
+      nil
+    end
+
+    def link_selector(segment)
+      return nil unless segment.primary_link
+
+      relative = css_for_path(segment.primary_link.tag_path, segment.root_node.tag_path)
+      { selector: relative, extractor: 'href' }
+    end
+
+    def description_selector(root, segment)
+      relative = css_for_path(root.tag_path, segment.root_node.tag_path)
+      { selector: relative }
+    end
+
+    def css_for_path(full_path, root_path)
+      relative = full_path.delete_prefix(root_path)
+      return '.' if relative.empty?
+
+      relative.split('/').reject(&:empty?).join(' > ')
+    end
+
+    def build_channel(response)
+      {
+        url: @url,
+        time_zone: 'UTC'
+      }.compact
+    end
+
+    def channel_title_from(response)
+      Channel.from_response(response).title
+    rescue StandardError
+      nil
+    end
+  end
+end

--- a/lib/html2rss/cli.rb
+++ b/lib/html2rss/cli.rb
@@ -2,6 +2,7 @@
 
 require 'fileutils'
 require 'json'
+require 'yaml'
 require 'thor'
 
 module Html2rss
@@ -96,6 +97,53 @@ module Html2rss
       end
 
       puts(format == 'jsonfeed' ? JSON.pretty_generate(result) : result)
+    end
+
+    desc 'capture URL', 'Analyze a URL and print a reusable YAML feed config'
+    method_option :strategy,
+                  type: :string,
+                  desc: STRATEGY_OPTION_DESC,
+                  enum: STRATEGY_OPTION_ENUM
+    method_option :items_selector, type: :string, desc: 'CSS selector hint for items (optional)'
+    method_option :max_redirects,
+                  type: :numeric,
+                  desc: 'Maximum redirects to follow per request'
+    method_option :max_requests,
+                  type: :numeric,
+                  desc: 'Maximum requests to allow for this feed build'
+    method_option :limit,
+                  type: :numeric,
+                  desc: 'Maximum number of articles to keep (default: 25)'
+    method_option :input,
+                  type: :string,
+                  desc: 'Local HTML file path to read input from'
+    ##
+    # Captures a URL and prints a reusable YAML config.
+    #
+    # @param url [String, nil] source page URL for capture
+    # @return [void]
+    def capture(url = nil)
+      strategy = options[:strategy]&.to_sym || :auto
+      input_path = options[:input]
+
+      if input_path
+        file_path = check_file_exists!(input_path)
+        url ||= detect_base_url!(file_path, 'Please specify a URL: html2rss capture [URL] --input <file>')
+        config = Html2rss.capture(url, strategy:, items_selector: options[:items_selector],
+                                        limit: options[:limit]&.to_i, max_redirects: options[:max_redirects],
+                                        max_requests: options[:max_requests])
+        config[:request] ||= {}
+        config[:request][:local_file_path] = file_path
+        puts YAML.dump(config)
+        return
+      end
+
+      raise Thor::Error, 'A URL is required unless --input is specified' unless url
+
+      config = Html2rss.capture(url, strategy:, items_selector: options[:items_selector],
+                                      limit: options[:limit]&.to_i, max_redirects: options[:max_redirects],
+                                      max_requests: options[:max_requests])
+      puts YAML.dump(config)
     end
 
     desc 'schema', 'Print the exported config JSON Schema'

--- a/spec/lib/html2rss/capture_spec.rb
+++ b/spec/lib/html2rss/capture_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Html2rss::Capture do
+  subject(:capture) { described_class }
+
+  let(:url) { 'https://example.com/blog' }
+  let(:response_body) { '<html><body>Hello</body></html>' }
+
+  describe '.build' do
+    it 'returns a CaptureResult' do
+      allow_any_instance_of(described_class).to receive(:fetch_response).and_return(
+        instance_double(Html2rss::RequestService::Response,
+                        body: response_body,
+                        url: Html2rss::Url.from_absolute(url),
+                        headers: { 'content-type' => 'text/html' },
+                        html_response?: true,
+                        parsed_body: Nokogiri::HTML(response_body))
+      )
+      allow_any_instance_of(described_class).to receive(:extract_articles).and_return([])
+      allow(Html2rss::Channel).to receive(:from_response).and_return(
+        Html2rss::Channel.new(
+          title: 'Example Blog',
+          url: Html2rss::Url.from_absolute(url),
+          description: 'Latest items from https://example.com/blog',
+          language: nil,
+          ttl: 360,
+          last_build_date: Time.now,
+          image: nil,
+          author: nil
+        )
+      )
+
+      result = described_class.build(url)
+
+      expect(result).to be_a(described_class::CaptureResult)
+      expect(result.config).to have_key(:channel)
+      expect(result.articles_count).to eq(0)
+    end
+  end
+
+  describe 'CaptureResult' do
+    subject(:result) { described_class::CaptureResult.new(config:, articles_count: 5, channel_title: 'Test') }
+
+    let(:config) { { channel: { url: 'https://example.com' } } }
+
+    it 'has config accessor' do
+      expect(result.config).to eq(config)
+    end
+
+    it 'has articles_count accessor' do
+      expect(result.articles_count).to eq(5)
+    end
+
+    it 'has channel_title accessor' do
+      expect(result.channel_title).to eq('Test')
+    end
+  end
+end
+
+RSpec.describe Html2rss do
+  describe '.capture' do
+    it 'delegates to Capture.build' do
+      config_hash = { channel: { url: 'https://example.com' } }
+      capture_result = instance_double(Html2rss::Capture::CaptureResult, config: config_hash)
+
+      allow(Html2rss::Capture).to receive(:build).and_return(capture_result)
+
+      result = described_class.capture('https://example.com')
+
+      expect(Html2rss::Capture).to have_received(:build).with(
+        'https://example.com',
+        hash_including(strategy: :auto)
+      )
+      expect(result).to eq(config_hash)
+    end
+  end
+end

--- a/spec/lib/html2rss/cli_spec.rb
+++ b/spec/lib/html2rss/cli_spec.rb
@@ -268,6 +268,61 @@ RSpec.describe Html2rss::CLI do
     end
   end
 
+  describe '#capture' do
+    let(:captured_config) { { channel: { url: 'https://example.com', title: 'Example' } } }
+    let(:capture_defaults) do
+      {
+        strategy: :auto,
+        items_selector: nil,
+        max_redirects: nil,
+        max_requests: nil,
+        limit: nil
+      }
+    end
+
+    before do
+      allow(Html2rss).to receive(:capture).and_return(captured_config)
+    end
+
+    it 'prints the captured config as YAML to stdout' do
+      expect { cli.capture('https://example.com') }
+        .to output(YAML.dump(captured_config)).to_stdout
+    end
+
+    {
+      'strategy' => [{ strategy: 'botasaurus' }, { strategy: :botasaurus }],
+      'items_selector' => [{ items_selector: '.item' }, { items_selector: '.item' }],
+      'max_redirects' => [{ max_redirects: 8 }, { max_redirects: 8 }],
+      'max_requests' => [{ max_requests: 8 }, { max_requests: 8 }],
+      'limit' => [{ limit: 10 }, { limit: 10 }]
+    }.each do |label, (options, expected_kwargs)|
+      it "forwards #{label} to Html2rss.capture" do
+        cli.invoke(:capture, ['https://example.com'], options)
+
+        expect(Html2rss).to have_received(:capture)
+          .with('https://example.com', **capture_defaults, **expected_kwargs)
+      end
+    end
+
+    context 'when no URL is given and no input file is provided' do
+      it 'raises a Thor::Error' do
+        expect { cli.capture(nil) }
+          .to raise_error(Thor::Error, /A URL is required unless --input is specified/)
+      end
+    end
+
+    context 'with input option' do
+      it 'wires --input as local_file_path in the output config' do
+        cli.invoke(:capture, [], { input: 'spec/fixtures/local_feed_test.html' })
+
+        expect(Html2rss).to have_received(:capture).with(
+          'https://example.com/blog',
+          **capture_defaults
+        )
+      end
+    end
+  end
+
   describe '#validate' do
     let(:result) { instance_double(Dry::Validation::Result, success?: success, errors:) }
     let(:errors) { instance_double(Dry::Validation::MessageSet, to_h: { selectors: ['bad config'] }) }


### PR DESCRIPTION
## Summary

Adds a first-class `Html2rss.capture` API and `html2rss capture` CLI subcommand that analyzes any URL through the auto-source pipeline and produces a reusable feed config hash with derived CSS selectors.

- `Html2rss::Capture` class: fetches a page, runs auto-source discovery, matches SST segments back to extracted articles, and derives CSS selectors for items, title, link, and description.
- `Html2rss.capture` public method: concise entry point returning a serializable config hash.
- `html2rss capture [URL]` CLI subcommand: prints YAML config to stdout, supports `--strategy`, `--items-selector`, `--limit`, `--input` options.
- `CaptureResult` value object: config hash, article count, channel title.
- `docs/capture.md`: usage documentation for the gem API and CLI.

## Usage

```bash
html2rss capture https://example.com/articles > my-feed.yml
html2rss feed my-feed.yml
```

```ruby
config = Html2rss.capture('https://example.com', strategy: :botasaurus)
File.write('feed.yml', config.to_yaml)
```

## Test Plan

- [x] `bundle exec rspec` — 1225 examples, 0 failures
- [x] `bundle exec rubocop` — 0 offenses
- [x] CLI help renders correctly: `ruby -Ilib bin/html2rss help capture`