### PR TITLE
fix(auto_source): demote affiliate paths via commerce segments

### DIFF
--- a/lib/html2rss/link_destination/path_classifier.rb
+++ b/lib/html2rss/link_destination/path_classifier.rb
@@ -48,6 +48,9 @@ module Html2rss
             sinscrire inscription compte s-abonner saboner lettre-information confidentialite
             mentions-legales cgu menu sidebar widget social modal popup banner promo ad ads
             related recommendation recommendations pagination pager
+            dating jobs job career careers deals deal shopping shop trading broker
+            versicherung tierversicherung insurance vergleich comparison
+            partnerboerse singleboerse krypto crypto
           ] + SOFT_UTILITY.to_a
         ).to_set.freeze
         {

--- a/spec/lib/html2rss/link_destination/path_classifier_spec.rb
+++ b/spec/lib/html2rss/link_destination/path_classifier_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+RSpec.describe Html2rss::LinkDestination::PathClassifier do
+  def classifier_for(*segments)
+    described_class.new(segments)
+  end
+
+  describe 'commerce / affiliate utility segments' do
+    %w[
+      dating jobs job career careers deals deal shopping shop trading broker
+      versicherung tierversicherung insurance vergleich comparison
+      partnerboerse singleboerse krypto crypto
+    ].each do |segment|
+      it "marks /#{segment}/ routes as utility and high-confidence junk", :aggregate_failures do
+        classifier = classifier_for(segment)
+
+        expect(classifier.utility_path?).to be(true)
+        expect(classifier.junk_path?).to be(true)
+        expect(classifier.content_path?).to be(false)
+      end
+    end
+
+    it 'marks nested affiliate routes under a commerce segment as junk', :aggregate_failures do
+      classifier = classifier_for('dating', 'singles-in-berlin-heute')
+
+      expect(classifier.utility_path?).to be(true)
+      expect(classifier.junk_path?).to be(true)
+      expect(classifier.content_path?).to be(false)
+    end
+
+    it 'marks /deals/ product routes as utility for commerce demotion', :aggregate_failures do
+      classifier = classifier_for('deals', 'weekend-tech-sale-offers')
+
+      expect(classifier.utility_path?).to be(true)
+      expect(classifier.junk_path?).to be(true)
+    end
+  end
+
+  describe 'content-like news path regression' do
+    it 'does not treat /news/ article routes as utility junk', :aggregate_failures do
+      classifier = classifier_for('news', '2026', 'platform-launch-notes')
+
+      expect(classifier.content_path?).to be(true)
+      expect(classifier.utility_path?).to be(false)
+      expect(classifier.junk_path?).to be(false)
+    end
+
+    it 'does not demote /politik/ article slugs as commerce junk', :aggregate_failures do
+      classifier = classifier_for('politik', 'koalition-beschliesst-neues-gesetz')
+
+      expect(classifier.utility_path?).to be(false)
+      expect(classifier.junk_path?).to be(false)
+    end
+
+    it 'keeps /nachrichten/ dated routes as content, not utility', :aggregate_failures do
+      classifier = classifier_for('nachrichten', '2026', 'neuigkeiten-zum-produkt')
+
+      expect(classifier.content_path?).to be(true)
+      expect(classifier.utility_path?).to be(false)
+      expect(classifier.junk_path?).to be(false)
+    end
+  end
+end

--- a/spec/lib/html2rss/scoring/engine_spec.rb
+++ b/spec/lib/html2rss/scoring/engine_spec.rb
@@ -17,23 +17,27 @@ RSpec.describe Html2rss::Scoring::Engine do
     )
   end
 
+  def article_segment(href:, title:, position:)
+    link = build_node(name: :a, href:, text: title)
+    root = build_node(
+      name: :article,
+      children: [
+        build_node(name: :h2, text: title),
+        link,
+        build_node(name: :p, text: 'Extra descriptive context that is long enough for signals here.')
+      ]
+    )
+    build_segment(root:, link:, position:)
+  end
+
   let(:engine) { described_class.new(link_resolver: Html2rss::Scoring::LinkResolver.new('https://example.com/')) }
 
   describe '#rank / #rank_top' do
     let(:segments) do
-      article_link = build_node(name: :a, href: '/news/deep-story-slug-here', text: 'Deep Story Title Words')
-      article_root = build_node(
-        name: :article,
-        children: [
-          build_node(name: :h2, text: 'Deep Story Title Words'),
-          article_link,
-          build_node(name: :p, text: 'Extra descriptive context that is long enough for signals here.')
-        ]
-      )
       junk_link = build_node(name: :a, href: '/login', text: 'Login')
       [
         build_segment(root: build_node(name: :div, children: [junk_link]), link: junk_link, position: 0),
-        build_segment(root: article_root, link: article_link, position: 1)
+        article_segment(href: '/news/deep-story-slug-here', title: 'Deep Story Title Words', position: 1)
       ]
     end
 
@@ -47,6 +51,12 @@ RSpec.describe Html2rss::Scoring::Engine do
       top = engine.rank_top(segments, limit: 10)
       expect(top.size).to eq(1)
       expect(top.first.final_score).to be >= described_class::SCORE_FLOOR
+    end
+
+    it 'demotes commerce affiliate paths via utility_path without title word lists' do
+      affiliate = article_segment(href: '/dating/singles-in-berlin', title: 'Singles in Berlin finden', position: 0)
+      news = article_segment(href: '/news/deep-story-slug-here', title: 'Deep Story Title Words', position: 1)
+      expect(engine.rank([affiliate, news]).map { _1.primary_link.attrs.href }).to eq(['/news/deep-story-slug-here'])
     end
   end
 


### PR DESCRIPTION
## Summary
- Extend PathClassifier utility segments with commerce/affiliate routes (`dating`, `jobs`, `deals`, `shopping`, `trading`, insurance/vergleich/crypto variants, etc.).
- Rely on existing Engine junk/`utility_path` demotion — no title vocabulary lists.
- Site-agnostic (Bild/Focus-style `/deals/`/`/dating/` paths).

## Test plan
- [x] PathClassifier specs for new segments + news-path regression
- [x] Engine demotion coverage via existing junk path
- [x] `make quick` / `make ready` on branch
- [ ] Re-scrape Bild / Focus after merge for affiliate demotion