### PR TITLE
fix(request): retry once from last redirect hop on RedirectLimitReached

### DIFF
--- a/lib/html2rss/cli.rb
+++ b/lib/html2rss/cli.rb
@@ -280,7 +280,8 @@ module Html2rss
       yield
     rescue Faraday::FollowRedirects::RedirectLimitReached => error
       raise Thor::Error,
-            "#{error.message}. retry with --max-redirects #{suggested_max_redirects} or use the final URL directly."
+            "#{error.message}. already retried the last redirect hop once; " \
+            "retry with --max-redirects #{suggested_max_redirects} or use the final URL directly."
     rescue Html2rss::RequestService::RequestBudgetExceeded => error
       raise Thor::Error,
             "#{error.message}. retry with --max-requests #{suggested_max_requests} " \

--- a/lib/html2rss/request_service/faraday_strategy.rb
+++ b/lib/html2rss/request_service/faraday_strategy.rb
@@ -9,6 +9,7 @@ module Html2rss
     ##
     # Strategy to use Faraday for the request.
     # @see https://rubygems.org/gems/faraday
+    # rubocop:disable Metrics/ClassLength -- terminal redirect retry colocated with Faraday transport
     class FaradayStrategy < Strategy
       ##
       # Restores buffered streamed bytes so response middleware can process them.
@@ -36,7 +37,8 @@ module Html2rss
       def perform_execute
         deadline = request_deadline
         @response_guard = ResponseGuard.new(policy: ctx.policy)
-        raw_response = faraday_request(response_guard, deadline:, streaming_buffer: true)
+        reset_redirect_tracking!
+        raw_response = request_with_terminal_redirect_retry(response_guard, deadline:)
         raw_response = retry_without_streaming(response_guard, deadline:) if retry_without_streaming?(raw_response)
         build_response(raw_response)
       end
@@ -45,6 +47,45 @@ module Html2rss
 
       def request_deadline
         monotonic_now + ctx.budget.effective_timeout_seconds(fallback: ctx.policy.total_timeout_seconds)
+      end
+
+      def reset_redirect_tracking!
+        @last_redirect_to = nil
+        @terminal_redirect_retried = false
+        @request_url_override = nil
+      end
+
+      def request_with_terminal_redirect_retry(response_guard, deadline:)
+        faraday_request(response_guard, deadline:, streaming_buffer: true)
+      rescue Faraday::FollowRedirects::RedirectLimitReached => error
+        raise error unless terminal_redirect_retryable?
+
+        retry_from_terminal_redirect!(response_guard, deadline:)
+      end
+
+      def terminal_redirect_retryable?
+        return false if @terminal_redirect_retried || @last_redirect_to.nil?
+
+        @last_redirect_to.to_s != request_url.to_s
+      end
+
+      def retry_from_terminal_redirect!(response_guard, deadline:)
+        terminal_url = @last_redirect_to
+        @terminal_redirect_retried = true
+        Log.debug("#{self.class}: redirect limit reached; retrying once from #{terminal_url}")
+        begin_terminal_url_request!(terminal_url)
+        faraday_request(response_guard, deadline:, streaming_buffer: true, consume_budget: false)
+      end
+
+      def begin_terminal_url_request!(terminal_url)
+        ctx.policy.validate_request!(url: terminal_url, origin_url: ctx.origin_url, relation: ctx.relation)
+        @request_url_override = terminal_url
+        @client = nil
+        @last_redirect_to = nil
+      end
+
+      def request_url
+        @request_url_override || ctx.url
       end
 
       def build_response(response)
@@ -105,7 +146,7 @@ module Html2rss
 
       # rubocop:disable Metrics/AbcSize
       def client
-        @client ||= Faraday.new(url: ctx.url.to_s, headers: ctx.headers) do |faraday|
+        @client ||= Faraday.new(url: request_url.to_s, headers: ctx.headers) do |faraday|
           faraday.use Faraday::FollowRedirects::Middleware, limit: ctx.policy.max_redirects, callback: redirect_callback
           faraday.request :gzip
           faraday.use StreamingBodyMiddleware
@@ -168,6 +209,7 @@ module Html2rss
         lambda do |old_env, new_env|
           from_url = normalize_url(old_env[:url])
           to_url = normalize_url(new_env[:url])
+          @last_redirect_to = to_url
           ctx.policy.validate_redirect!(from_url:, to_url:, origin_url: ctx.origin_url, relation: ctx.relation)
         end
       end
@@ -180,5 +222,6 @@ module Html2rss
         Process.clock_gettime(Process::CLOCK_MONOTONIC)
       end
     end
+    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/spec/lib/html2rss/cli_spec.rb
+++ b/spec/lib/html2rss/cli_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Html2rss::CLI do
         expect { cli.auto('https://example.com') }
           .to raise_error(
             Thor::Error,
-            /retry with --max-redirects 6 or use the final URL directly/
+            /already retried the last redirect hop once; retry with --max-redirects 6 or use the final URL directly/
           )
       end
 
@@ -171,7 +171,7 @@ RSpec.describe Html2rss::CLI do
         expect { cli.invoke(:auto, ['https://example.com'], { max_redirects: 8 }) }
           .to raise_error(
             Thor::Error,
-            /retry with --max-redirects 9 or use the final URL directly/
+            /already retried the last redirect hop once; retry with --max-redirects 9 or use the final URL directly/
           )
       end
     end
