### PR TITLE
fix(request): raise default max_redirects to 5

### DIFF
--- a/lib/html2rss/request_service/policy.rb
+++ b/lib/html2rss/request_service/policy.rb
@@ -18,7 +18,7 @@ module Html2rss
         connect_timeout_seconds: Integer(ENV.fetch('HTML2RSS_CONNECT_TIMEOUT_SECONDS', 5)),
         read_timeout_seconds: Integer(ENV.fetch('HTML2RSS_READ_TIMEOUT_SECONDS', 10)),
         total_timeout_seconds: Integer(ENV.fetch('HTML2RSS_TOTAL_TIMEOUT_SECONDS', 30)),
-        max_redirects: 3,
+        max_redirects: 5,
         max_response_bytes: 5_242_880,
         max_decompressed_bytes: 10_485_760,
         max_requests: 1,

--- a/spec/lib/html2rss/cli_spec.rb
+++ b/spec/lib/html2rss/cli_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Html2rss::CLI do
         expect { cli.auto('https://example.com') }
           .to raise_error(
             Thor::Error,
-            /retry with --max-redirects 4 or use the final URL directly/
+            /retry with --max-redirects 6 or use the final URL directly/
           )
       end
 
@@ -408,7 +408,7 @@ RSpec.describe Html2rss::CLI do
       expect { cli.feed('example.yml') }
         .to raise_error(
           Thor::Error,
-          /retry with --max-redirects 4 or use the final URL directly/
+          /retry with --max-redirects 6 or use the final URL directly/
         )
     end
 


### PR DESCRIPTION
## What changed

- `RequestService::Policy::DEFAULTS[:max_redirects]` raised from `3` to `5`
- CLI redirect-limit retry hints updated for the new default (`--max-redirects 6`)

## Why

Geo/edition redirect chains commonly need more than three hops. Higher default only — no auto-retry on the terminal URL (CLI hint unchanged in shape).

## Risk

- Slightly higher redirect-loop cost before the hard cap; policy otherwise unchanged
- Stacked on #450 (`fix/cleanup-fragment-title-quality`)

## Review map

Review map: whole PR is small — start at `lib/html2rss/request_service/policy.rb`.

## Validation

- `make quick` — exit 0
- `mise exec -- bundle exec rspec spec/lib/html2rss/cli_spec.rb spec/lib/html2rss/request_service/policy_spec.rb` — exit 0
- `make ready` — see commit notes / CI