### PR TITLE
fix(auto_source): reject fragment self-links and junk titles in Cleanup

### DIFF
--- a/lib/html2rss/auto_source/cleanup.rb
+++ b/lib/html2rss/auto_source/cleanup.rb
@@ -9,81 +9,85 @@ module Html2rss
     class Cleanup
       # Default cleanup behavior for auto-sourced article lists.
       DEFAULT_CONFIG = {
-        keep_different_domain: false,
-        min_words_title: 3
+        keep_different_domain: false
       }.freeze
+
+      # Minimum alphanumeric word count for present titles.
+      MIN_WORDS = 3
 
       # Allowed URL schemes for article filtering.
       VALID_SCHEMES = %w[http https].to_set.freeze
+
+      # Credit-agency-only or photo-credit titles (not headlines).
+      CREDIT_TITLE = %r{
+        \A(?:AFP|Getty(?:\s+Images)?|Reuters|dpa|Imagn)
+          (?:\s*/\s*(?:AFP|Getty(?:\s+Images)?|Reuters|dpa|Imagn))*\z
+        |
+        \A(?:Image|Photo|Credit)\s*[:|]?\s*
+          (?:AFP|Getty(?:\s+Images)?|Reuters|dpa|Imagn)\b
+      }ix
+
+      # Dotted / methode CMS tokens mistaken for titles.
+      CMS_TOKEN_TITLE = /\A(?:lucy\.\w[\w.-]*|methode[-.][\w.-]+)\z/i
 
       class << self
         # @param articles [Array<Article>] extracted article candidates
         # @param url [Html2rss::Url] feed source URL used for same-host filtering
         # @param keep_different_domain [Boolean] whether to keep off-domain entries
-        # @param min_words_title [Integer] minimum word count for title filtering
         # @return [Array<Article>] cleaned article list
-        def call(articles, url:, keep_different_domain:, min_words_title:)
+        def call(articles, url:, keep_different_domain: DEFAULT_CONFIG.fetch(:keep_different_domain))
           Log.debug "Cleanup: start with #{articles.size} articles"
 
           articles.select!(&:valid?)
 
-          deduplicate_by!(articles, :url)
-
+          deduplicate_by_url!(articles)
           keep_only_http_urls!(articles)
+          reject_self_links!(articles, url)
           reject_different_domain!(articles, url) unless keep_different_domain
-          keep_only_with_min_words_title!(articles, min_words_title:)
+          reject_low_quality_titles!(articles)
 
           Log.debug "Cleanup: end with #{articles.size} articles"
           articles
         end
 
-        ##
-        # Deduplicates articles by a given key.
-        #
-        # @param articles [Array<Article>] The list of articles to process.
-        # @param key [Symbol] The key to deduplicate by.
-        # @return [Array<Article>] the mutated articles array
-        def deduplicate_by!(articles, key)
+        private
+
+        def deduplicate_by_url!(articles)
           seen = {}
           articles.reject! do |article|
-            value = article.public_send(key)
-            value.nil? || seen.key?(value).tap { seen[value] = true }
+            identity = url_identity(article.url)
+            identity.nil? || seen.key?(identity).tap { seen[identity] = true }
           end
         end
 
-        ##
-        # Keeps only articles with HTTP or HTTPS URLs.
-        #
-        # @param articles [Array<Article>] The list of articles to process.
-        # @return [Array<Article>] the mutated articles array
         def keep_only_http_urls!(articles)
           articles.select! { |article| VALID_SCHEMES.include?(article.url&.scheme) }
         end
 
-        ##
-        # Rejects articles that have a URL not on the same domain as the source.
-        #
-        # @param articles [Array<Article>] The list of articles to process.
-        # @param base_url [Html2rss::Url] The source URL to compare against.
-        # @return [Array<Article>] the mutated articles array
+        def reject_self_links!(articles, base_url)
+          source_identity = url_identity(base_url)
+          articles.reject! { |article| url_identity(article.url) == source_identity }
+        end
+
         def reject_different_domain!(articles, base_url)
           base_host = base_url.host
           articles.select! { |article| article.url&.host == base_host }
         end
 
