### PR TITLE
feat: require directory.topics on feed configs

### DIFF
--- a/lib/html2rss/config/schema.rb
+++ b/lib/html2rss/config/schema.rb
@@ -79,6 +79,9 @@ module Html2rss
             { 'required' => ['selectors'] },
             { 'required' => ['auto_source'] }
           ]
+
+          topics = schema.dig(:properties, :directory, :properties, :topics)
+          topics[:minItems] = 1 if topics.is_a?(Hash)
         end
 
         # @return [Hash{Symbol => Hash}] catalog under $defs.post_processors / $defs.extractors

--- a/lib/html2rss/config/validator.rb
+++ b/lib/html2rss/config/validator.rb
@@ -6,7 +6,7 @@ module Html2rss
   class Config
     # Validates the configuration hash using Dry::Validation.
     # The configuration options adhere to the documented schema in README.md.
-    class Validator < Dry::Validation::Contract
+    class Validator < Dry::Validation::Contract # rubocop:disable Metrics/ClassLength
       # URI format used for channel URL validation.
       URI_REGEXP = Url::URI_REGEXP
       # Allowed stylesheet MIME types.

--- a/lib/html2rss/config/validator.rb
+++ b/lib/html2rss/config/validator.rb
@@ -15,6 +15,11 @@ module Html2rss
       LANGUAGE_FORMAT_REGEX = /\A[a-z]{2}(-[A-Z]{2})?\z/
       # Baseline strategy-plan enum (:auto plus concrete RequestService strategies).
       BASE_STRATEGY_OPTIONS = Html2rss::FeedPipeline::StrategyPlan.accepted_names.freeze
+      # Controlled vocabulary for catalog-only `directory.topics` (not RSS channel fields).
+      DIRECTORY_TOPICS = %w[
+        sports energy tech science news entertainment jobs finance
+        security travel environment consumer civic product research
+      ].freeze
 
       # Contract for the top-level `channel` section.
       ChannelConfig = Dry::Schema.Params do
@@ -26,6 +31,11 @@ module Html2rss
         optional(:time_zone).maybe(:string)
         optional(:author).maybe(:string)
         optional(:image).maybe(:string, format?: URI_REGEXP)
+      end
+
+      # Contract for catalog-only `directory` metadata (topics for feed directories).
+      DirectoryConfig = Dry::Schema.Params do
+        optional(:topics).value(:array, min_size?: 1).each(:string, included_in?: DIRECTORY_TOPICS)
       end
 
       # Contract for a stylesheet entry in `stylesheets`.
@@ -71,6 +81,7 @@ module Html2rss
       params do
         optional(:strategy).filled(:symbol)
         required(:channel).hash(ChannelConfig)
+        optional(:directory).hash(DirectoryConfig)
         optional(:headers).hash
         optional(:stylesheets).array(StylesheetConfig)
         optional(:auto_source).hash(Config::AutoSourceContract)

--- a/schema/html2rss-config.schema.json
+++ b/schema/html2rss-config.schema.json
@@ -63,6 +63,36 @@
         "url"
       ]
     },
+    "directory": {
+      "type": "object",
+      "properties": {
+        "topics": {
+          "type": "array",
+          "items": {
+            "minLength": 1,
+            "type": "string",
+            "enum": [
+              "sports",
+              "energy",
+              "tech",
+              "science",
+              "news",
+              "entertainment",
+              "jobs",
+              "finance",
+              "security",
+              "travel",
+              "environment",
+              "consumer",
+              "civic",
+              "product",
+              "research"
+            ]
+          }
+        }
+      },
+      "required": []
+    },
     "headers": {
       "type": "object",
       "description": "HTTP headers applied to every request.",

--- a/schema/html2rss-config.schema.json
+++ b/schema/html2rss-config.schema.json
@@ -88,7 +88,8 @@
               "product",
               "research"
             ]
-          }
+          },
+          "minItems": 1
         }
       },
       "required": []

--- a/spec/lib/html2rss/config_spec.rb
+++ b/spec/lib/html2rss/config_spec.rb
@@ -274,6 +274,51 @@ RSpec.describe Html2rss::Config do
       expect(described_class.validate(config_with_unknown_strategy)).to be_failure
     end
 
+    context 'when directory includes valid topics' do
+      let(:config) do
+        {
+          directory: { topics: %w[sports news] },
+          channel: { url: 'http://example.com' },
+          selectors: { items: { selector: '.item' }, title: { selector: 'h2' } }
+        }
+      end
+
+      it 'accepts the directory topics contract', :aggregate_failures do
+        result = described_class.validate(config)
+
+        expect(result).to be_success
+        expect(result.to_h.dig(:directory, :topics)).to eq(%w[sports news])
+      end
+    end
+
+    context 'when directory topics are empty' do
+      let(:config) do
+        {
+          directory: { topics: [] },
+          channel: { url: 'http://example.com' },
+          selectors: { items: { selector: '.item' }, title: { selector: 'h2' } }
+        }
+      end
+
+      it 'rejects an empty topics array' do
+        expect(described_class.validate(config)).to be_failure
+      end
+    end
+
+    context 'when directory topics include an unknown value' do
+      let(:config) do
+        {
+          directory: { topics: %w[sports unknown-topic] },
+          channel: { url: 'http://example.com' },
+          selectors: { items: { selector: '.item' }, title: { selector: 'h2' } }
+        }
+      end
+
+      it 'rejects topics outside the vocabulary' do
+        expect(described_class.validate(config)).to be_failure
+      end
+    end
+
     context 'when channel includes author and image' do
       let(:config) do
         {


### PR DESCRIPTION
## What changed

- Add catalog-only top-level `directory.topics` with a controlled vocabulary in `lib/html2rss/config/schema.rb` and `lib/html2rss/config/validator.rb`.
- Export the contract in `schema/html2rss-config.schema.json`, including `minItems: 1` so empty topic arrays fail JSON Schema and Dry validation alike.
- Cover acceptance and rejection cases in `spec/lib/html2rss/config_spec.rb`.

## Why

Curated configs and the docs feed directory need a stable way to tag and filter feeds by topic. This schema change is the core half of [html2rss/html2rss.github.io#135](https://github.com/html2rss/html2rss.github.io/issues/135) (issue lives in the docs repo; this PR enables it).

## Risk

- Low for existing runtime feeds that omit `directory` — field remains optional at the object level.
- Configs that already declare `directory.topics: []` will fail validation after this lands; the configs PR fills real topics.

## Review map

Review map: whole PR is small — start at `lib/html2rss/config/validator.rb`.

## Validation

- not run in this open step (commits already on branch; prefer CI on the PR)

## Ticket

Enables [html2rss/html2rss.github.io#135](https://github.com/html2rss/html2rss.github.io/issues/135) (schema only; issue is in the docs repo).

## Merge order

Merge first: **core → configs → docs**.