### PR TITLE
fix(feed): surface app-shell hint when auto_source yields no items

### DIFF
--- a/lib/html2rss/auto_source/scraper.rb
+++ b/lib/html2rss/auto_source/scraper.rb
@@ -39,15 +39,15 @@ module Html2rss
       ##
       # Error raised when no suitable scraper is found.
       class NoScraperFound < Html2rss::Error
-        # User-facing messages grouped by no-scraper surface category.
+        # Surface diagnostics shared with {Html2rss::NoFeedItemsExtracted} (one string home).
         CATEGORY_MESSAGES = {
-          blocked_surface: 'No scrapers found: blocked surface likely (anti-bot or interstitial). ' \
+          blocked_surface: 'blocked surface likely (anti-bot or interstitial). ' \
                            'Target a direct listing URL, configure BOTASAURUS_SCRAPER_URL, ' \
                            'or run from an environment that can complete anti-bot checks.',
-          app_shell: 'No scrapers found: app-shell surface detected (client-rendered page with little or no ' \
+          app_shell: 'app-shell surface detected (client-rendered page with little or no ' \
                      'server-rendered article HTML). Configure BOTASAURUS_SCRAPER_URL or target a direct ' \
                      'listing/update URL instead of a homepage or shell entrypoint.',
-          unsupported_surface: 'No scrapers found: unsupported extraction surface for auto mode. ' \
+          unsupported_surface: 'unsupported extraction surface for auto mode. ' \
                                'Try a direct listing/changelog/category URL, ' \
                                'or use explicit selectors in a feed config.'
         }.freeze
@@ -57,7 +57,7 @@ module Html2rss
         def initialize(message = nil, category: :unsupported_surface)
           validate_category!(category)
           @category = category
-          super(message || CATEGORY_MESSAGES.fetch(@category))
+          super(message || "No scrapers found: #{CATEGORY_MESSAGES.fetch(@category)}")
         end
 
         attr_reader :category
@@ -174,13 +174,18 @@ module Html2rss
       end
       private_class_method :construction_kwargs
 
+      ##
+      # Classifies why scrapers could not extract from a parsed page.
+      #
+      # @param parsed_body [Nokogiri::HTML::Document]
+      # @param body [String, nil] raw body for blocked-surface detection
+      # @return [Symbol] one of {NoScraperFound::CATEGORY_MESSAGES} keys
       def self.classify_no_scraper_surface(parsed_body, body: nil)
         return :blocked_surface if blocked_surface?(parsed_body, body:)
         return :app_shell if app_shell_surface?(parsed_body)
 
         :unsupported_surface
       end
-      private_class_method :classify_no_scraper_surface
 
       def self.blocked_surface?(parsed_body, body: nil)
         Html2rss::RequestService::BlockedSurface.interstitial?(body || parsed_body.to_html)

--- a/lib/html2rss/error.rb
+++ b/lib/html2rss/error.rb
@@ -6,15 +6,23 @@ module Html2rss
 
   # Raised when auto fallback exhausts all concrete tiers and extractors find no feed items.
   class NoFeedItemsExtracted < Error
+    # Categories that append shared surface guidance to the empty-feed message.
+    SURFACE_HINT_CATEGORIES = %i[app_shell blocked_surface].freeze
+
     ##
     # @param attempts [Array<Hash{Symbol => Object}>] tier attempt diagnostics
-    def initialize(attempts:)
+    # @param surface_category [Symbol, nil] optional Scraper surface classification
+    def initialize(attempts:, surface_category: nil)
       @attempts = attempts
+      @surface_category = surface_category
       super(build_message)
     end
 
     # @return [Array<Hash{Symbol => Object}>] tier attempt diagnostics
     attr_reader :attempts
+
+    # @return [Symbol, nil] surface classification when a response body was available
+    attr_reader :surface_category
 
     private
 
@@ -24,8 +32,12 @@ module Html2rss
         "#{attempt[:strategy]} (#{details})"
       end.join(', ')
 
-      "No feed items extracted after auto fallback across strategies: #{summaries}. " \
-        'Try a more specific listing URL or provide explicit selectors.'
+      message = "No feed items extracted after auto fallback across strategies: #{summaries}. " \
+                'Try a more specific listing URL or provide explicit selectors.'
+      return message unless SURFACE_HINT_CATEGORIES.include?(surface_category)
+
+      guidance = AutoSource::Scraper::NoScraperFound::CATEGORY_MESSAGES.fetch(surface_category)
+      "#{message} #{guidance}"
     end
   end
 end