@@ -408,7 +408,7 @@ RSpec.describe Html2rss::CLI do
       expect { cli.feed('example.yml') }
         .to raise_error(
           Thor::Error,
-          /retry with --max-redirects 6 or use the final URL directly/
+          /already retried the last redirect hop once; retry with --max-redirects 6 or use the final URL directly/
         )
     end
 
@@ -416,7 +416,7 @@ RSpec.describe Html2rss::CLI do
       expect { cli.invoke(:feed, ['example.yml'], { max_redirects: 8 }) }
         .to raise_error(
           Thor::Error,
-          /retry with --max-redirects 9 or use the final URL directly/
+          /already retried the last redirect hop once; retry with --max-redirects 9 or use the final URL directly/
         )
     end
   end

--- a/spec/lib/html2rss/request_service/faraday_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/faraday_strategy_spec.rb
@@ -176,6 +176,94 @@ RSpec.describe Html2rss::RequestService::FaradayStrategy do # rubocop:disable RS
       .to raise_error(Html2rss::RequestService::BlockedSurfaceDetected, /Blocked surface detected/)
   end
 
+  describe 'RedirectLimitReached terminal URL retry' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+    let(:redirect_callback) { {} }
+    let(:terminal_url) { 'https://cdn.example.com/terminal' }
+    let(:terminal_env) { instance_double(Faraday::Env, url: Addressable::URI.parse("#{terminal_url}/final")) }
+    let(:terminal_response) do
+      instance_double(
+        Faraday::Response,
+        body: '<html>terminal</html>',
+        headers: { 'content-type' => 'text/html' },
+        env: terminal_env,
+        status: 200
+      )
+    end
+    let(:terminal_request) { instance_double(Faraday::Request, options: Faraday::RequestOptions.new) }
+    let(:simulate_redirect_hops) do
+      lambda do |*hop_urls|
+        ([ctx.url.to_s] + hop_urls).each_cons(2) do |from, to|
+          redirect_callback[:proc].call(
+            { url: Addressable::URI.parse(from) },
+            { url: Addressable::URI.parse(to) }
+          )
+        end
+      end
+    end
+
+    before do
+      allow(builder).to receive(:use) do |klass, options = nil|
+        redirect_callback[:proc] = options[:callback] if klass == Faraday::FollowRedirects::Middleware
+      end
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(100.0)
+    end
+
+    it 're-fetches the last redirect hop once and succeeds', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      call_count = 0
+      allow(connection).to receive(:get) do |&block|
+        call_count += 1
+        block&.call(call_count == 1 ? request : terminal_request)
+        if call_count == 1
+          simulate_redirect_hops.call('https://cdn.example.com/hop1', terminal_url)
+          raise Faraday::FollowRedirects::RedirectLimitReached, 'too many redirects'
+        end
+
+        terminal_response
+      end
+
+      result = execute
+
+      expect(connection).to have_received(:get).twice
+      expect(budget).to have_received(:consume!).once
+      expect(policy).to have_received(:validate_redirect!).with(
+        from_url: Html2rss::Url.from_absolute('https://cdn.example.com/hop1'),
+        to_url: Html2rss::Url.from_absolute(terminal_url),
+        origin_url: ctx.origin_url,
+        relation: :initial
+      )
+      expect(policy).to have_received(:validate_request!).with(
+        hash_including(url: Html2rss::Url.from_absolute(terminal_url))
+      )
+      expect(Faraday).to have_received(:new).with(hash_including(url: terminal_url))
+      expect(result.body).to eq('<html>terminal</html>')
+      expect(result.url.to_s).to eq("#{terminal_url}/final")
+    end
+
+    it 'does not retry RedirectLimitReached more than once', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      call_count = 0
+      allow(connection).to receive(:get) do |&block|
+        call_count += 1
+        block&.call(call_count == 1 ? request : terminal_request)
+        simulate_redirect_hops.call(terminal_url)
+        raise Faraday::FollowRedirects::RedirectLimitReached, 'too many redirects'
+      end
+
+      expect { execute }.to raise_error(Faraday::FollowRedirects::RedirectLimitReached, /too many redirects/)
+      expect(connection).to have_received(:get).twice
+      expect(budget).to have_received(:consume!).once
+    end
+
+    it 'raises without retry when no redirect hop was recorded', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      allow(connection).to receive(:get) do |&block|
+        block&.call(request)
+        raise Faraday::FollowRedirects::RedirectLimitReached, 'too many redirects'
+      end
+
+      expect { execute }.to raise_error(Faraday::FollowRedirects::RedirectLimitReached, /too many redirects/)
+      expect(connection).to have_received(:get).once
+    end
+  end
+
   describe described_class::PeerIpValidator do # rubocop:disable RSpec/MultipleMemoizedHelpers
     let(:mock_socket) { instance_double(IPSocket, peeraddr: ['AF_INET', 443, '93.184.216.34', '93.184.216.34']) }
     let(:mock_net_http) do


### PR DESCRIPTION
## Summary
- Record the last validated redirect hop in FaradayStrategy.
- On `RedirectLimitReached`, re-fetch that terminal URL once (hard stop: one retry).
- Update CLI hint so it reflects the one-hop retry already attempted.

## Test plan
- [x] FaradayStrategy specs: success via terminal retry; no infinite retry; policy still validates hops
- [x] CLI hint expectations updated
- [x] `make quick` / `make ready` on branch
- [ ] Smoke cnn.com / usatoday.com without edition/eu workaround after merge