### PR TITLE
fix(auto_source): stop inventing titles; prefer in-card provenance

### DIFF
--- a/lib/html2rss/auto_source/cleanup.rb
+++ b/lib/html2rss/auto_source/cleanup.rb
@@ -30,6 +30,18 @@ module Html2rss
       # Dotted / methode CMS tokens mistaken for titles.
       CMS_TOKEN_TITLE = /\A(?:lucy\.\w[\w.-]*|methode[-.][\w.-]+)\z/i
 
+      # Raw URL slug / token clusters (hyphen or underscore, no natural phrasing).
+      SLUG_TITLE = /\A\p{Alnum}+(?:[-_]\p{Alnum}+){2,}\z/
+
+      # Date-prefix path tokens, raw or titleized ("2026 08 16 …", "2026-08-16-…").
+      DATE_PREFIX_TITLE = /\A\d{4}(?:[\s.-]+\d{1,2}){2}\b/
+
+      # Titleized path ending in a long numeric CMS id.
+      TITLEIZED_PATH_TITLE = /\A(?:\d+|\p{Lu}[\p{L}\p{M}]*)(?:\s+(?:\d+|\p{Lu}[\p{L}\p{M}]*))*\s+\d{6,}\z/
+
+      # Template / placeholder tokens mistaken for titles.
+      TEMPLATE_TITLE = /(\{\{[^}]+\}\}|%\{\w+\})/
+
       class << self
         # @param articles [Array<Article>] extracted article candidates
         # @param url [Html2rss::Url] feed source URL used for same-host filtering
@@ -86,7 +98,15 @@ module Html2rss
         end
 
         def junk_title?(title)
-          CREDIT_TITLE.match?(title) || CMS_TOKEN_TITLE.match?(title)
+          CREDIT_TITLE.match?(title) || CMS_TOKEN_TITLE.match?(title) || unnatural_title?(title)
+        end
+
+        def unnatural_title?(title)
+          stripped = title.to_s.strip
+          SLUG_TITLE.match?(stripped) ||
+            DATE_PREFIX_TITLE.match?(stripped) ||
+            TITLEIZED_PATH_TITLE.match?(stripped) ||
+            TEMPLATE_TITLE.match?(stripped)
         end
 
         def word_count_at_least?(str, min_words)

--- a/lib/html2rss/auto_source/cleanup.rb
+++ b/lib/html2rss/auto_source/cleanup.rb
@@ -86,6 +86,8 @@ module Html2rss
           articles.select! { |article| article.url&.host == base_host }
         end
 
+        # Keep missing titles (nil provenance). Drop present junk/unnatural titles —
+        # blanking them would hide bad extraction as "unknown" and inflate empty items.
         def reject_low_quality_titles!(articles)
           articles.select! do |article|
             title = article.title

--- a/lib/html2rss/auto_source/scraper/schema/item_list.rb
+++ b/lib/html2rss/auto_source/scraper/schema/item_list.rb
@@ -31,9 +31,8 @@ module Html2rss
             return unless object.is_a?(Hash)
             return unless emit?(object, from_list_item:)
 
-            article = Thing.new(object, url: base_url || '').call
-            titleize_list_item_stub!(article) if from_list_item
-            article
+            # Leave empty titles empty — do not invent from URL path (Cleanup allows nil).
+            Thing.new(object, url: base_url || '').call
           end
 
           # @param element [Object] raw list entry
@@ -55,17 +54,6 @@ module Html2rss
             return true if from_list_item
 
             Schema.normalize_types(object[:@type]).intersect?(Thing::SUPPORTED_TYPES)
-          end
-
-          # URL-only ListItem stubs historically used a titleized path as title.
-          #
-          # @param article [Hash] scraped article hash
-          # @return [void]
-          def titleize_list_item_stub!(article)
-            return unless article[:title].to_s.empty?
-            return unless (article_url = article[:url])
-
-            article[:title] = article_url.titleized
           end
         end
       end

--- a/lib/html2rss/html/sst_article_extractor.rb
+++ b/lib/html2rss/html/sst_article_extractor.rb
@@ -80,17 +80,46 @@ module Html2rss
         Url.from_relative("##{id}", @base_url) if id
       end
 
-      def extract_title # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-        source = heading || @selected_anchor
-        title_text = if source
-                       source.visible_text
-                     elsif @fallback_anchorless && @selected_anchor.nil?
-                       first_nonempty_own_text
-                     end
+      def extract_title
+        title_text = title_from_in_card_sources
         return unless title_text
 
         kicker = kicker_node&.visible_text.to_s.strip
         kicker && !kicker.empty? && !title_text.include?(kicker) ? "#{kicker}: #{title_text}" : title_text