-        ##
-        # Keeps only articles with a title that is present and has at least `min_words_title` words.
-        #
-        # @param articles [Array<Article>] The list of articles to process.
-        # @param min_words_title [Integer] The minimum number of words in the title.
-        # @return [Array<Article>] the mutated articles array
-        def keep_only_with_min_words_title!(articles, min_words_title:)
+        def reject_low_quality_titles!(articles)
           articles.select! do |article|
-            article.title ? word_count_at_least?(article.title, min_words_title) : true
+            title = article.title
+            title.nil? || (word_count_at_least?(title, MIN_WORDS) && !junk_title?(title))
           end
         end
 
-        private
+        def url_identity(url)
+          url&.without_fragment&.to_s
+        end
+
+        def junk_title?(title)
+          CREDIT_TITLE.match?(title) || CMS_TOKEN_TITLE.match?(title)
+        end
 
         def word_count_at_least?(str, min_words)
           count = 0

--- a/lib/html2rss/config/auto_source_contract.rb
+++ b/lib/html2rss/config/auto_source_contract.rb
@@ -46,7 +46,6 @@ module Html2rss
 
       optional(:cleanup).hash do
         optional(:keep_different_domain).filled(:bool)
-        optional(:min_words_title).filled(:integer, gt?: 0)
       end
     end
   end

--- a/lib/html2rss/url.rb
+++ b/lib/html2rss/url.rb
@@ -21,6 +21,7 @@ module Html2rss
   #   url = Url.from_relative('/foo-bar/baz.txt', 'https://example.com')
   #   url.titleized # => "Foo Bar Baz"
   #   url.channel_titleized # => "example.com: Foo Bar Baz"
+  # rubocop:disable Metrics/ClassLength -- value object owns resolve/sanitize/titleize/identity
   class Url
     include Comparable
 
@@ -190,6 +191,14 @@ module Html2rss
     end
 
     ##
+    # Returns a copy of the URL with the fragment removed (dedup / self-link identity).
+    #
+    # @return [Url] this URL when already fragment-free; otherwise a new URL
+    def without_fragment
+      @uri.fragment ? self.class.from_absolute(@uri.omit(:fragment).normalize.to_s) : self
+    end
+
+    ##
     # Returns a copy of the URL with the provided query values.
     #
     # @param values [Hash{String, Symbol => #to_s}] query parameters to assign
@@ -259,13 +268,7 @@ module Html2rss
     # @param other [Object] the other object to compare with
     # @return [Boolean] true if the URLs are equal
     def ==(other) = other.is_a?(Url) && to_s == other.to_s
-
-    ##
-    # Supports hash-based comparisons by ensuring equality semantics match `hash`.
-    #
-    # @param other [Object] the other object to compare with
-    # @return [Boolean] true if the URLs are considered equal
-    def eql?(other) = other.is_a?(Url) && to_s == other.to_s
+    alias eql? ==
 
     ##
     # Returns the hash code for this URL.
@@ -279,4 +282,5 @@ module Html2rss
     # @return [String] the debug representation
     def inspect = "#<#{self.class}:#{object_id} @uri=#{@uri.inspect}>"
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/schema/html2rss-config.schema.json
+++ b/schema/html2rss-config.schema.json
@@ -274,13 +274,6 @@
               "not": {
                 "type": "null"
               }
-            },
-            "min_words_title": {
-              "type": "integer",
-              "not": {
-                "type": "null"
-              },
-              "exclusiveMinimum": 0
             }
           },
           "required": []
@@ -325,8 +318,7 @@
           }
         },
         "cleanup": {
-          "keep_different_domain": false,
-          "min_words_title": 3
+          "keep_different_domain": false
         }
       }
     },

--- a/spec/lib/html2rss/auto_source/cleanup_spec.rb
+++ b/spec/lib/html2rss/auto_source/cleanup_spec.rb
@@ -32,13 +32,12 @@ RSpec.describe Html2rss::AutoSource::Cleanup do
   end
 
   describe '.call' do
