### PR TITLE
fix(mcp,request): auto strategy fallback for JS-rendered sites

### DIFF
--- a/lib/html2rss/mcp/server.rb
+++ b/lib/html2rss/mcp/server.rb
@@ -9,9 +9,9 @@ module Html2rss
     # ({Html2rss.auto_json_feed}, {Capture.build}, {Config.validate}, {Html2rss.feed}).
     # This module only maps MCP kwargs ↔ those APIs and shapes Tool::Response.
     #
-    # Strategy note: MCP +auto+ collapses to +:faraday+ (no FeedPipeline botasaurus
-    # fallback). Agents that get empty/blocked results should retry with
-    # +strategy: "botasaurus"+ (requires +BOTASAURUS_SCRAPER_URL+).
+    # Strategy note: MCP +auto+ passes through to FeedPipeline AutoFallback
+    # (faraday → botasaurus). Concrete strategies are used as-is.
+    # Botasaurus requires +BOTASAURUS_SCRAPER_URL+.
     module Server # rubocop:disable Metrics/ModuleLength
       # MCP server display name.
       SERVER_NAME = 'html2rss'
@@ -56,14 +56,14 @@ module Html2rss
         end
 
         ##
-        # Maps MCP strategy shortcut to a concrete request strategy.
-        # +:auto+ becomes +:faraday+ (no FeedPipeline fallback).
+        # Maps MCP strategy shortcut to a feed-level strategy plan.
+        # +:auto+ passes through as +:auto+ so the FeedPipeline's AutoFallback
+        # chain (faraday → botasaurus) is triggered for JS-rendered sites.
         #
         # @param strategy [String, Symbol, nil]
         # @return [Symbol]
         def resolve_mcp_strategy(strategy)
-          sym = (strategy || :auto).to_sym
-          sym == :auto ? :faraday : sym
+          (strategy || :auto).to_sym
         end
 
         ##
@@ -107,9 +107,10 @@ module Html2rss
             html2rss MCP — decide which tool to call:
 
             1. Need articles now (no saved config)? → scrape_url
-               - strategy "auto" = faraday only (no botasaurus fallback). If empty/JS-blocked, retry with strategy "botasaurus".
+               - strategy "auto" triggers faraday → botasaurus fallback chain for JS-rendered sites.
+               - If botasaurus is unconfigured and auto fails, try explicit "faraday" or set up Botasaurus.
             2. Need a reusable feed YAML/config? → capture_config, then validate_config, then apply_config
-            3. Debugging why scrape/capture is weak? → inspect_url (scrapers/SST/segments), then retry scrape/capture
+            3. Debugging why scrape/capture is weak? → inspect_url (scrapers/SST/segments/blocked_surface), then retry scrape/capture
             4. Have a config already? → validate_config (must succeed) → apply_config for RSS XML
             5. Schema / extractor / strategy lists → resources html2rss://schema|extractors|strategies
 
@@ -131,7 +132,7 @@ module Html2rss
             name: 'scrape_url',
             description: 'One-shot article extraction as JSON Feed items. ' \
                          'Use when you need articles now without a saved config. ' \
