### PR TITLE
fix(request): detect DataDome and split Botasaurus service errors

### DIFF
--- a/lib/html2rss/cli.rb
+++ b/lib/html2rss/cli.rb
@@ -266,6 +266,7 @@ module Html2rss
             'or increase request.max_requests in the config.'
     rescue Html2rss::RequestService::BotasaurusConfigurationError,
            Html2rss::RequestService::BotasaurusConnectionFailed,
+           Html2rss::RequestService::BotasaurusServiceError,
            Html2rss::RequestService::BlockedSurfaceDetected,
            Html2rss::NoFeedItemsExtracted => error
       raise Thor::Error, error.message

--- a/lib/html2rss/request_service.rb
+++ b/lib/html2rss/request_service.rb
@@ -35,8 +35,10 @@ module Html2rss
     class RequestTimedOut < Html2rss::Error; end
     # Raised when Botasaurus configuration is missing or invalid.
     class BotasaurusConfigurationError < Html2rss::Error; end
-    # Raised when Botasaurus cannot be reached or returns invalid payloads.
+    # Raised when the Botasaurus service cannot be reached (network / DNS / SSL).
     class BotasaurusConnectionFailed < Html2rss::Error; end
+    # Raised when Botasaurus responds but the scrape fails (upstream error, bad payload).
+    class BotasaurusServiceError < Html2rss::Error; end
 
     class << self
       extend Forwardable

--- a/lib/html2rss/request_service/blocked_surface.rb
+++ b/lib/html2rss/request_service/blocked_surface.rb
@@ -23,6 +23,17 @@ module Html2rss
           message: 'Blocked surface detected: Cloudflare anti-bot interstitial page. ' \
                    'Target a direct listing URL, configure BOTASAURUS_SCRAPER_URL, ' \
                    'or run from an environment that can complete anti-bot checks.'
+        },
+        {
+          key: :datadome_interstitial,
+          min_matches: 2,
+          patterns: [
+            /captcha-delivery\.com/,
+            /DataDome/i,
+            /interstitial/i
+          ],
+          message: 'Blocked surface detected: DataDome anti-bot challenge page. ' \
+                   'Target a direct listing URL, or scrape via a session with resolved DataDome cookies.'
         }
       ].freeze
 

--- a/lib/html2rss/request_service/botasaurus_contract.rb
+++ b/lib/html2rss/request_service/botasaurus_contract.rb
@@ -84,10 +84,10 @@ module Html2rss
         end
 
         # @return [String] rendered HTML body from Botasaurus
-        # @raise [BotasaurusConnectionFailed] when html is missing
+        # @raise [BotasaurusServiceError] when html is missing
         def html
           value = payload['html']
-          raise BotasaurusConnectionFailed, "Botasaurus response missing required 'html' field" if value.nil?
+          raise BotasaurusServiceError, "Botasaurus response missing required 'html' field" if value.nil?
 
           value.to_s
         end
@@ -166,14 +166,14 @@ module Html2rss
 
       # @param transport_response [Faraday::Response] upstream HTTP response
       # @return [ParsedResponse]
-      # @raise [BotasaurusConnectionFailed] when payload is not valid JSON object
+      # @raise [BotasaurusServiceError] when payload is not valid JSON object
       def parse_response(transport_response)
         payload = JSON.parse(transport_response.body.to_s)
-        raise BotasaurusConnectionFailed, 'Botasaurus response must be a JSON object' unless payload.is_a?(Hash)
+        raise BotasaurusServiceError, 'Botasaurus response must be a JSON object' unless payload.is_a?(Hash)
 
         ParsedResponse.new(payload:, transport_status: transport_response.status)
       rescue JSON::ParserError => error
-        raise BotasaurusConnectionFailed, "Botasaurus response JSON parse failed: #{error.message}"
+        raise BotasaurusServiceError, "Botasaurus response JSON parse failed: #{error.message}"
       end
 
       private

--- a/lib/html2rss/request_service/botasaurus_strategy.rb
+++ b/lib/html2rss/request_service/botasaurus_strategy.rb
@@ -41,7 +41,7 @@ module Html2rss
       def raise_if_upstream_failed!(parsed_response)
         return unless parsed_response.upstream_failure?
 
-        raise BotasaurusConnectionFailed, parsed_response.upstream_failure_message
+        raise BotasaurusServiceError, parsed_response.upstream_failure_message
       end
 
       def response_url(final_url)

--- a/spec/lib/html2rss/request_service/blocked_surface_spec.rb
+++ b/spec/lib/html2rss/request_service/blocked_surface_spec.rb
@@ -4,19 +4,37 @@ require 'spec_helper'
 
 RSpec.describe Html2rss::RequestService::BlockedSurface do
   describe '.interstitial?' do
-    let(:blocked_body) do
+    let(:cloudflare_body) do
       '<html><head><title>Just a moment...</title></head>' \
         '<body>Checking your browser before accessing example.com.</body></html>'
     end
 