--- a/lib/html2rss/feed_pipeline.rb
+++ b/lib/html2rss/feed_pipeline.rb
@@ -81,12 +81,19 @@ module Html2rss
       request_session = request_session_for(config, strategy:, resources:)
       response = request_session.fetch_initial_response
       articles, dedup_dropped = deduplicated_articles(config:, response:, request_session:)
-      if config.auto_source && articles.empty?
-        raise NoFeedItemsExtracted.new(attempts: [{ strategy:, items_count: 0, error_class: nil }])
-      end
+      raise_empty_auto_source!(strategy:, response:) if config.auto_source && articles.empty?
 
       PipelineOutcome.new(
         response:, articles:, dedup_dropped:, selected_strategy: nil, attempt_count: 0, strategy_attempts: []
+      )
+    end
+
+    def raise_empty_auto_source!(strategy:, response:)
+      raise NoFeedItemsExtracted.new(
+        attempts: [{ strategy:, items_count: 0, error_class: nil }],
+        surface_category: AutoSource::Scraper.classify_no_scraper_surface(
+          response.parsed_body, body: response.body
+        )
       )
     end
 

--- a/lib/html2rss/feed_pipeline/auto_fallback.rb
+++ b/lib/html2rss/feed_pipeline/auto_fallback.rb
@@ -25,11 +25,12 @@ module Html2rss
       ##
       # Mutable run state for one auto-fallback chain: attempts plus selected result.
       class AttemptState
-        attr_reader :attempts, :result
+        attr_reader :attempts, :result, :last_response
 
         def initialize
           @attempts = []
           @result = nil
+          @last_response = nil
         end
 
         # @return [Boolean] true when a strategy already yielded items
@@ -50,6 +51,12 @@ module Html2rss
           attempt = { strategy:, items_count:, error_class: nil }
           attempt[:transport_meta] = transport_meta if transport_meta && !transport_meta.empty?
           @attempts << attempt
+        end
+
+        # @param response [RequestService::Response] last response that reached extraction
+        # @return [void]
+        def remember_response(response)
+          @last_response = response
         end
 
         # @param response [RequestService::Response] successful response
@@ -91,7 +98,7 @@ module Html2rss
         state = run_attempts
         return state.result if state.succeeded?
 
-        finalize_failure(attempts: state.attempts)
+        finalize_failure(attempts: state.attempts, response: state.last_response)
       end
 
       private
@@ -126,6 +133,7 @@ module Html2rss
       end
 
       def process_response(response:, strategy:, next_strategy:, request_session:, state:)
+        state.remember_response(response)
         articles, dedup_dropped = articles_for(response:, request_session:)
         items_count = articles.size
         state.record_items(strategy:, items_count:, transport_meta: response.transport_meta)
@@ -151,8 +159,11 @@ module Html2rss
                  "budget_remaining=#{budget_remaining_label}")
       end
 
-      def finalize_failure(attempts:)
-        raise NoFeedItemsExtracted.new(attempts:)
+      def finalize_failure(attempts:, response:)
+        surface_category = response && AutoSource::Scraper.classify_no_scraper_surface(
+          response.parsed_body, body: response.body
+        )
+        raise NoFeedItemsExtracted.new(attempts:, surface_category:)
       end
 
       # rubocop:disable Metrics/AbcSize, Metrics/MethodLength

--- a/spec/lib/html2rss/error_spec.rb
+++ b/spec/lib/html2rss/error_spec.rb
@@ -4,4 +4,24 @@ require 'nokogiri'
 
 RSpec.describe Html2rss::Error do
   it { expect(described_class).to be < StandardError }
+
+  describe Html2rss::NoFeedItemsExtracted do
+    let(:attempts) { [{ strategy: :faraday, items_count: 0, error_class: nil }] }
+
+    it 'keeps the base empty-feed message without a surface hint', :aggregate_failures do
+      error = described_class.new(attempts:)
+
+      expect(error.message).to include('No feed items extracted after auto fallback')
+      expect(error.message).not_to include('app-shell surface detected')
+    end
+
+    it 'appends shared Scraper guidance for app_shell', :aggregate_failures do
+      error = described_class.new(attempts:, surface_category: :app_shell)
+      guidance = Html2rss::AutoSource::Scraper::NoScraperFound::CATEGORY_MESSAGES.fetch(:app_shell)
+
+      expect(error.surface_category).to eq(:app_shell)
+      expect(error.message).to include(guidance)
+      expect(error.message).not_to include('No scrapers found:')
+    end
+  end
 end