+      end
+
+      # Prefer heading over credit-shaped visible text; never emit agency-only titles.
+      #
+      # @return [String, nil]
+      def title_from_in_card_sources
+        title_candidates.find { |text| !credit_shaped_title?(text) }
+      end
+
+      # @return [Array<String>] ordered in-card title candidates (heading → anchor → fallback)
+      def title_candidates
+        [].tap do |candidates|
+          add_title_candidate!(candidates, heading&.visible_text)
+          add_title_candidate!(candidates, @selected_anchor&.visible_text)
+          next unless candidates.empty? && @fallback_anchorless && @selected_anchor.nil?
+
+          add_title_candidate!(candidates, first_nonempty_own_text)
+        end
+      end
+
+      # @param candidates [Array<String>]
+      # @param text [String, nil]
+      # @return [void]
+      def add_title_candidate!(candidates, text)
+        stripped = text.to_s.strip
+        return if stripped.empty? || candidates.include?(stripped)
+
+        candidates << stripped
+      end
+
+      # @param text [String]
+      # @return [Boolean]
+      def credit_shaped_title?(text)
+        AutoSource::Cleanup::CREDIT_TITLE.match?(text)
       end
 
       def heading

--- a/spec/lib/html2rss/auto_source/cleanup_spec.rb
+++ b/spec/lib/html2rss/auto_source/cleanup_spec.rb
@@ -168,6 +168,10 @@ RSpec.describe Html2rss::AutoSource::Cleanup do
                           title: '2026 08 16 World Europe Some Article Slug'),
           instance_double(Html2rss::Article,
                           valid?: true,
+                          url: Html2rss::Url.from_absolute('http://example.com/template'),
+                          title: 'Hello {{article_title}} world token'),
+          instance_double(Html2rss::Article,
+                          valid?: true,
                           url: Html2rss::Url.from_absolute('http://example.com/jobs'),
                           title: 'Jobs in Berlin'),
           instance_double(Html2rss::Article,
@@ -177,13 +181,16 @@ RSpec.describe Html2rss::AutoSource::Cleanup do
         ]
       end
 
+      # Unnatural present titles are dropped (not blanked): inventing was wrong; missing
+      # provenance stays as nil and is kept. Template tokens prove TEMPLATE_TITLE is live.
       it 'rejects slug/token-shaped titles while keeping natural headlines', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
         titles = cleaned.map(&:title)
         expect(titles).to include('Jobs in Berlin', '5 Wahrheiten über die deutsche Leichtathletik')
         expect(titles).not_to include(
           'breakdancerin-raygun-geht-weiter-110168077',
           'Breakdancerin Raygun Geht Weiter 110168077',
-          '2026 08 16 World Europe Some Article Slug'
+          '2026 08 16 World Europe Some Article Slug',
+          'Hello {{article_title}} world token'
         )
       end
     end

--- a/spec/lib/html2rss/auto_source/cleanup_spec.rb
+++ b/spec/lib/html2rss/auto_source/cleanup_spec.rb
@@ -150,6 +150,44 @@ RSpec.describe Html2rss::AutoSource::Cleanup do
       end
     end
 
+    context 'with slug, date-path, and natural titles' do
+      let(:url) { Html2rss::Url.from_absolute('http://example.com/list') }
+      let(:articles) do
+        [
+          instance_double(Html2rss::Article,
+                          valid?: true,
+                          url: Html2rss::Url.from_absolute('http://example.com/slug'),
+                          title: 'breakdancerin-raygun-geht-weiter-110168077'),
+          instance_double(Html2rss::Article,
+                          valid?: true,
+                          url: Html2rss::Url.from_absolute('http://example.com/titleized'),
+                          title: 'Breakdancerin Raygun Geht Weiter 110168077'),
+          instance_double(Html2rss::Article,
+                          valid?: true,
+                          url: Html2rss::Url.from_absolute('http://example.com/date'),
+                          title: '2026 08 16 World Europe Some Article Slug'),
+          instance_double(Html2rss::Article,
+                          valid?: true,
+                          url: Html2rss::Url.from_absolute('http://example.com/jobs'),
+                          title: 'Jobs in Berlin'),
+          instance_double(Html2rss::Article,
+                          valid?: true,
+                          url: Html2rss::Url.from_absolute('http://example.com/leicht'),
+                          title: '5 Wahrheiten über die deutsche Leichtathletik')
+        ]
+      end
+
+      it 'rejects slug/token-shaped titles while keeping natural headlines', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+        titles = cleaned.map(&:title)
+        expect(titles).to include('Jobs in Berlin', '5 Wahrheiten über die deutsche Leichtathletik')
+        expect(titles).not_to include(
+          'breakdancerin-raygun-geht-weiter-110168077',
+          'Breakdancerin Raygun Geht Weiter 110168077',
+          '2026 08 16 World Europe Some Article Slug'
+        )
+      end
+    end
+
     context 'with non-Latin titles' do
       let(:url) { Html2rss::Url.from_absolute('http://example.com/list') }
       let(:articles) do