-    subject { described_class.call(articles, url:, keep_different_domain:, min_words_title:) }
+    subject(:cleaned) { described_class.call(articles, url:, keep_different_domain:) }
 
     let(:keep_different_domain) { false }
-    let(:min_words_title) { 2 }
 
     it 'removes invalid articles' do
-      expect(subject).not_to include(articles[2])
+      expect(cleaned).not_to include(articles[2])
     end
 
     context 'with duplicated articles' do
@@ -46,26 +45,53 @@ RSpec.describe Html2rss::AutoSource::Cleanup do
         instance_double(Html2rss::Article,
                         valid?: true,
                         url: articles.first.url,
-                        title: 'Duplicated Article')
+                        title: 'Duplicated Article Title')
       end
 
-      before do
-        articles << duplicated_url_article
-      end
+      before { articles << duplicated_url_article }
 
       it 'removes duplicate articles by URL', :aggregate_failures do
-        expect(subject).not_to include(duplicated_url_article)
-        expect(subject.first.url).to eq(duplicated_url_article.url)
+        expect(cleaned).not_to include(duplicated_url_article)
+        expect(cleaned.first.url).to eq(duplicated_url_article.url)
+      end
+    end
+
+    context 'when URLs differ only by fragment' do
+      let(:url) { Html2rss::Url.from_absolute('http://example.com/news') }
+      let(:articles) do
+        [
+          instance_double(Html2rss::Article,
+                          valid?: true,
+                          url: Html2rss::Url.from_absolute('http://example.com/story-one'),
+                          title: 'First Story Title Here'),
+          instance_double(Html2rss::Article,
+                          valid?: true,
+                          url: Html2rss::Url.from_absolute('http://example.com/story-one#comments'),
+                          title: 'Same Story Different Fragment'),
+          instance_double(Html2rss::Article,
+                          valid?: true,
+                          url: Html2rss::Url.from_absolute('http://example.com/news#section'),
+                          title: 'Self Link With Fragment Text'),
+          instance_double(Html2rss::Article,
+                          valid?: true,
+                          url: Html2rss::Url.from_absolute('http://example.com/news'),
+                          title: 'Exact Self Link Title Words')
+        ]
+      end
+
+      it 'dedupes fragment variants and rejects page self-links', :aggregate_failures do
+        expect(cleaned.map { |article| article.url.to_s }).to eq(['http://example.com/story-one'])
+        expect(cleaned.size).to eq(1)
       end
     end
 
     it 'keeps only HTTP and HTTPS articles' do
-      expect(subject).not_to include(articles[4])
+      expect(cleaned).not_to include(articles[4])
     end
 
     context 'when keep_different_domain is false' do
       it 'removes articles from different domains' do
-        expect(subject).not_to include(articles[3])
+        expect(cleaned).not_to include(articles[3])
       end
     end
 
@@ -74,81 +100,79 @@ RSpec.describe Html2rss::AutoSource::Cleanup do
 
       it 'keeps articles from different domains' do
         different_domain_article = articles[3]
-        expect(subject).to include(different_domain_article)
+        expect(cleaned).to include(different_domain_article)
       end
     end
 
-    it 'keeps only articles with a title having at least min_words_title words' do
-      expect(subject).not_to include(articles[5])
-    end
-  end
-
-  describe '.keep_only_with_min_words_title!' do
-    subject(:keep_only_with_min_words_title!) do
-      described_class.keep_only_with_min_words_title!(articles, min_words_title:)
+    it 'rejects titles with fewer than three words' do
+      expect(cleaned).not_to include(articles[5])
     end
 