-    it 'returns true when a known interstitial signature matches' do
-      expect(described_class.interstitial?(blocked_body)).to be(true)
+    let(:datadome_body) do
+      '<html><body>' \
+        '<script src="https://ct.captcha-delivery.com/c.js"></script>' \
+        '<div>DataDome interstitial challenge</div>' \
+        '</body></html>'
+    end
+
+    it 'returns true when a Cloudflare interstitial signature matches' do
+      expect(described_class.interstitial?(cloudflare_body)).to be(true)
+    end
+
+    it 'returns true when a DataDome interstitial signature matches' do
+      expect(described_class.interstitial?(datadome_body)).to be(true)
     end
 
     it 'does not raise when body includes invalid byte sequences', :aggregate_failures do
       body = "\xFF\xFE".b
       expect { described_class.interstitial?(body) }.not_to raise_error
       expect(described_class.interstitial?(body)).to be(false)
+    end
+  end
+
+  describe '.interstitial_signature_for' do
+    it 'returns the DataDome signature key when matched' do
+      body = '<html><body>captcha-delivery.com DataDome</body></html>'
+      expect(described_class.interstitial_signature_for(body)[:key]).to eq(:datadome_interstitial)
     end
   end
 end

--- a/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
@@ -288,10 +288,10 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
         }
       end
 
-      it 'raises BotasaurusConnectionFailed with diagnostics' do
+      it 'raises BotasaurusServiceError with diagnostics' do
         expect { execute }
           .to raise_error(
-            Html2rss::RequestService::BotasaurusConnectionFailed,
+            Html2rss::RequestService::BotasaurusServiceError,
             /status=502, error_category=navigation_error, error=navigation failed, request_id=trace-123/
           )
       end
@@ -308,10 +308,10 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
         }
       end
 
-      it 'raises BotasaurusConnectionFailed' do
+      it 'raises BotasaurusServiceError' do
         expect { execute }
           .to raise_error(
-            Html2rss::RequestService::BotasaurusConnectionFailed,
+            Html2rss::RequestService::BotasaurusServiceError,
             /status=200, error_category=metadata_error, error=metadata collection failed, request_id=trace-456/
           )
       end
@@ -320,9 +320,9 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
     context 'when upstream payload is invalid JSON' do
       let(:api_response) { instance_double(Faraday::Response, status: 200, body: 'not-json') }
 
-      it 'raises BotasaurusConnectionFailed' do
+      it 'raises BotasaurusServiceError' do
         expect { execute }
-          .to raise_error(Html2rss::RequestService::BotasaurusConnectionFailed, /JSON parse failed/)
+          .to raise_error(Html2rss::RequestService::BotasaurusServiceError, /JSON parse failed/)
       end
     end
 
@@ -336,9 +336,9 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
         }
       end
 
-      it 'raises BotasaurusConnectionFailed' do
+      it 'raises BotasaurusServiceError' do
         expect { execute }
-          .to raise_error(Html2rss::RequestService::BotasaurusConnectionFailed, /missing required 'html'/)
+          .to raise_error(Html2rss::RequestService::BotasaurusServiceError, /missing required 'html'/)
       end
     end
 

--- a/spec/lib/html2rss/request_service_spec.rb
+++ b/spec/lib/html2rss/request_service_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Html2rss::RequestService do
       described_class::ResponseTooLarge,
       described_class::RequestTimedOut,
       described_class::BotasaurusConfigurationError,
-      described_class::BotasaurusConnectionFailed
+      described_class::BotasaurusConnectionFailed,
+      described_class::BotasaurusServiceError
     ]
   end
 


### PR DESCRIPTION
## What changed

- Add DataDome interstitial signature to `BlockedSurface` (`captcha-delivery.com` / `DataDome` / `interstitial`, min 2 matches) so auto-source classifies those pages as `:blocked_surface`.
- Introduce `RequestService::BotasaurusServiceError` for scrape/payload failures from a reachable Botasaurus service.
- Keep `BotasaurusConnectionFailed` for transport reachability (connection refused, DNS, SSL).
- Route contract/strategy upstream failures and CLI rescue to the new error class.

## Why

DataDome challenge HTML was falling through to `:unsupported_surface`. Upstream scrape failures were also labeled as connection failures, so callers could not tell “service down” from “scrape failed through the service.”

## Risk

- Low for DataDome detection false positives when pages casually mention two signature strings.
- Breaking for callers that rescued only `BotasaurusConnectionFailed` for upstream/payload failures — they must also rescue `BotasaurusServiceError` (no shim).

## Review map

Review map: whole PR is small — start at `lib/html2rss/request_service/blocked_surface.rb`, then `botasaurus_strategy.rb` / `botasaurus_contract.rb`.

## Validation

- `mise exec -- bundle exec rspec spec/lib/html2rss/request_service/blocked_surface_spec.rb` — exit 0
- `mise exec -- bundle exec rspec spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb` — exit 0
- `make ready` — exit 0 (1265 examples, 0 failures)