-                         'strategy "auto" = faraday only; retry with "botasaurus" if empty/JS-blocked.',
+                         'strategy "auto" triggers fallback chain (faraday → botasaurus) for JS-rendered sites.',
             input_schema: {
               type: 'object',
               properties: {
@@ -388,11 +389,22 @@ module Html2rss
         module_function
 
         ##
+        # Resolves feed-level strategy plans to concrete strategies for diagnostic fetch.
+        # +:auto+ collapses to +:faraday+ (inspect is a single-request diagnostic, not a fallback run).
+        #
+        # @param strategy [String, Symbol]
+        # @return [Symbol]
+        def concrete_strategy(strategy)
+          plan = FeedPipeline::StrategyPlan.resolve(Server.resolve_mcp_strategy(strategy))
+          plan.is_a?(FeedPipeline::StrategyPlan::Auto) ? :faraday : plan.strategy
+        end
+
+        ##
         # @param url [String]
         # @param strategy [String, Symbol]
         # @return [Hash]
-        def call(url:, strategy: :auto) # rubocop:disable Metrics/MethodLength
-          resolved = Server.resolve_mcp_strategy(strategy)
+        def call(url:, strategy: :auto) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+          resolved = concrete_strategy(strategy)
           response = fetch_response(url, resolved)
           parsed = response.parsed_body
 
@@ -415,6 +427,9 @@ module Html2rss
               }
             end
           end
+
+          blocked = Html2rss::RequestService::BlockedSurface.interstitial_signature_for(response.body)
+          result[:blocked_surface] = blocked[:key].to_s if blocked
 
           result
         end

--- a/lib/html2rss/request_service/blocked_surface.rb
+++ b/lib/html2rss/request_service/blocked_surface.rb
@@ -34,6 +34,18 @@ module Html2rss
           ],
           message: 'Blocked surface detected: DataDome anti-bot challenge page. ' \
                    'Target a direct listing URL, or scrape via a session with resolved DataDome cookies.'
+        },
+        {
+          key: :vercel_security_checkpoint,
+          min_matches: 1,
+          patterns: [
+            /Vercel Security Checkpoint/i,
+            %r{vercel\.com/security}i,
+            /checking the security/i
+          ],
+          message: 'Blocked surface detected: Vercel Security Checkpoint. ' \
+                   'This site is a JS-rendered SPA behind Vercel edge protection. ' \
+                   'Configure BOTASAURUS_SCRAPER_URL or target a direct listing URL.'
         }
       ].freeze
 

--- a/spec/lib/html2rss/mcp/server_spec.rb
+++ b/spec/lib/html2rss/mcp/server_spec.rb
@@ -43,10 +43,10 @@ RSpec.describe Html2rss::MCP::Server do
   end
 
   describe '.resolve_mcp_strategy' do
-    it 'collapses auto to faraday and passes through concrete strategies', :aggregate_failures do
-      expect(described_class.resolve_mcp_strategy(:auto)).to eq(:faraday)
+    it 'passes auto through and resolves concrete strategies', :aggregate_failures do
+      expect(described_class.resolve_mcp_strategy(:auto)).to eq(:auto)
       expect(described_class.resolve_mcp_strategy('botasaurus')).to eq(:botasaurus)
-      expect(described_class.resolve_mcp_strategy(nil)).to eq(:faraday)
+      expect(described_class.resolve_mcp_strategy(nil)).to eq(:auto)
     end
   end
 
@@ -57,7 +57,7 @@ RSpec.describe Html2rss::MCP::Server do
         'scrape_url', 'inspect_url', 'capture_config', 'validate_config', 'apply_config'
       )
       expect(protocol_server.prompts.keys).to contain_exactly('scrape-webpage', 'capture-feed-config')
-      expect(protocol_server.instructions).to include('auto" = faraday only')
+      expect(protocol_server.instructions).to include('"auto" triggers faraday')
       expect(protocol_server.instructions).to include('capture_config')
       expect(protocol_server.tools['validate_config'].description).to include('html2rss://schema')
       expect(protocol_server.tools['capture_config'].description).to include('html2rss://schema')
@@ -79,13 +79,13 @@ RSpec.describe Html2rss::MCP::Server do
 
         expect(Html2rss).to have_received(:auto_json_feed).with(
           'https://example.com',
-          hash_including(strategy: :faraday)
+          hash_including(strategy: :auto)
         )
         expect(result.dig(:result, :isError)).to be(false)
         expect(JSON.parse(result.dig(:result, :content, 0, :text))).to eq(
           [{ 'title' => 'A', 'url' => 'https://example.com/a' }]
         )
