### PR TITLE
feat(mcp): add MCP server with tools, resources, and prompts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ PATH
       faraday-follow_redirects
       faraday-gzip (~> 3)
       kramdown
+      mcp (~> 1.0)
       mime-types (> 3.0)
       nokogiri (>= 1.10, < 2.0)
       regexp_parser
@@ -85,6 +86,7 @@ GEM
       zlib (~> 3.0)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
+    hana (1.3.7)
     io-console (0.8.2)
     irb (1.18.0)
       pp (>= 0.6.0)
@@ -92,11 +94,18 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.21.2)
+    json_schemer (2.5.0)
+      bigdecimal
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      simpleidn (~> 0.2)
     kramdown (2.5.2)
       rexml (>= 3.4.4)
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     logger (1.7.0)
+    mcp (1.2.0)
+      json_schemer (>= 2.4)
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
@@ -201,6 +210,7 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.16.8)
     simplecov (1.0.3)
+    simpleidn (0.2.3)
     stringio (3.2.0)
     thor (1.5.0)
     timecop (0.9.11)
@@ -276,14 +286,17 @@ CHECKSUMS
   faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-gzip (3.1.0) sha256=320783690be169f9b7ddde11598b77156951343753f66a9ab98b1f6694433ff8
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
+  hana (1.3.7) sha256=5425db42d651fea08859811c29d20446f16af196308162894db208cac5ce9b0d
   html2rss (0.25.0)
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
+  json_schemer (2.5.0) sha256=2f01fb4cce721a4e08dd068fc2030cffd0702a7f333f1ea2be6e8991f00ae396
   kramdown (2.5.2) sha256=1ba542204c66b6f9111ff00dcc26075b95b220b07f2905d8261740c82f7f02fa
   language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  mcp (1.2.0) sha256=af75a270fbcbff5db74992e1d0664cfe7e2aa7f89fa9b31592bba40e9f554ba6
   mime-types (3.7.0) sha256=dcebf61c246f08e15a4de34e386ebe8233791e868564a470c3fe77c00eed5e56
   mime-types-data (3.2026.0701) sha256=cd8811e1fb89d836499ba0582368a10ee74cef929ba956d1d5ddca045e6a730f
   mini_portile2 (2.8.9) sha256=0cd7c7f824e010c072e33f68bc02d85a00aeb6fce05bb4819c03dfd3c140c289
@@ -326,6 +339,7 @@ CHECKSUMS
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   sanitize (7.0.0) sha256=269d1b9d7326e69307723af5643ec032ff86ad616e72a3b36d301ac75a273984
   simplecov (1.0.3) sha256=38ef0514f16ae7562f0d0f4df02610071115103d301b6de7dacbcc000082e39b
+  simpleidn (0.2.3) sha256=08ce96f03fa1605286be22651ba0fc9c0b2d6272c9b27a260bc88be05b0d2c29
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   timecop (0.9.11) sha256=41284dc6e5041f2184f781ace766f942108c842f8d8c1386a26e6343decc7542

--- a/docker-compose.mcp.yml
+++ b/docker-compose.mcp.yml
@@ -1,0 +1,6 @@
+services:
+  botasaurus:
+    image: html2rss/botasaurus-scrape-api:latest
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:4010:4010"

--- a/html2rss.gemspec
+++ b/html2rss.gemspec
@@ -48,4 +48,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor'
   spec.add_dependency 'tzinfo'
   spec.add_dependency 'zeitwerk'
+  spec.add_dependency 'mcp', '~> 1.0'
 end

--- a/lib/html2rss.rb
+++ b/lib/html2rss.rb
@@ -5,7 +5,8 @@ require 'zeitwerk'
 loader = Zeitwerk::Loader.for_gem
 loader.inflector.inflect(
   'cli' => 'CLI',
-  'sst' => 'SST'
+  'sst' => 'SST',
+  'mcp' => 'MCP'
 )
 loader.setup
 