-    let(:articles) do
-      [
-        instance_double(Html2rss::Article, title: 'A valid title'),
-        instance_double(Html2rss::Article, title: 'Short'),
-        instance_double(Html2rss::Article, title: 'Another valid article title'),
-        instance_double(Html2rss::Article, title: nil),
-        instance_double(Html2rss::Article, title: ''),
-        instance_double(Html2rss::Article, title: 'Two words')
-      ]
-    end
-
-    context 'when min_words_title is 3' do
-      let(:min_words_title) { 3 }
-
-      it 'keeps only articles with at least 3 words in the title or nil title', :aggregate_failures do
-        keep_only_with_min_words_title!
-        expect(articles.map(&:title)).to contain_exactly('A valid title', 'Another valid article title', nil)
-      end
-    end
-
-    context 'when min_words_title is 1' do
-      let(:min_words_title) { 1 }
-
-      it 'keeps all articles except those with empty string title', :aggregate_failures do
-        keep_only_with_min_words_title!
-        expect(articles.map(&:title)).to contain_exactly(
-          'A valid title', 'Short', 'Another valid article title', nil, 'Two words'
-        )
-      end
-    end
-
-    context 'when all titles are nil or empty' do
+    context 'with junk and acceptable titles' do
+      let(:url) { Html2rss::Url.from_absolute('http://example.com/list') }
       let(:articles) do
         [
-          instance_double(Html2rss::Article, title: nil),
-          instance_double(Html2rss::Article, title: '')
+          instance_double(Html2rss::Article,
+                          valid?: true,
+                          url: Html2rss::Url.from_absolute('http://example.com/a'),
+                          title: 'A valid title'),
+          instance_double(Html2rss::Article,
+                          valid?: true,
+                          url: Html2rss::Url.from_absolute('http://example.com/b'),
+                          title: 'Getty Images'),
+          instance_double(Html2rss::Article,
+                          valid?: true,
+                          url: Html2rss::Url.from_absolute('http://example.com/c'),
+                          title: 'Photo: Reuters'),
+          instance_double(Html2rss::Article,
+                          valid?: true,
+                          url: Html2rss::Url.from_absolute('http://example.com/d'),
+                          title: 'lucy.smith.token'),
+          instance_double(Html2rss::Article,
+                          valid?: true,
+                          url: Html2rss::Url.from_absolute('http://example.com/e'),
+                          title: 'methode-article-slug'),
+          instance_double(Html2rss::Article,
+                          valid?: true,
+                          url: Html2rss::Url.from_absolute('http://example.com/f'),
+                          title: nil),
+          instance_double(Html2rss::Article,
+                          valid?: true,
+                          url: Html2rss::Url.from_absolute('http://example.com/g'),
+                          title: 'Reuters reports major breakthrough today')
         ]
       end
-      let(:min_words_title) { 2 }
 
-      it 'keeps only articles with nil title' do
-        keep_only_with_min_words_title!
-        expect(articles.map(&:title)).to contain_exactly(nil)
+      it 'rejects credit/CMS junk while keeping real headlines and nil titles', :aggregate_failures do
+        titles = cleaned.map(&:title)
+        expect(titles).to include('A valid title', nil, 'Reuters reports major breakthrough today')
+        expect(titles).not_to include('Getty Images', 'Photo: Reuters', 'lucy.smith.token', 'methode-article-slug')
       end
     end
 
     context 'with non-Latin titles' do
+      let(:url) { Html2rss::Url.from_absolute('http://example.com/list') }
       let(:articles) do
         [
-          instance_double(Html2rss::Article, title: 'Привет мир'),
-          instance_double(Html2rss::Article, title: 'مرحبا بالعالم'),
-          instance_double(Html2rss::Article, title: '你好 世界'),
-          instance_double(Html2rss::Article, title: '你好世界'),
-          instance_double(Html2rss::Article, title: nil)
+          instance_double(Html2rss::Article,
+                          valid?: true,
+                          url: Html2rss::Url.from_absolute('http://example.com/ru'),
+                          title: 'Привет мир сегодня'),
+          instance_double(Html2rss::Article,
+                          valid?: true,
+                          url: Html2rss::Url.from_absolute('http://example.com/ar'),
+                          title: 'مرحبا بالعالم اليوم'),
+          instance_double(Html2rss::Article,
+                          valid?: true,
+                          url: Html2rss::Url.from_absolute('http://example.com/zh'),
+                          title: '你好世界')
         ]
       end