--- a/spec/lib/html2rss/feed_pipeline_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline_spec.rb
@@ -80,6 +80,23 @@ RSpec.describe Html2rss::FeedPipeline do
       it 'raises NoFeedItemsExtracted at the pipeline boundary', :aggregate_failures do
         expect { pipeline.to_result }.to raise_error(Html2rss::NoFeedItemsExtracted) do |error|
           expect(error.attempts).to eq([{ strategy: :faraday, items_count: 0, error_class: nil }])
+          expect(error.surface_category).to eq(:unsupported_surface)
+        end
+      end
+
+      context 'when the empty page looks like an app shell' do # rubocop:disable RSpec/NestedGroups, RSpec/MultipleMemoizedHelpers
+        let(:empty_response) do
+          build_response.call(
+            body: '<html><body><div id="root"></div><script src="/assets/app.js"></script></body></html>'
+          )
+        end
+
+        it 'appends the shared app-shell guidance', :aggregate_failures do
+          expect { pipeline.to_result }.to raise_error(Html2rss::NoFeedItemsExtracted) do |error|
+            expect(error.surface_category).to eq(:app_shell)
+            expect(error.message).to include('app-shell surface detected')
+            expect(error.message).to include('BOTASAURUS_SCRAPER_URL')
+          end
         end
       end
     end
@@ -179,6 +196,35 @@ RSpec.describe Html2rss::FeedPipeline do
         end
         expect(Html2rss::RequestService).to have_received(:execute).with(anything, strategy: :botasaurus).once
         expect(Html2rss::RequestService).not_to have_received(:execute).with(anything, strategy: :browserless)
+      end
+
+      context 'when every strategy yields an app-shell page' do # rubocop:disable RSpec/NestedGroups, RSpec/MultipleMemoizedHelpers
+        let(:app_shell_response) do
+          build_response.call(
+            body: '<html><body><div id="root"></div><script src="/assets/app.js"></script></body></html>'
+          )
+        end
+        let(:strategy_results) do
+          {
+            faraday: app_shell_response,
+            botasaurus: app_shell_response
+          }
+        end
+        let(:config) do
+          {
+            strategy: :auto,
+            request: { max_requests: 3 },
+            channel: { url: 'https://example.com/news', title: 'Example News' },
+            auto_source: {}
+          }
+        end
+
+        it 'raises NoFeedItemsExtracted with app-shell guidance', :aggregate_failures do
+          expect { pipeline.to_result }.to raise_error(Html2rss::NoFeedItemsExtracted) do |error|
+            expect(error.surface_category).to eq(:app_shell)
+            expect(error.message).to include('app-shell surface detected')
+          end
+        end
       end
 
       context 'when first strategy fails but fallback strategy succeeds' do # rubocop:disable RSpec/MultipleMemoizedHelpers, RSpec/NestedGroups


### PR DESCRIPTION
## What changed

- `Scraper.classify_no_scraper_surface` is public; `NoScraperFound::CATEGORY_MESSAGES` is the single guidance home (prefix composed at raise time)
- `NoFeedItemsExtracted` accepts `surface_category:` and appends shared guidance for `:app_shell` / `:blocked_surface`
- Single-strategy and `AutoFallback` empty auto paths classify from the last response body
- Specs cover app-shell fixtures on both paths

## Why

AutoSource rescues `NoScraperFound` → `[]`, so empty-feed errors lost the app-shell diagnosis. Reuse Scraper classification instead of inventing Status/telemetry.

## Risk

- Message text for `NoScraperFound` still includes `No scrapers found:` (composed); guidance body is shared
- Dense junk-only pages may still classify as `:unsupported_surface` — Phase 1 Cleanup addresses that class
- Stacked on #451 (`fix/default-max-redirects-5`)

## Review map

1. `lib/html2rss/error.rb` — message enrichment + hint categories
2. `lib/html2rss/auto_source/scraper.rb` — shared `CATEGORY_MESSAGES` + public classify
3. `lib/html2rss/feed_pipeline.rb` / `auto_fallback.rb` — raise sites

## Validation

- `make quick` — exit 0
- `mise exec -- bundle exec rspec spec/lib/html2rss/error_spec.rb spec/lib/html2rss/feed_pipeline_spec.rb spec/lib/html2rss/auto_source/scraper_spec.rb` — exit 0
- `make ready` — see commit / CI