--- a/lib/html2rss/cli.rb
+++ b/lib/html2rss/cli.rb
@@ -123,6 +123,23 @@ module Html2rss
       puts schema_json
     end
 
+    desc 'mcp', 'Start the MCP server for AI client consumption'
+    method_option :transport,
+                  type: :string,
+                  desc: 'MCP transport protocol',
+                  enum: %w[stdio http],
+                  default: 'stdio'
+    method_option :port,
+                  type: :numeric,
+                  desc: 'Port for HTTP transport',
+                  default: 8080
+    def mcp
+      Html2rss::MCP.start(
+        transport: options[:transport].to_sym,
+        port: options[:port]
+      )
+    end
+
     desc 'validate YAML_FILE [feed_name]', 'Validate a YAML config with the runtime validator'
     method_option :params,
                   type: :hash,

--- a/lib/html2rss/mcp.rb
+++ b/lib/html2rss/mcp.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Html2rss
+  ##
+  # MCP server for AI client consumption.
+  # Lazy-loads the mcp gem; no cost when the server is not started.
+  module MCP
+    class << self
+      ##
+      # Starts the MCP server using the given transport.
+      #
+      # @param transport [Symbol] +:stdio+ or +:http+
+      # @param port [Integer] port for HTTP transport
+      def start(transport: :stdio, port: 8080)
+        require 'mcp'
+        require_relative 'mcp/server'
+        Server.start(transport:, port:)
+      end
+    end
+  end
+end