--- a/spec/lib/html2rss/auto_source/scraper/schema/item_list_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper/schema/item_list_spec.rb
@@ -38,6 +38,10 @@ RSpec.describe Html2rss::AutoSource::Scraper::Schema::ItemList do
       expect(call).not_to include(hash_including(title: 'Parent list (must not emit)'))
     end
 
+    it 'leaves URL-only ListItem stub titles empty instead of titleizing the path' do
+      expect(call).to all(include(title: nil))
+    end
+
     context 'when the schema_object does not contain itemListElement' do
       let(:schema_object) { { '@type': 'ItemList', name: 'Empty' } }
 

--- a/spec/lib/html2rss/html/sst_article_extractor_spec.rb
+++ b/spec/lib/html2rss/html/sst_article_extractor_spec.rb
@@ -85,6 +85,22 @@ RSpec.describe Html2rss::Html::SstArticleExtractor do
     expect(article.title).to be_nil
   end
 
+  it 'prefers real anchor text when the heading is credit-shaped', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+    html = <<~HTML
+      <html><body>
+        <article>
+          <h2>AFP / Getty Images</h2>
+          <a href="/news/story">Real Headline About The Story</a>
+          <p>Useful context paragraph with enough words for description extraction.</p>
+        </article>
+      </body></html>
+    HTML
+
+    article = described_class.call(segment_for(html), base_url: 'https://example.com')
+
+    expect(article.title).to eq('Real Headline About The Story')
+  end
+
   it 'extracts a background-image style URL as the article image', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
     html = <<~HTML
       <html><body>

--- a/spec/lib/html2rss/html/sst_article_extractor_spec.rb
+++ b/spec/lib/html2rss/html/sst_article_extractor_spec.rb
@@ -53,6 +53,38 @@ RSpec.describe Html2rss::Html::SstArticleExtractor do
     expect(article.title).to eq('Anchorless card text here')
   end
 
+  it 'prefers heading over credit-shaped anchor text', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+    html = <<~HTML
+      <html><body>
+        <article>
+          <h2>Real Headline About The Story</h2>
+          <a href="/news/story">AFP / Getty Images</a>
+          <p>Useful context paragraph with enough words for description extraction.</p>
+        </article>
+      </body></html>
+    HTML
+
+    article = described_class.call(segment_for(html), base_url: 'https://example.com')
+
+    expect(article.title).to eq('Real Headline About The Story')
+  end
+
+  it 'returns nil title when the only candidate is credit-shaped', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+    html = <<~HTML
+      <html><body>
+        <article>
+          <a href="/news/story">Photo: Reuters</a>
+          <p>Useful context paragraph with enough words for description extraction.</p>
+        </article>
+      </body></html>
+    HTML
+
+    article = described_class.call(segment_for(html), base_url: 'https://example.com')
+
+    expect(article).to be_a(Html2rss::Article)
+    expect(article.title).to be_nil
+  end
+
   it 'extracts a background-image style URL as the article image', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
     html = <<~HTML
       <html><body>


### PR DESCRIPTION
## Summary
- Stop Schema ListItem stubs from filling empty titles via `Url#titleized` (no invented path titles).
- Prefer in-card headings over credit-shaped visible text in SST extraction; otherwise leave title `nil`.
- Reject slug/token/date-shaped titles in Cleanup; keep CREDIT/CMS denylists as a safety net only (no document `og:title` fallback on list pages).

## Test plan
- [x] Targeted specs for Schema ItemList, Cleanup naturalness, SST extractor
- [x] `make quick` / `make ready` on branch
- [ ] Re-scrape CNN / WaPo / NYT / Zeit via MCP after merge for title quality