-        expect(result.dig(:result, :_meta)).to include(total: 1, strategy: 'faraday', channel_title: 'Channel')
+        expect(result.dig(:result, :_meta)).to include(total: 1, strategy: 'auto', channel_title: 'Channel')
       end
       # rubocop:enable RSpec/ExampleLength
     end
@@ -109,7 +109,7 @@ RSpec.describe Html2rss::MCP::Server do
 
         expect(Html2rss::Capture).to have_received(:build).with(
           'https://example.com',
-          hash_including(strategy: :faraday)
+          hash_including(strategy: :auto)
         )
         expect(result.dig(:result, :isError)).to be(false)
         expect(result.dig(:result, :_meta)).to include(

--- a/spec/lib/html2rss/request_service/blocked_surface_spec.rb
+++ b/spec/lib/html2rss/request_service/blocked_surface_spec.rb
@@ -16,12 +16,21 @@ RSpec.describe Html2rss::RequestService::BlockedSurface do
         '</body></html>'
     end
 
+    let(:vercel_body) do
+      '<html><head><title>Vercel Security Checkpoint</title></head>' \
+        '<body>Checking the security of your connection before accessing example.com.</body></html>'
+    end
+
     it 'returns true when a Cloudflare interstitial signature matches' do
       expect(described_class.interstitial?(cloudflare_body)).to be(true)
     end
 
     it 'returns true when a DataDome interstitial signature matches' do
       expect(described_class.interstitial?(datadome_body)).to be(true)
+    end
+
+    it 'returns true when a Vercel Security Checkpoint signature matches' do
+      expect(described_class.interstitial?(vercel_body)).to be(true)
     end
 
     it 'does not raise when body includes invalid byte sequences', :aggregate_failures do
@@ -35,6 +44,11 @@ RSpec.describe Html2rss::RequestService::BlockedSurface do
     it 'returns the DataDome signature key when matched' do
       body = '<html><body>captcha-delivery.com DataDome</body></html>'
       expect(described_class.interstitial_signature_for(body)[:key]).to eq(:datadome_interstitial)
+    end
+
+    it 'returns the Vercel signature key when matched' do
+      body = '<html><title>Vercel Security Checkpoint</title></html>'
+      expect(described_class.interstitial_signature_for(body)[:key]).to eq(:vercel_security_checkpoint)
     end
   end
 end


### PR DESCRIPTION
## What changed

- **BlockedSurface** — detect Vercel Security Checkpoint (`vercel_security_checkpoint`) alongside existing Cloudflare and DataDome signatures
- **MCP resolve_mcp_strategy** — pass `:auto` through to trigger `FeedPipeline::AutoFallback` (faraday -> botasaurus) instead of collapsing to `:faraday`
- **MCP Inspect** — expose `blocked_surface` key in `inspect_url` output when an interstitial is matched
- **Specs** — updated for new behavior; added Vercel pattern tests

## Why

JS-rendered SPA sites like newsminimalist.com (Next.js behind Vercel) returned 0 items with `:auto` because the MCP server collapsed it to `:faraday`, bypassing the botasaurus fallback that already existed in `FeedPipeline::AutoFallback`.

## Risk

Low -- `resolve_mcp_strategy` now returns `:auto` for `:auto` input, which flows into the existing `FeedPipeline::StrategyPlan` resolver that already understands `:auto`. The Vercel pattern is additive and only fires on bodies matching `vercel.com/security` or `"Vercel Security Checkpoint"`.

## Review map

Small PR (4 files, ~60 insertions, ~19 deletions). Start at `lib/html2rss/mcp/server.rb` for the strategy pass-through and inspect additions, then `lib/html2rss/request_service/blocked_surface.rb` for the Vercel signature.

## Validation

- `make quick` -- 36 examples, 0 failures, 0 lint offenses
- `make ready` -- 1273 examples, 0 failures, 98.32% line coverage
- Confirmed Vercel detection on live newsminimalist.com body