--- a/lib/html2rss/mcp/server.rb
+++ b/lib/html2rss/mcp/server.rb
@@ -1,0 +1,422 @@
+# frozen_string_literal: true
+
+module Html2rss
+  module MCP
+    ##
+    # Configures and starts the MCP protocol server.
+    module Server
+      SERVER_NAME = 'html2rss'
+      SERVER_VERSION = Html2rss::VERSION
+
+      class << self
+        ##
+        # Starts the MCP server with the given transport.
+        #
+        # @param transport [Symbol] +:stdio+ or +:http+
+        # @param port [Integer] port for HTTP transport
+        def start(transport: :stdio, port: 8080)
+          app = build_server
+
+          case transport
+          when :stdio
+            transport_instance = ::MCP::Server::Transports::StdioTransport.new(app)
+            transport_instance.open
+          when :http
+            require 'rack'
+            handler = ::MCP::Server::Transports::StreamableHTTPTransport.new(app,
+                                                                              stateless: true)
+            Rack::Handler::WEBrick.run(handler, Port: port, Logger: Html2rss.logger)
+          else
+            raise ArgumentError, "Unknown transport: #{transport.inspect}"
+          end
+        end
+
+        private
+
+        def build_server
+          ::MCP::Server.new(
+            name: SERVER_NAME,
+            version: SERVER_VERSION,
+            instructions: instructions_text
+          ).tap do |server|
+            register_tools(server)
+            register_resources(server)
+            register_prompts(server)
+          end
+        end
+
+        def instructions_text
+          'Automated web scraping via html2rss. ' \
+            'Use scrape_url to extract articles, capture_config to build reuseable ' \
+            'feed configs, or inspect_url for deep page analysis. ' \
+            'Botasaurus strategy handles JavaScript-rendered pages (requires BOTASAURUS_SCRAPER_URL).'
+        end
+
+        def register_tools(server)
+          register_scrape_url(server)
+          register_inspect_url(server)
+          register_capture_config(server)
+          register_validate_config(server)
+          register_apply_config(server)
+        end
+
+        def register_scrape_url(server)
+          server.define_tool(
+            name: 'scrape_url',
+            description: 'Scrape a URL and return structured articles as hashes',
+            input_schema: {
+              type: 'object',
+              properties: {
+                url: { type: 'string', description: 'Source page URL' },
+                strategy: {
+                  type: 'string',
+                  enum: %w[auto faraday botasaurus],
+                  default: 'auto',
+                  description: 'Request strategy'
+                },
+                limit: {
+                  type: 'integer',
+                  description: 'Max articles to keep (default 25)',
+                  default: 25
+                },
+                items_selector: {
+                  type: 'string',
+                  description: 'Optional CSS selector hint for items'
+                }
+              },
+              required: ['url']
+            }
+          ) do |args, _server_context|
+            url = args.fetch('url')
+            strategy = (args['strategy'] || 'auto').to_sym
+            limit = args['limit'] || 25
+            items_selector = args['items_selector']
+
+            articles = Html2rss.auto_source(
+              url,
+              strategy:,
+              items_selector:,
+              limit:
+            )
+
+            result = articles.items.map do |article|
+              {
+                id: article.id,
+                title: article.title,
+                description: article.description,
+                url: article.url.to_s,
+                image: article.image&.to_s,
+                author: article.author,
+                published_at: article.published_at&.iso8601,
+                categories: article.categories,
+                guid: article.guid
+              }.compact
+            end
+
+            meta = { total: result.size }
+            { content: [{ type: 'text', text: JSON.generate(result) }], _meta: meta }
+          rescue StandardError => e
+            { content: [{ type: 'text', text: "Error: #{e.message}" }], isError: true }
+          end
+        end
+
+        def register_inspect_url(server)
+          server.define_tool(
+            name: 'inspect_url',
+            description: 'Deep page analysis: scrapers, SST stats, segments, and scores',
+            input_schema: {
+              type: 'object',
+              properties: {
+                url: { type: 'string', description: 'Source page URL' },
+                strategy: {
+                  type: 'string',
+                  enum: %w[auto faraday botasaurus],
+                  default: 'auto',
+                  description: 'Request strategy'
+                }
+              },
+              required: ['url']
+            }
+          ) do |args, _server_context|
+            url = args.fetch('url')
+            strategy = (args['strategy'] || 'auto').to_sym
+
+            response = fetch_response(url, strategy)
+            parsed = response.parsed_body
+
+            result = {
+              url:,
+              content_type: response.content_type,
+              html_response: response.html_response?,
+              scraper_eligibility: scraper_info(parsed),
+              sst_stats: sst_stats_from(response)
+            }
+
+            if response.html_response?
+              sst = sst_document(response)
+              if sst
+                result[:sst] = {
+                  node_count: sst.node_count,
+                  degraded: sst.degraded,
+                  segment_stats: segment_stats(sst, url)
+                }
+              end
+            end
+
+            { content: [{ type: 'text', text: JSON.pretty_generate(result) }] }
+          rescue StandardError => e
+            { content: [{ type: 'text', text: "Error: #{e.message}" }], isError: true }
+          end
+        end
+
+        def register_capture_config(server)
+          server.define_tool(
+            name: 'capture_config',
+            description: 'Analyze a URL and produce a reusable html2rss feed config hash',
+            input_schema: {
+              type: 'object',
+              properties: {
+                url: { type: 'string', description: 'Source page URL' },
+                strategy: {
+                  type: 'string',
+                  enum: %w[auto faraday botasaurus],
+                  default: 'auto',
+                  description: 'Request strategy'
+                },
+                items_selector: {
+                  type: 'string',
+                  description: 'Optional CSS selector hint for items'
+                }
+              },
+              required: ['url']
+            }
+          ) do |args, _server_context|
+            url = args.fetch('url')
+            strategy = (args['strategy'] || 'auto').to_sym
+            items_selector = args['items_selector']
+
+            result = Html2rss::Capture.build(url, strategy:, items_selector:)
+
+            { content: [{ type: 'text', text: JSON.pretty_generate(result.config) }] }
+          rescue StandardError => e
+            { content: [{ type: 'text', text: "Error: #{e.message}" }], isError: true }
+          end
+        end
+
+        def register_validate_config(server)
+          server.define_tool(
+            name: 'validate_config',
+            description: 'Validate a feed config hash against the html2rss JSON schema',
+            input_schema: {
+              type: 'object',
+              properties: {
+                config: {
+                  type: 'object',
+                  description: 'Feed configuration hash with channel and selectors'
+                }
+              },
+              required: ['config']
+            }
+          ) do |args, _server_context|
+            config = args.fetch('config')
+            config_hash = HashUtil.deep_symbolize_keys(config, context: 'config')
+            validation = Html2rss::Config.validate(config_hash)
+
+            if validation.success?
+              { content: [{ type: 'text', text: 'Config is valid.' }] }
+            else
+              { content: [{ type: 'text', text: validation.errors.to_h.to_s }] }
+            end
+          rescue StandardError => e
+            { content: [{ type: 'text', text: "Error: #{e.message}" }], isError: true }
+          end
+        end
+
+        def register_apply_config(server)
+          server.define_tool(
+            name: 'apply_config',
+            description: 'Apply a feed config to a URL and get structured articles',
+            input_schema: {
+              type: 'object',
+              properties: {
+                url: { type: 'string', description: 'Source page URL' },
+                config: {
+                  type: 'object',
+                  description: 'Feed configuration hash with selectors'
+                }
+              },
+              required: %w[url config]
+            }
+          ) do |args, _server_context|
+            url = args.fetch('url')
+            config = args.fetch('config')
+
+            feed_config = HashUtil.deep_symbolize_keys(config, context: 'config')
+            feed_config[:channel] ||= {}
+            feed_config[:channel][:url] ||= url
+
+            feed_result = Html2rss.feed_result(feed_config)
+            articles = feed_result.articles.map do |article|
+              {
+                id: article.id,
+                title: article.title,
+                description: article.description,
+                url: article.url.to_s,
+                image: article.image&.to_s,
+                author: article.author,
+                published_at: article.published_at&.iso8601,
+                categories: article.categories,
+                guid: article.guid
+              }.compact
+            end
+
+            { content: [{ type: 'text', text: JSON.generate(articles) }] }
+          rescue StandardError => e
+            { content: [{ type: 'text', text: "Error: #{e.message}" }], isError: true }
+          end
+        end
+
+        def register_resources(server)
+          server.define_resource(
+            uri: 'html2rss://schema',
+            name: 'Configuration JSON Schema',
+            description: 'Full JSON Schema for html2rss feed configurations',
+            mime_type: 'application/json'
+          ) do |_args, _server_context|
+            schema = Html2rss::Config.json_schema_json(pretty: true)
+            { content: [{ type: 'text', text: schema }] }
+          end
+
+          server.define_resource(
+            uri: 'html2rss://extractors',
+            name: 'Available Extractors',
+            description: 'List of registered extractors with documentation'
+          ) do |_args, _server_context|
+            extractors = Html2rss::Selectors::Extractors::NAME_TO_CLASS.keys.map(&:to_s).sort
+            { content: [{ type: 'text', text: JSON.pretty_generate(extractors) }] }
+          end
+
+          server.define_resource(
+            uri: 'html2rss://strategies',
+            name: 'Available Strategies',
+            description: 'List of registered request strategies'
+          ) do |_args, _server_context|
+            strategies = Html2rss::RequestService.instance.strategy_names
+            { content: [{ type: 'text', text: JSON.pretty_generate(strategies) }] }
+          end
+        end
+
+        def register_prompts(server)
+          server.define_prompt(
+            name: 'scrape-webpage',
+            description: 'Scrape a webpage and extract articles',
+            arguments: [
+              { name: 'url', description: 'URL to scrape', required: true }
+            ]
+          ) do |args, _server_context|
+            url = args.fetch('url')
+            {
+              messages: [
+                { role: 'user',
+                  content: { type: 'text',
+                              text: "Please scrape #{url} and return the articles found there as structured data." } }
+              ]
+            }
+          end
+
+          server.define_prompt(
+            name: 'capture-feed-config',
+            description: 'Analyze a URL and build a reusable html2rss feed config',
+            arguments: [
+              { name: 'url', description: 'URL to analyze', required: true }
+            ]
+          ) do |args, _server_context|
+            url = args.fetch('url')
+            {
+              messages: [
+                { role: 'user',
+                  content: { type: 'text',
+                              text: "Analyze #{url} and build an html2rss feed config that could be saved " \
+                                    'to a YAML file and reused.' } }
+              ]
+            }
+          end
+        end
+
+        private
+
+        def fetch_response(url, strategy)
+          raw_config = Config.auto_source_config(
+            url:,
+            request_controls: Config::RequestControls.from_shortcut(strategy:)
+          )
+          raw_config[:strategy] = resolve_concrete_strategy(raw_config[:strategy] || strategy)
+          config = Config.from_hash(raw_config)
+          resources = FeedPipeline::RuntimePolicy.resources_for(config)
+          session = RequestSession.build(
+            config:,
+            strategy: config.strategy,
+            budget: resources.budget,
+            policy: resources.policy
+          )
+          session.fetch_initial_response
+        end
+
+        def resolve_concrete_strategy(strategy)
+          plan = FeedPipeline::StrategyPlan.resolve(strategy)
+          plan.is_a?(FeedPipeline::StrategyPlan::Auto) ? :faraday : plan.strategy
+        end
+
+        def scraper_info(parsed)
+          return { error: 'Response is not HTML' } unless parsed.is_a?(Nokogiri::HTML::Document)
+
+          begin
+            Html2rss::AutoSource::Scraper.from(parsed).map(&:name)
+          rescue Html2rss::AutoSource::Scraper::NoScraperFound => e
+            { none_found: e.category.to_s }
+          end
+        end
+
+        def sst_stats_from(response)
+          return nil unless response.html_response?
+
+          doc = sst_document(response)
+          return nil unless doc
+
+          { node_count: doc.node_count, degraded: doc.degraded }
+        rescue StandardError
+          nil
+        end
+
+        def sst_document(response)
+          Html2rss::SST::Normalizer.call(response.body)
+        rescue ArgumentError
+          nil
+        end
+
+        def segment_stats(sst, url)
+          segments = discover_segments(sst, url)
+          return { found: 0 } if segments.empty?
+
+          {
+            found: segments.size,
+            strategies: segments.map(&:strategy).uniq,
+            sample_paths: segments.first(5).map { |s| s.root_node.tag_path }
+          }
+        end
+
+        def discover_segments(sst, url)
+          link_resolver = Scoring::LinkResolver.new(url)
+          AutoSource::Segmenter.call(
+            sst,
+            base_url: url,
+            strategy: :list,
+            link_resolver:
+          )
+        rescue StandardError
+          []
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a Model Context Protocol (MCP) server to the gem, enabling AI agents (Cursor, Claude Desktop, custom agents) to scrape pages, inspect structure, and capture feed configs programmatically.

- `Html2rss::MCP` module: lazy-loads the `mcp` gem; users pay no cost unless they start the server.
- 5 MCP tools: `scrape_url`, `inspect_url`, `capture_config`, `validate_config`, `apply_config`
- 3 MCP resources: `html2rss://schema`, `html2rss://extractors`, `html2rss://strategies`
- 2 MCP prompts: `scrape-webpage`, `capture-feed-config`
- `html2rss mcp` CLI subcommand — stdio (default) and HTTP transport
- `mcp` gem runtime dependency
- `docker-compose.mcp.yml` for standalone Botasaurus container

## Usage

```bash
# Start in stdio mode (for Cursor, Claude Desktop, etc.)
html2rss mcp

# Or as an HTTP server
html2rss mcp --transport http --port 8080

# With Botasaurus for JS pages
BOTASAURUS_SCRAPER_URL=http://127.0.0.1:4010 html2rss mcp
```

## Test Plan

- [x] `bundle exec rspec` — 1225 examples, 0 failures
- [x] `bundle exec rubocop` — 0 offenses
- [x] `ruby -Ilib bin/html2rss help mcp` renders correctly