-      let(:min_words_title) { 2 }
 
-      it 'counts Unicode words correctly', :aggregate_failures do
-        keep_only_with_min_words_title!
-        expect(articles.map(&:title)).to contain_exactly('Привет мир', 'مرحبا بالعالم', '你好 世界', nil)
+      it 'counts Unicode words with the fixed three-word gate', :aggregate_failures do
+        titles = cleaned.map(&:title)
+        expect(titles).to include('Привет мир сегодня', 'مرحبا بالعالم اليوم')
+        expect(titles).not_to include('你好世界')
       end
     end
   end

--- a/spec/lib/html2rss/auto_source_spec.rb
+++ b/spec/lib/html2rss/auto_source_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Html2rss::AutoSource do
       let(:config) do
         described_class::DEFAULT_CONFIG.merge(
           scraper: described_class::DEFAULT_CONFIG[:scraper].transform_values { |cfg| cfg.merge(enabled: false) },
-          cleanup: { keep_different_domain: true, min_words_title: 5 }
+          cleanup: { keep_different_domain: true }
         )
       end
 

--- a/spec/lib/html2rss/config_spec.rb
+++ b/spec/lib/html2rss/config_spec.rb
@@ -535,8 +535,7 @@ RSpec.describe Html2rss::Config do
             wordpress_api: { enabled: true } # wasn't explicitly set -> default
           },
           cleanup: {
-            keep_different_domain: false,     # wasn't explicitly set -> default
-            min_words_title: 3                # wasn't explicitly set -> default
+            keep_different_domain: false # wasn't explicitly set -> default
           }
         }
       end

--- a/spec/lib/html2rss/url_spec.rb
+++ b/spec/lib/html2rss/url_spec.rb
@@ -130,6 +130,28 @@ RSpec.describe Html2rss::Url do
     end
   end
 
+  describe '#without_fragment' do
+    it 'returns a copy without the fragment' do
+      url = described_class.from_absolute('https://example.com/news?q=1#section')
+
+      expect(url.without_fragment.to_s).to eq('https://example.com/news?q=1')
+    end
+
+    it 'returns self when there is no fragment' do
+      url = described_class.from_absolute('https://example.com/news')
+
+      expect(url.without_fragment).to equal(url)
+    end
+
+    it 'does not mutate the original url' do
+      url = described_class.from_absolute('https://example.com/news#top')
+
+      url.without_fragment
+
+      expect(url.to_s).to eq('https://example.com/news#top')
+    end
+  end
+
   describe '#with_query_values' do
     it 'returns a new url with the provided query values' do
       url = described_class.from_absolute('https://example.com/index.php?rest_route=%2F')


### PR DESCRIPTION
## What changed

- `Url#without_fragment` provides fragment-stripped URL identity
- `Cleanup` dedupes on that identity and rejects same-page `#fragment` self-links
- Title quality is a private fixed gate (`MIN_WORDS = 3` + credit/CMS denylist); `min_words_title` removed from config, contract, and schema
- Cleanup filter bang methods are private; behavior asserted via `.call`

## Why

Fragment-only and page self-links were treated as distinct articles, and credit/CMS junk titles survived the word-count-only filter. Cleanup remains the sole list-quality owner.

## Risk

- **Breaking:** configs that set `cleanup.min_words_title` are rejected
- Credit denylist may false-positive rare headlines that are agency-name-only; patterns stay credit-shaped
- Residual: sites with SSR anchors but client-rendered titles (e.g. NYT) still need scraper title ownership later

## Review map

Review map: whole PR is small — start at `lib/html2rss/auto_source/cleanup.rb`.

## Validation

- `make quick` — exit 0
- `make ready` — exit 0 (1267 examples, 0 failures)
- `mise exec -- bundle exec rake config:schema` — schema synced