### PR TITLE
feat(capture): derive reusable feed configs from a URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,37 @@ Cloud development: [Open in GitHub Codespaces](https://github.com/codespaces/new
 Config -> Request -> Extraction -> Processing -> Building -> Output
 ```
 
+## Capture API
+
+The `Html2rss.capture` method analyzes any URL and produces a reusable feed config hash with derived CSS selectors. Use it to speed up writing feed configuration files.
+
+```ruby
+config = Html2rss.capture('https://example.com/articles')
+File.write('my-feed.yml', YAML.dump(Html2rss::HashUtil.deep_stringify_keys(config)))
+```
+
+The CLI alias `html2rss capture` prints the generated config as YAML to stdout. See [`docs/capture.md`](docs/capture.md) for detailed documentation.
+
+## Botasaurus Docker Compose
+
+Start the Botasaurus scrape API for JavaScript-rendered pages:
+
+```bash
+docker compose -f docker-compose.mcp.yml up -d
+```
+
+Set `BOTASAURUS_SCRAPER_URL` to `http://127.0.0.1:4010` and the strategy to `botasaurus` in the capture call or CLI.
+
+## Request Strategies
+
+| Strategy | Description |
+|----------|-------------|
+| `auto` | Tries `faraday`, falls back to `botasaurus` (default) |
+| `faraday` | Plain HTTP requests via Faraday |
+| `botasaurus` | Puppeteer-backed scraping for JavaScript pages |
+
+The strategy can be set via CLI option (`--strategy`), gem API keyword argument, or in the feed config under `request.strategy`. See the [request strategies docs](https://html2rss.github.io/ruby-gem/reference/strategy) for more details.
+
 ## License
 
 This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.

--- a/docker-compose.mcp.yml
+++ b/docker-compose.mcp.yml
@@ -1,0 +1,6 @@
+services:
+  botasaurus:
+    image: html2rss/botasaurus-scrape-api:latest
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:4010:4010"

--- a/docs/capture.md
+++ b/docs/capture.md
@@ -1,0 +1,86 @@
+# Capture — Automatic Feed Config Derivation
+
+The `Html2rss.capture` method (and its CLI alias `html2rss capture`) analyzes
+any URL through the auto-source pipeline and produces a reusable feed config
+hash with derived CSS selectors.
+
+## Use Case
+
+Speed up writing feed configs. Instead of manually inspecting HTML to craft CSS
+selectors, point `capture` at your target URL and let it produce a first draft.
+Tweak the output as needed.
+
+## Gem API
+
+```ruby
+config = Html2rss.capture('https://example.com/articles')
+
+# config contains a hash with :channel and :selectors keys:
+# {
+#   channel: { url: "https://example.com/articles", title: "...", time_zone: "UTC" },
+#   selectors: {
+#     items: { selector: "div.post" },
+#     title: { selector: "h2 > a" },
+#     link: { selector: "a.more", extractor: "href" },
+#     description: { selector: "div.excerpt" }
+#   }
+# }
+
+# Save to YAML for reuse (string keys — same wire form as hand-written configs)
+File.write('my-feed.yml', YAML.dump(Html2rss::HashUtil.deep_stringify_keys(config)))
+
+# Use immediately
+feed = Html2rss.feed(config)
+```
+
+### Options
+
+```ruby
+# Pin a specific request strategy
+Html2rss.capture('https://spa-site.com', strategy: :botasaurus)
+
+# Provide a CSS selector hint for items
+Html2rss.capture('https://example.com', items_selector: '.article-card')
+
+# Analyze a local HTML file (stamps strategy: :local_file and local_file_path)
+Html2rss.capture('https://example.com', strategy: :local_file, local_file_path: './page.html')
+```
+
+## CLI
+
+```bash
+# Print a reusable YAML config
+html2rss capture https://example.com/articles
+
+# With Botasaurus strategy
+html2rss capture https://example.com --strategy botasaurus
+
+# Save to file
+html2rss capture https://example.com/articles > my-feed.yml
+
+# Read from a local HTML file
+html2rss capture https://example.com --input ./page.html
+```
+
+## How It Works
+
+1. **Request** — fetches the page using the configured strategy
+2. **Discover** — runs the AutoSource pipeline to extract articles
+3. **Analyze** — normalizes the page into an SST document, segments it, and
+   maps segment positions back to extracted articles
+4. **Derive** — builds CSS selectors from SST tag_paths for items, title, link,
+   and description attributes
+5. **Assemble** — returns a complete config hash ready for serialization
+
+## Limitations
+
+- Selector quality depends on the page structure and auto-source detection.
+  Complex layouts may produce imperfect selectors that need manual adjustment.
+  Treat capture output as a first draft.
+- Capture segment discovery currently uses the list Segmenter strategy only
+  (not AutoSource's cluster/semantic heuristics), so some layouts may need a
+  manual `items_selector` hint.
+- The capture only derives items, title, link, and description selectors.
+  Description is omitted when it would resolve to the invalid CSS selector `.`
+  (item root equals description root). Additional attributes (author,
+  published_at, categories, enclosures) can be added manually.

--- a/lib/html2rss.rb
+++ b/lib/html2rss.rb
@@ -118,6 +118,36 @@ module Html2rss
                                        local_file_path:, limit:))
   end
 
+  ##
+  # Analyzes a URL and produces a reusable YAML-ready feed config hash.
+  #
+  # Uses auto-source discovery to extract articles, then derives CSS selectors
+  # from the structural analysis.
+  #
+  # @param url [String] source page URL
+  # @param strategy [Symbol] request strategy (+:auto+, +:faraday+, +:botasaurus+)
+  # @param items_selector [String, nil] optional CSS selector hint for items
+  # @param max_redirects [Integer, nil] optional redirect limit override
+  # @param max_requests [Integer, nil] optional request budget override
+  # @param limit [Integer, nil] max articles to keep
+  # @param local_file_path [String, nil] optional local HTML file path
+  # @return [Hash] feed config hash with +:channel+ and +:selectors+
+  def self.capture(url,
+                   strategy: :auto,
+                   items_selector: nil,
+                   max_redirects: nil,
+                   max_requests: nil,
+                   limit: nil,
+                   local_file_path: nil)
+    Capture.build(url,
+                  strategy:,
+                  items_selector:,
+                  max_redirects:,
+                  max_requests:,
+                  limit:,
+                  local_file_path:).config
+  end
+
   # rubocop:enable Metrics/ParameterLists
 
   # rubocop:disable ThreadSafety/ClassInstanceVariable

--- a/lib/html2rss/capture.rb
+++ b/lib/html2rss/capture.rb
@@ -1,0 +1,315 @@
+# frozen_string_literal: true
+
+module Html2rss
+  ##
+  # Analyzes a URL and produces a reusable feed config hash with derived CSS selectors.
+  #
+  # Uses the auto-source pipeline to extract articles, then traces back through
+  # SST segments to build items + attribute selectors suitable for a static feed config.
+  class Capture # rubocop:disable Metrics/ClassLength
+    LEADING_TRIM_TAGS = %w[html body].freeze
+    private_constant :LEADING_TRIM_TAGS
+
+    ##
+    # Result of a capture operation.
+    # @!attribute config [Hash] feed config hash with +:channel+ and +:selectors+
+    # @!attribute articles_count [Integer] number of articles extracted
+    # @!attribute channel_title [String] derived channel title
+    CaptureResult = Data.define(:config, :articles_count, :channel_title)
+
+    class << self
+      ##
+      # Analyzes a URL and builds a reusable feed config.
+      #
+      # @param url [String] source page URL
+      # @param strategy [Symbol] request strategy (+:auto+, +:faraday+, +:botasaurus+)
+      # @option options [String, nil] :items_selector optional selector hint
+      # @option options [Integer, nil] :max_redirects optional redirect limit override
+      # @option options [Integer, nil] :max_requests optional request budget override
+      # @option options [Integer, nil] :limit max articles to keep
+      # @option options [String, nil] :local_file_path optional local HTML file path
+      # @return [CaptureResult]
+      def build(url, strategy: :auto, **)
+        new(url, strategy:, **).build
+      end
+    end
+
+    ##
+    # @param url [String] source page URL
+    # @param strategy [Symbol] request strategy
+    # @param options [Hash] additional options
+    # @option options [String, nil] :items_selector optional selector hint
+    # @option options [Integer, nil] :max_redirects optional redirect limit override
+    # @option options [Integer, nil] :max_requests optional request budget override
+    # @option options [Integer, nil] :limit max articles to keep
+    # @option options [String, nil] :local_file_path optional local HTML file path
+    def initialize(url, strategy: :auto, **options)
+      @url = url
+      @strategy = strategy
+      @items_selector_hint = options.delete(:items_selector)
+      @max_redirects = options.delete(:max_redirects)
+      @max_requests = options.delete(:max_requests)
+      @limit = options.delete(:limit)
+      @local_file_path = options.delete(:local_file_path)
+    end
+
+    ##
+    # Runs the capture pipeline.
+    #
+    # @return [CaptureResult]
+    def build # rubocop:disable Metrics/MethodLength
+      response = fetch_response
+      articles = extract_articles(response)
+      selectors = derive_selectors(response, articles)
+
+      config = {
+        channel: build_channel(response),
+        selectors: selectors.empty? ? nil : selectors,
+        **local_file_request_overlay
+      }.compact
+
+      CaptureResult.new(
+        config:,
+        articles_count: articles.size,
+        channel_title: channel_title_from(response)
+      )
+    end
+
+    private
+
+    def raw_config
+      @raw_config ||= build_raw_config
+    end
+
+    def build_raw_config # rubocop:disable Metrics/MethodLength
+      Config.auto_source_config(
+        url: @url,
+        items_selector: @items_selector_hint,
+        request_controls: Config::RequestControls.from_shortcut(
+          strategy: @strategy,
+          max_redirects: @max_redirects,
+          max_requests: @max_requests
+        ),
+        limit: @limit
+      ).tap do |config|
+        config[:strategy] = resolve_strategy(config[:strategy] || @strategy)
+        apply_local_file_path!(config)
+      end
+    end
+
+    def apply_local_file_path!(config)
+      return unless @local_file_path
+
+      config[:strategy] = :local_file
+      config[:request] ||= {}
+      config[:request][:local_file_path] = @local_file_path
+    end
+
+    def local_file_request_overlay
+      return {} unless @local_file_path
+
+      { strategy: :local_file, request: { local_file_path: @local_file_path } }
+    end
+
+    def resolve_strategy(strategy)
+      plan = FeedPipeline::StrategyPlan.resolve(strategy)
+      plan.is_a?(FeedPipeline::StrategyPlan::Auto) ? :faraday : plan.strategy
+    end
+
+    def fetch_response
+      config = Config.from_hash(raw_config)
+      resources = FeedPipeline::RuntimePolicy.resources_for(config)
+      session = RequestSession.build(
+        config:,
+        strategy: config.strategy,
+        budget: resources.budget,
+        policy: resources.policy
+      )
+      session.fetch_initial_response
+    end
+
+    def extract_articles(response)
+      auto_source_opts = raw_config[:auto_source] || AutoSource::DEFAULT_CONFIG
+      AutoSource.new(response, auto_source_opts).articles
+    rescue AutoSource::Scraper::NoScraperFound
+      []
+    end
+
+    def derive_selectors(response, articles) # rubocop:disable Metrics/MethodLength
+      return {} if articles.empty? || !response.html_response?
+
+      sst = normalize_sst(response)
+      return {} unless sst
+
+      segments = discover_segments(sst)
+      return {} if segments.empty?
+
+      matched = match_segments_to_articles(segments, articles)
+      return {} if matched.empty?
+
+      build_selector_hash(matched, sst)
+    rescue ArgumentError => error
+      Log.warn("Capture selector derivation failed: #{error.message}")
+      {}
+    end
+
+    def normalize_sst(response)
+      SST::Normalizer.call(response.body)
+    end
+
+    def discover_segments(sst)
+      link_resolver = Scoring::LinkResolver.new(@url)
+
+      AutoSource::Segmenter.call(
+        sst,
+        base_url: @url,
+        strategy: :list,
+        permit_unanchored: false,
+        link_resolver:
+      )
+    end
+
+    def match_segments_to_articles(segments, articles)
+      articles_by_url = articles.each_with_object({}) do |article, hash|
+        url_str = article.url.to_s
+        hash[url_str] = article unless url_str.empty?
+      end
+
+      segments.filter_map do |segment|
+        next unless segment.primary_link
+
+        article = find_matching_article(segment, articles_by_url)
+        { segment:, article: } if article
+      end
+    end
+
+    def find_matching_article(segment, articles_by_url) # rubocop:disable Metrics/AbcSize
+      href = segment.primary_link.attrs.href.to_s
+      return articles_by_url.values.find { |a| a.title == title_from_segment(segment) } if href.empty?
+
+      resolved = Url.from_relative(href, @url)
+      articles_by_url[resolved.to_s] || articles_by_url.values.find { |a| fuzzy_url_match?(a.url, resolved) }
+    end
+
+    def fuzzy_url_match?(article_url, resolved)
+      article_url.to_s.end_with?(resolved.path.to_s)
+    rescue StandardError
+      false
+    end
+
+    def title_from_segment(segment)
+      segment.root_node.visible_text.to_s.strip
+    end
+
+    def build_selector_hash(matched, _sst)
+      items_sel = items_selector(matched)
+      return {} unless items_sel
+
+      first = matched.first
+      root = first[:segment].root_node
+
+      attrs = {}.tap do |a|
+        a[:title] = title_selector(root)
+        a[:link] = link_selector(first[:segment])
+        a[:description] = description_selector(root, first[:segment])
+      end.compact
+
+      { items: { selector: items_sel }, **attrs }
+    end
+
+    def items_selector(matched)
+      roots = matched.map { |m| m[:segment].root_node }
+      shared = shared_class_items_selector(roots)
+      return shared if shared
+
+      paths = roots.map(&:tag_path)
+      common = common_path_prefix(paths)
+      tag_path = common.empty? ? paths.first.to_s : common
+      return nil if tag_path.empty?
+
+      css_from_trimmed_tag_path(tag_path)
+    end
+
+    def shared_class_items_selector(roots)
+      shared = roots.map { |root| root.attrs.class_names }.reduce { |left, right| left & right }
+      return nil if shared.nil? || shared.empty?
+
+      "#{roots.first.name}.#{shared.min}"
+    end
+
+    def css_from_trimmed_tag_path(tag_path)
+      segments = tag_path.split('/').reject(&:empty?)
+      trimmed = trim_leading_items_segments(segments)
+      trimmed.join(' > ')
+    end
+
+    def trim_leading_items_segments(segments)
+      return segments if segments.empty?
+
+      trimmed = segments.dup
+      trimmed.shift while trimmed.any? && LEADING_TRIM_TAGS.include?(trimmed.first)
+      trimmed.shift while trimmed.length > 1 && trimmed.first == 'div'
+      trimmed.empty? ? [segments.last] : trimmed
+    end
+
+    def common_path_prefix(paths) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+      return '' if paths.empty?
+
+      segments = paths.map { |p| p.split('/').reject(&:empty?) }
+      prefix = segments.first
+      segments.each do |seg|
+        i = 0
+        i += 1 while i < prefix.length && i < seg.length && prefix[i] == seg[i]
+        prefix = prefix[0...i]
+      end
+      "/#{prefix.join('/')}"
+    end
+
+    def title_selector(root) # rubocop:disable Metrics/CyclomaticComplexity
+      heading = root.find(&:heading?)
+      relative = css_for_path(heading.tag_path, root.tag_path) if heading
+      relative ||= begin
+        link = root.find { |n| n.link? && n.visible_text.to_s.strip.length > 3 }
+        css_for_path(link.tag_path, root.tag_path) if link
+      end
+      return nil unless relative
+
+      { selector: relative }
+    end
+
+    def link_selector(segment)
+      return nil unless segment.primary_link
+
+      relative = css_for_path(segment.primary_link.tag_path, segment.root_node.tag_path)
+      { selector: relative, extractor: 'href' }
+    end
+
+    def description_selector(root, segment)
+      relative = css_for_path(root.tag_path, segment.root_node.tag_path)
+      return nil if relative.nil? || relative.empty? || relative == '.'
+
+      { selector: relative }
+    end
+
+    def css_for_path(full_path, root_path)
+      relative = full_path.delete_prefix(root_path)
+      return '.' if relative.empty?
+
+      relative.split('/').reject(&:empty?).join(' > ')
+    end
+
+    def build_channel(response)
+      {
+        url: @url,
+        title: channel_title_from(response),
+        time_zone: 'UTC'
+      }.compact
+    end
+
+    def channel_title_from(response)
+      Channel.from_response(response).title
+    rescue StandardError
+      nil
+    end
+  end
+end

--- a/lib/html2rss/cli.rb
+++ b/lib/html2rss/cli.rb
@@ -2,6 +2,7 @@
 
 require 'fileutils'
 require 'json'
+require 'yaml'
 require 'thor'
 
 module Html2rss
@@ -98,6 +99,43 @@ module Html2rss
       puts(format == 'jsonfeed' ? JSON.pretty_generate(result) : result)
     end
 
+    desc 'capture URL', 'Analyze a URL and print a reusable YAML feed config'
+    method_option :strategy,
+                  type: :string,
+                  desc: STRATEGY_OPTION_DESC,
+                  enum: STRATEGY_OPTION_ENUM
+    method_option :items_selector, type: :string, desc: 'CSS selector hint for items (optional)'
+    method_option :max_redirects,
+                  type: :numeric,
+                  desc: 'Maximum redirects to follow per request'
+    method_option :max_requests,
+                  type: :numeric,
+                  desc: 'Maximum requests to allow for this feed build'
+    method_option :limit,
+                  type: :numeric,
+                  desc: 'Maximum number of articles to keep (default: 25)'
+    method_option :input,
+                  type: :string,
+                  desc: 'Local HTML file path to read input from'
+    ##
+    # Captures a URL and prints a reusable YAML config.
+    #
+    # @param url [String, nil] source page URL for capture
+    # @return [void]
+    def capture(url = nil) # rubocop:disable Metrics/MethodLength
+      strategy, local_file_path, url = prepare_auto_inputs(url, options[:input])
+      config = Html2rss.capture(
+        url,
+        strategy:,
+        items_selector: options[:items_selector],
+        limit: options[:limit]&.to_i,
+        max_redirects: options[:max_redirects],
+        max_requests: options[:max_requests],
+        local_file_path:
+      )
+      puts YAML.dump(HashUtil.deep_stringify_keys(config))
+    end
+
     desc 'schema', 'Print the exported config JSON Schema'
     method_option :pretty,
                   type: :boolean,
@@ -183,7 +221,7 @@ module Html2rss
 
       file_path = check_file_exists!(input_option)
       detected_url = url || detect_base_url!(
-        file_path, 'Please specify a URL: html2rss auto [URL] --input <file>'
+        file_path, 'Please specify a URL: html2rss <command> [URL] --input <file>'
       )
 
       [:local_file, file_path, detected_url]

--- a/lib/html2rss/config/schema.rb
+++ b/lib/html2rss/config/schema.rb
@@ -64,7 +64,7 @@ module Html2rss
           schema[:$defs] = registry_catalog_defs
           schema.fetch(:properties).merge!(overlay)
           schema.fetch(:properties).delete(:dynamic_params_error)
-          DeepStringifier.call(schema)
+          HashUtil.deep_stringify_keys(schema)
         end
 
         private
@@ -144,7 +144,7 @@ module Html2rss
               items: Html2rss::Config::Validator::StylesheetConfig.json_schema(loose: true)
             },
             auto_source: Html2rss::Config::AutoSourceContract.json_schema(loose: true).merge(
-              default: DeepStringifier.call(Html2rss::AutoSource::DEFAULT_CONFIG)
+              default: HashUtil.deep_stringify_keys(Html2rss::AutoSource::DEFAULT_CONFIG)
             ),
             selectors: {
               type: 'object',
@@ -222,33 +222,6 @@ module Html2rss
       def registry_ref_list(catalog, registry)
         registry.keys.sort.map do |name|
           { '$ref' => "#/$defs/#{catalog}/#{name}" }
-        end
-      end
-
-      ##
-      # Converts nested hash keys to strings so the resulting schema serializes cleanly.
-      module DeepStringifier
-        module_function
-
-        # @param object [Hash, Array, Object] nested data to normalize
-        # @return [Hash, Array, Object] deep copy with stringified hash keys
-        def call(object)
-          case object
-          when Hash
-            stringify_hash(object)
-          when Array
-            object.map { |value| call(value) }
-          when Symbol
-            object.to_s
-          else
-            object
-          end
-        end
-
-        # @param object [Hash{Object => Object}] hash whose keys should become strings
-        # @return [Hash{String => Object}] hash with recursively normalized values
-        def stringify_hash(object)
-          object.to_h { |key, value| [key.to_s, call(value)] }
         end
       end
     end

--- a/lib/html2rss/hash_util.rb
+++ b/lib/html2rss/hash_util.rb
@@ -54,6 +54,23 @@ module Html2rss
       end
     end
 
+    # Converts hash keys (and Symbol values) to strings recursively.
+    #
+    # @param object [Object] value to normalize
+    # @return [Object] normalized value with string keys
+    def deep_stringify_keys(object)
+      case object
+      when Hash
+        object.to_h { |key, value| [key.to_s, deep_stringify_keys(value)] }
+      when Array
+        object.map { deep_stringify_keys(_1) }
+      when Symbol
+        object.to_s
+      else
+        object
+      end
+    end
+
     # Validates that hash keys are symbols.
     #
     # @param value [Object] candidate hash container whose keys must be symbols

--- a/spec/lib/html2rss/capture_spec.rb
+++ b/spec/lib/html2rss/capture_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Html2rss::Capture do
+  let(:url) { 'https://example.com/blog' }
+
+  def html_response(body, page_url: url)
+    Html2rss::RequestService::Response.new(
+      body:,
+      url: Html2rss::Url.from_absolute(page_url),
+      headers: { 'content-type' => 'text/html' }
+    )
+  end
+
+  describe '#build' do
+    context 'with a list fixture that shares an item class' do
+      subject(:result) do
+        instance = described_class.new(url)
+        allow(instance).to receive(:fetch_response).and_return(response)
+        instance.build
+      end
+
+      let(:response) { html_response(File.read('spec/fixtures/local_feed_test.html')) }
+
+      it 'emits items selector, title hash, and channel title', :aggregate_failures do # rubocop:disable RSpec/ExampleLength -- fixture contract
+        expect(result.articles_count).to eq(3)
+        expect(result.config[:selectors]).to include(
+          items: { selector: 'div.item' },
+          title: { selector: 'h2' },
+          link: { selector: 'h2 > a', extractor: 'href' }
+        )
+        expect(result.config[:selectors]).not_to have_key(:description)
+        expect(result.config[:channel]).to include(url:, title: a_string_matching(/\S/), time_zone: 'UTC')
+        expect(result.channel_title).to eq(result.config.dig(:channel, :title))
+      end
+    end
+
+    {
+      'drops leading html/body/div' => [
+        <<~HTML,
+          <html><body><div><main><section>
+            <article><h2><a href="/a1">Article One Title</a></h2></article>
+            <article><h2><a href="/a2">Article Two Title</a></h2></article>
+            <article><h2><a href="/a3">Article Three Title</a></h2></article>
+          </section></main></div></body></html>
+        HTML
+        'main > section > article'
+      ],
+      'keeps mid-path div after trim' => [
+        <<~HTML,
+          <html><body><main>
+            <div>
+              <article><h2><a href="/x1">Card One Here Longer</a></h2><p>more text here for item</p></article>
+              <article><h2><a href="/x2">Card Two Here Longer</a></h2><p>more text here for item</p></article>
+              <article><h2><a href="/x3">Card Three Here Longer</a></h2><p>more text here for item</p></article>
+            </div>
+          </main></body></html>
+        HTML
+        'main > div > article'
+      ],
+      'keeps a single remaining segment' => [
+        <<~HTML,
+          <html><body>
+            <section><h2><a href="/s1">Section One Item</a></h2></section>
+            <section><h2><a href="/s2">Section Two Item</a></h2></section>
+            <section><h2><a href="/s3">Section Three Item</a></h2></section>
+          </body></html>
+        HTML
+        'section'
+      ]
+    }.each do |label, (html, expected_items_selector)|
+      it "trims items path: #{label}" do
+        instance = described_class.new(url)
+        allow(instance).to receive(:fetch_response).and_return(html_response(html))
+
+        expect(instance.build.config.dig(:selectors, :items, :selector)).to eq(expected_items_selector)
+      end
+    end
+
+    context 'when selector derivation raises ArgumentError' do
+      subject(:result) { instance.build }
+
+      let(:instance) { described_class.new(url) }
+      let(:article) do
+        instance_double(Html2rss::Article, url: Html2rss::Url.from_absolute("#{url}/1"), title: 'One')
+      end
+
+      before do
+        allow(instance).to receive_messages(
+          fetch_response: html_response('<html><body></body></html>'),
+          extract_articles: [article]
+        )
+        allow(Html2rss::SST::Normalizer).to receive(:call).and_raise(ArgumentError, 'bad sst')
+        allow(Html2rss::Log).to receive(:warn)
+      end
+
+      it 'warns and omits selectors', :aggregate_failures do
+        expect(result.config[:selectors]).to be_nil
+        expect(Html2rss::Log).to have_received(:warn).with(/bad sst/)
+      end
+    end
+
+    it 'analyzes a local file when local_file_path is provided', :aggregate_failures do # rubocop:disable RSpec/ExampleLength -- local overlay contract
+      path = File.expand_path('spec/fixtures/local_feed_test.html')
+      result = described_class.build(url, strategy: :local_file, local_file_path: path)
+
+      expect(result.articles_count).to eq(3)
+      expect(result.config.dig(:selectors, :items, :selector)).to eq('div.item')
+      expect(result.config[:strategy]).to eq(:local_file)
+      expect(result.config.dig(:request, :local_file_path)).to eq(path)
+    end
+
+    it 'round-trips local capture config through Html2rss.feed', :aggregate_failures do # rubocop:disable RSpec/ExampleLength -- capture→feed contract
+      path = File.expand_path('spec/fixtures/local_feed_test.html')
+      config = described_class.build(url, strategy: :local_file, local_file_path: path).config
+
+      expect(config[:strategy]).to eq(:local_file)
+      expect(config.dig(:request, :local_file_path)).to eq(path)
+      expect(config[:selectors]).not_to have_key(:description)
+
+      feed = Html2rss.feed(config)
+      expect(feed.items.size).to eq(3)
+      expect(feed.items.map(&:title)).to eq(['First Post Item', 'Second Post Item', 'Third Post Item'])
+    end
+  end
+
+  describe 'Html2rss.capture' do
+    let(:config_hash) { { channel: { url: 'https://example.com' } } }
+
+    before do
+      allow(described_class).to receive(:build)
+        .and_return(instance_double(described_class::CaptureResult, config: config_hash))
+    end
+
+    it 'delegates to Capture.build', :aggregate_failures do
+      expect(Html2rss.capture('https://example.com')).to eq(config_hash)
+      expect(described_class).to have_received(:build)
+        .with('https://example.com', hash_including(strategy: :auto, local_file_path: nil))
+    end
+  end
+end

--- a/spec/lib/html2rss/cli_spec.rb
+++ b/spec/lib/html2rss/cli_spec.rb
@@ -268,6 +268,65 @@ RSpec.describe Html2rss::CLI do
     end
   end
 
+  describe '#capture' do
+    let(:captured_config) { { channel: { url: 'https://example.com', title: 'Example' } } }
+    let(:capture_defaults) do
+      {
+        strategy: :auto,
+        items_selector: nil,
+        max_redirects: nil,
+        max_requests: nil,
+        limit: nil,
+        local_file_path: nil
+      }
+    end
+
+    before do
+      allow(Html2rss).to receive(:capture).and_return(captured_config)
+    end
+
+    it 'prints string-key YAML without symbol-key prefixes' do
+      expect { cli.capture('https://example.com') }
+        .to output(YAML.dump(Html2rss::HashUtil.deep_stringify_keys(captured_config))).to_stdout
+    end
+
+    {
+      'strategy' => [{ strategy: 'botasaurus' }, { strategy: :botasaurus }],
+      'items_selector' => [{ items_selector: '.item' }, { items_selector: '.item' }],
+      'max_redirects' => [{ max_redirects: 8 }, { max_redirects: 8 }],
+      'max_requests' => [{ max_requests: 8 }, { max_requests: 8 }],
+      'limit' => [{ limit: 10 }, { limit: 10 }]
+    }.each do |label, (options, expected_kwargs)|
+      it "forwards #{label} to Html2rss.capture" do
+        cli.invoke(:capture, ['https://example.com'], options)
+
+        expect(Html2rss).to have_received(:capture)
+          .with('https://example.com', **capture_defaults, **expected_kwargs)
+      end
+    end
+
+    context 'when no URL is given and no input file is provided' do
+      it 'raises a Thor::Error' do
+        expect { cli.capture(nil) }
+          .to raise_error(Thor::Error, /A URL is required unless --input is specified/)
+      end
+    end
+
+    context 'with input option' do
+      it 'forwards local_file_path into Capture', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+        path = File.expand_path('spec/fixtures/local_feed_test.html')
+        cli.invoke(:capture, [], { input: 'spec/fixtures/local_feed_test.html' })
+
+        expect(Html2rss).to have_received(:capture).with(
+          'https://example.com/blog',
+          **capture_defaults,
+          strategy: :local_file,
+          local_file_path: path
+        )
+      end
+    end
+  end
+
   describe '#validate' do
     let(:result) { instance_double(Dry::Validation::Result, success?: success, errors:) }
     let(:errors) { instance_double(Dry::Validation::MessageSet, to_h: { selectors: ['bad config'] }) }

--- a/spec/lib/html2rss/hash_util_spec.rb
+++ b/spec/lib/html2rss/hash_util_spec.rb
@@ -40,6 +40,15 @@ RSpec.describe Html2rss::HashUtil do
     end
   end
 
+  describe '.deep_stringify_keys' do
+    it 'converts nested symbol keys and symbol values to strings' do
+      input = { channel: { url: 'https://example.com' }, strategy: :faraday }
+      expected = { 'channel' => { 'url' => 'https://example.com' }, 'strategy' => 'faraday' }
+
+      expect(described_class.deep_stringify_keys(input)).to eq(expected)
+    end
+  end
+
   describe '.assert_symbol_keys!' do
     it 'raises when a hash contains string keys' do
       expect do


### PR DESCRIPTION
## Summary
- Add `Html2rss.capture` and `html2rss capture` to derive YAML-ready feed configs (stable selectors, local `--input` support).
- Centralize deep key stringification in `HashUtil` (schema export + capture YAML).
- Document Capture API, Botasaurus compose helper, and request strategies.

## Test plan
- [x] `mise exec -- bundle exec rspec spec/lib/html2rss/capture_spec.rb spec/lib/html2rss/hash_util_spec.rb spec/lib/html2rss/cli_spec.rb`
- [ ] Smoke: `html2rss capture https://example.com` prints string-key YAML
- [ ] Smoke: `html2rss capture --input spec/fixtures/local_feed_test.html` stamps `local_file` strategy

Stacked follow-up: MCP server PR will target this branch.