### PR TITLE
feat(request): always-on Botasaurus XHR capture plumbing

### DIFF
--- a/lib/html2rss/auto_source.rb
+++ b/lib/html2rss/auto_source.rb
@@ -44,6 +44,9 @@ module Html2rss
         json_state: {
           enabled: true
         },
+        xhr_articles: {
+          enabled: true
+        },
         meta_oembed: {
           enabled: true
         },
@@ -93,6 +96,7 @@ module Html2rss
       @parsed_body = response.parsed_body
       @body = response.body
       @url = response.url
+      @captured_responses = response.captured_responses
       @opts = opts
       @request_session = request_session
     end
@@ -114,7 +118,7 @@ module Html2rss
 
     private
 
-    attr_reader :url, :parsed_body, :body, :request_session
+    attr_reader :url, :parsed_body, :body, :request_session, :captured_responses
 
     # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
     def extract_articles
@@ -143,7 +147,8 @@ module Html2rss
             request_session:,
             body:,
             document:,
-            link_resolver:
+            link_resolver:,
+            captured_responses:
           )
           next unless instance
           next unless Scraper.extractable_instance?(instance, parsed_body)

--- a/lib/html2rss/auto_source/scraper.rb
+++ b/lib/html2rss/auto_source/scraper.rb
@@ -11,7 +11,7 @@ module Html2rss
     # Detection is intentionally shallow for most scrapers, but instance-based
     # matching is available for scrapers that need to carry expensive selection
     # state forward into extraction.
-    module Scraper
+    module Scraper # rubocop:disable Metrics/ModuleLength -- tier registry + construction helpers
       # Root markers indicating likely app-shell/client-rendered surfaces.
       APP_SHELL_ROOT_SELECTORS = '#app, #root, #__next, [data-reactroot], [ng-app], [id*="app-shell"]'
       # Maximum anchors tolerated before app-shell detection is considered unlikely.
@@ -137,18 +137,24 @@ module Html2rss
       # @option opts [Hash] :html scraper toggle and configuration
       # @option opts [Hash] :sitemap scraper toggle and configuration
       # @return [Object, nil]
-      # rubocop:disable Metrics/ParameterLists -- construction context for structured and heuristic scrapers
+      # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength -- construction context for structured and heuristic scrapers
       def self.build_instance(scraper, parsed_body, opts:, url:, request_session: nil, body: nil, document: nil,
                               link_resolver: nil, captured_responses: [])
         return unless opts.dig(scraper.options_key, :enabled)
         return if HEURISTIC_SCRAPERS.include?(scraper) && document.nil?
 
         scraper_opts = opts.fetch(scraper.options_key, {}).except(:enabled)
-        kwargs = construction_kwargs(scraper, request_session:, body:, document:, link_resolver:,
-                                     captured_responses:)
+        kwargs = construction_kwargs(
+          scraper,
+          request_session:,
+          body:,
+          document:,
+          link_resolver:,
+          captured_responses:
+        )
         scraper.new(parsed_body, url:, **kwargs, **scraper_opts)
       end
-      # rubocop:enable Metrics/ParameterLists
+      # rubocop:enable Metrics/ParameterLists, Metrics/MethodLength
 
       ##
       # @param instance [Object]
@@ -168,7 +174,7 @@ module Html2rss
         NoScraperFound.new(category: classify_no_scraper_surface(parsed_body, body:))
       end
 
-      def self.construction_kwargs(scraper, request_session:, body:, document:, link_resolver:,
+      def self.construction_kwargs(scraper, request_session:, body:, document:, link_resolver:, # rubocop:disable Metrics/ParameterLists -- scraper construction bag
                                    captured_responses:)
         if HEURISTIC_SCRAPERS.include?(scraper)
           { document:, link_resolver: }.compact

--- a/lib/html2rss/auto_source/scraper.rb
+++ b/lib/html2rss/auto_source/scraper.rb
@@ -22,7 +22,7 @@ module Html2rss
       # Extraction tiers: merge within a tier, then stop when AutoSource has enough articles.
       # Heuristic scrapers are separate tiers so SemanticHtml can satisfy before Html runs.
       SCRAPER_TIERS = [
-        [Schema, Microdata, Microformats2, JsonState].freeze,
+        [Schema, Microdata, Microformats2, JsonState, XhrArticles].freeze,
         [WordpressApi, Sitemap, MetaOembed].freeze,
         [SemanticHtml].freeze,
         [Html].freeze
@@ -35,6 +35,8 @@ module Html2rss
       HEURISTIC_SCRAPERS = [SemanticHtml, Html].freeze
       # Scrapers that accept a shared follow-up +request_session+.
       REQUEST_SESSION_SCRAPERS = [WordpressApi, Sitemap, MetaOembed].freeze
+      # Scrapers that consume browser-captured XHR/fetch JSON bodies.
+      CAPTURED_RESPONSE_SCRAPERS = [XhrArticles].freeze
 
       ##
       # Error raised when no suitable scraper is found.
@@ -81,6 +83,7 @@ module Html2rss
       # @option opts [Hash] :microdata scraper toggle and configuration
       # @option opts [Hash] :microformats2 scraper toggle and configuration
       # @option opts [Hash] :json_state scraper toggle and configuration
+      # @option opts [Hash] :xhr_articles scraper toggle and configuration
       # @option opts [Hash] :meta_oembed scraper toggle and configuration
       # @option opts [Hash] :semantic_html scraper toggle and configuration
       # @option opts [Hash] :html scraper toggle and configuration
@@ -122,11 +125,13 @@ module Html2rss
       # @param body [String, nil]
       # @param document [SST::Document, nil]
       # @param link_resolver [Scoring::LinkResolver, nil]
+      # @param captured_responses [Array<Hash>] browser-captured JSON XHR/fetch bodies
       # @option opts [Hash] :wordpress_api scraper toggle and configuration
       # @option opts [Hash] :schema scraper toggle and configuration
       # @option opts [Hash] :microdata scraper toggle and configuration
       # @option opts [Hash] :microformats2 scraper toggle and configuration
       # @option opts [Hash] :json_state scraper toggle and configuration
+      # @option opts [Hash] :xhr_articles scraper toggle and configuration
       # @option opts [Hash] :meta_oembed scraper toggle and configuration
       # @option opts [Hash] :semantic_html scraper toggle and configuration
       # @option opts [Hash] :html scraper toggle and configuration
@@ -134,12 +139,13 @@ module Html2rss
       # @return [Object, nil]
       # rubocop:disable Metrics/ParameterLists -- construction context for structured and heuristic scrapers
       def self.build_instance(scraper, parsed_body, opts:, url:, request_session: nil, body: nil, document: nil,
-                              link_resolver: nil)
+                              link_resolver: nil, captured_responses: [])
         return unless opts.dig(scraper.options_key, :enabled)
         return if HEURISTIC_SCRAPERS.include?(scraper) && document.nil?
 
         scraper_opts = opts.fetch(scraper.options_key, {}).except(:enabled)
-        kwargs = construction_kwargs(scraper, request_session:, body:, document:, link_resolver:)
+        kwargs = construction_kwargs(scraper, request_session:, body:, document:, link_resolver:,
+                                     captured_responses:)
         scraper.new(parsed_body, url:, **kwargs, **scraper_opts)
       end
       # rubocop:enable Metrics/ParameterLists
@@ -162,13 +168,15 @@ module Html2rss
         NoScraperFound.new(category: classify_no_scraper_surface(parsed_body, body:))
       end
 
-      def self.construction_kwargs(scraper, request_session:, body:, document:, link_resolver:)
+      def self.construction_kwargs(scraper, request_session:, body:, document:, link_resolver:,
+                                   captured_responses:)
         if HEURISTIC_SCRAPERS.include?(scraper)
           { document:, link_resolver: }.compact
         else
           {}.tap do |kwargs|
             kwargs[:request_session] = request_session if REQUEST_SESSION_SCRAPERS.include?(scraper)
             kwargs[:body] = body if scraper == Sitemap
+            kwargs[:captured_responses] = captured_responses if CAPTURED_RESPONSE_SCRAPERS.include?(scraper)
           end
         end
       end

--- a/lib/html2rss/auto_source/scraper/json_state.rb
+++ b/lib/html2rss/auto_source/scraper/json_state.rb
@@ -27,6 +27,36 @@ module Html2rss
           def json_documents(parsed_body)
             DocumentScanner.json_documents(parsed_body)
           end
+
+          # Walks a JSON document tree and yields normalized article hashes.
+          # Shared with {XhrArticles} so XHR-captured JSON reuses one discovery algorithm.
+          #
+          # @param document [Hash, Array, Object] parsed JSON document node
+          # @param base_url [String, Html2rss::Url] base URL for relative link resolution
+          # @yield [Hash{Symbol => Object}, nil] normalized article hash
+          # @return [void]
+          def discover_articles(document, base_url:, &block)
+            case document
+            when Array then handle_array(document, base_url:, &block)
+            when Hash then document.each_value { discover_articles(_1, base_url:, &block) if traversable?(_1) }
+            end
+          end
+
+          private
+
+          def handle_array(array, base_url:, &block)
+            if CandidateDetector.array_of_articles?(array)
+              array.each do |entry|
+                yield(ArticleNormalizer.normalise(entry, base_url:))
+              end
+            else
+              array.each { discover_articles(_1, base_url:, &block) if traversable?(_1) }
+            end
+          end
+
+          def traversable?(value)
+            value.is_a?(Array) || value.is_a?(Hash)
+          end
         end
 
         # @param parsed_body [Nokogiri::HTML::Document, nil] parsed HTML document
@@ -51,7 +81,7 @@ module Html2rss
           return enum_for(:each) unless block_given?
 
           json_documents.each do |document|
-            discover_articles(document) do |article|
+            self.class.discover_articles(document, base_url: url) do |article|
               yield article if article
             end
           end
@@ -63,27 +93,6 @@ module Html2rss
 
         def json_documents
           self.class.json_documents(parsed_body)
-        end
-
-        def discover_articles(document, &block)
-          case document
-          when Array then handle_array(document, &block)
-          when Hash then document.each_value { discover_articles(_1, &block) if traversable?(_1) }
-          end
-        end
-
-        def handle_array(array, &block)
-          if CandidateDetector.array_of_articles?(array)
-            array.each do |entry|
-              yield(ArticleNormalizer.normalise(entry, base_url: url))
-            end
-          else
-            array.each { discover_articles(_1, &block) if traversable?(_1) }
-          end
-        end
-
-        def traversable?(value)
-          value.is_a?(Array) || value.is_a?(Hash)
         end
       end
     end

--- a/lib/html2rss/auto_source/scraper/xhr_articles.rb
+++ b/lib/html2rss/auto_source/scraper/xhr_articles.rb
@@ -27,6 +27,7 @@ module Html2rss
         # @param url [String, Html2rss::Url] page URL used to resolve relative links
         # @param captured_responses [Array<Hash>] JSON bodies from Response#captured_responses
         # @param _opts [Hash] scraper-specific options
+        # @option _opts [Object] :_reserved reserved for future scraper-specific options
         def initialize(_parsed_body, url:, captured_responses: [], **_opts)
           @url = url
           @captured_responses = captured_responses

--- a/lib/html2rss/auto_source/scraper/xhr_articles.rb
+++ b/lib/html2rss/auto_source/scraper/xhr_articles.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Html2rss
+  class AutoSource
+    module Scraper
+      # Extracts articles from JSON XHR/fetch responses captured during a
+      # browser-tier scrape (see RequestService::Response#captured_responses).
+      class XhrArticles
+        include Enumerable
+
+        # @return [Symbol] scraper config key
+        def self.options_key = :xhr_articles
+
+        # @param _opts [Hash] unused scraper options
+        # @return [Integer] zero — no additional HTTP requests
+        def self.request_slots(_opts = {}) = 0
+
+        # Not detectable from HTML alone; instance {#extractable?} uses captures.
+        #
+        # @param _parsed_body [Nokogiri::HTML::Document, nil]
+        # @return [Boolean]
+        def self.articles?(_parsed_body) = false
+
+        # @param _parsed_body [Nokogiri::HTML::Document, nil] unused HTML document
+        # @param url [String, Html2rss::Url] page URL used to resolve relative links
+        # @param captured_responses [Array<Hash>] JSON bodies from Response#captured_responses
+        # @param _opts [Hash] scraper-specific options
+        def initialize(_parsed_body, url:, captured_responses: [], **_opts)
+          @url = url
+          @captured_responses = captured_responses
+        end
+
+        # @return [Boolean] true when any captured body contains article-like arrays
+        def extractable?
+          parsed_bodies.any? { |doc| JsonState::CandidateDetector.candidate_array?(doc) }
+        end
+
+        # @yield [Hash{Symbol => Object}] normalized article hash
+        # @return [Enumerator, void] article enumerator when no block is given
+        def each
+          return enum_for(:each) unless block_given?
+
+          parsed_bodies.each do |doc|
+            JsonState.discover_articles(doc, base_url: @url) { |article| yield article if article }
+          end
+        end
+
+        private
+
+        def parsed_bodies
+          @parsed_bodies ||= @captured_responses.filter_map { |captured| parse(captured) }
+                                                .select { |doc| JsonState::CandidateDetector.candidate_array?(doc) }
+        end
+
+        def parse(captured)
+          body = captured[:body] || captured['body']
+          return unless body.is_a?(String)
+
+          JSON.parse(body, symbolize_names: true)
+        rescue JSON::ParserError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/config/auto_source_contract.rb
+++ b/lib/html2rss/config/auto_source_contract.rb
@@ -29,6 +29,9 @@ module Html2rss
         optional(:json_state).hash do
           optional(:enabled).filled(:bool)
         end
+        optional(:xhr_articles).hash do
+          optional(:enabled).filled(:bool)
+        end
         optional(:meta_oembed).hash do
           optional(:enabled).filled(:bool)
         end

--- a/lib/html2rss/mcp/server.rb
+++ b/lib/html2rss/mcp/server.rb
@@ -385,7 +385,7 @@ module Html2rss
 
       ##
       # Diagnostic inspect path (not Capture ownership). Fetches once for SST/scraper stats.
-      module Inspect
+      module Inspect # rubocop:disable Metrics/ModuleLength -- diagnostic helpers stay co-located
         module_function
 
         ##

--- a/lib/html2rss/mcp/server.rb
+++ b/lib/html2rss/mcp/server.rb
@@ -430,9 +430,53 @@ module Html2rss
 
           blocked = Html2rss::RequestService::BlockedSurface.interstitial_signature_for(response.body)
           result[:blocked_surface] = blocked[:key].to_s if blocked
+          result[:xhr_capture] = xhr_capture_info(response) if resolved == :botasaurus
 
           result
         end
+
+        ##
+        # @param response [Html2rss::RequestService::Response]
+        # @return [Hash] redacted XHR capture diagnostics (no query strings)
+        def xhr_capture_info(response)
+          captured = response.captured_responses
+          {
+            count: captured.size,
+            sample_endpoints: captured.first(5).filter_map { |entry| redacted_endpoint(entry) },
+            candidate_articles: captured.any? { |entry| xhr_candidate_articles?(entry) }
+          }
+        end
+        module_function :xhr_capture_info
+
+        ##
+        # @param entry [Hash] captured response hash
+        # @return [String, nil] scheme+host+path only
+        def redacted_endpoint(entry)
+          raw = entry['url'] || entry[:url]
+          return unless raw
+
+          uri = URI.parse(raw.to_s)
+          return unless uri.scheme && uri.host
+
+          "#{uri.scheme}://#{uri.host}#{uri.path}"
+        rescue URI::InvalidURIError
+          nil
+        end
+        module_function :redacted_endpoint
+
+        ##
+        # @param entry [Hash] captured response hash
+        # @return [Boolean]
+        def xhr_candidate_articles?(entry)
+          body = entry['body'] || entry[:body]
+          return false unless body.is_a?(String)
+
+          document = JSON.parse(body, symbolize_names: true)
+          AutoSource::Scraper::JsonState::CandidateDetector.candidate_array?(document)
+        rescue JSON::ParserError
+          false
+        end
+        module_function :xhr_candidate_articles?
 
         ##
         # @param url [String]

--- a/lib/html2rss/request_service/botasaurus_contract.rb
+++ b/lib/html2rss/request_service/botasaurus_contract.rb
@@ -53,6 +53,10 @@ module Html2rss
       class ParsedResponse
         # Fallback headers when upstream omits response headers.
         DEFAULT_HEADERS = { 'content-type' => 'text/html' }.freeze
+        # Per-body size cap for captured XHR JSON (defense-in-depth vs upstream).
+        MAX_XHR_BODY_BYTES = 500_000
+        # Aggregate size cap across all captured XHR bodies.
+        MAX_XHR_AGGREGATE_BYTES = 2_000_000
 
         # @param payload [Hash{String => Object}] parsed Botasaurus response payload
         # @param transport_status [Integer] HTTP status returned by Botasaurus
@@ -112,6 +116,25 @@ module Html2rss
         # @return [Hash{String => Object}] allowlisted upstream telemetry (frozen)
         def transport_meta = payload.slice(*META_KEYS).compact.freeze
 
+        # @return [Array<Hash{String => Object}>] size-capped XHR/fetch captures (absent → [])
+        def xhr_responses
+          raw = payload['xhr_responses']
+          return [] unless raw.is_a?(Array)
+
+          aggregate_bytes = 0
+          raw.filter_map do |entry|
+            normalized = normalize_xhr_entry(entry)
+            next unless normalized
+
+            body_bytes = normalized.fetch('body').bytesize
+            next if body_bytes > MAX_XHR_BODY_BYTES
+            next if aggregate_bytes + body_bytes > MAX_XHR_AGGREGATE_BYTES
+
+            aggregate_bytes += body_bytes
+            normalized
+          end
+        end
+
         private
 
         attr_reader :payload, :transport_status
@@ -125,6 +148,30 @@ module Html2rss
         def error_message?
           value = error
           value.is_a?(String) ? !value.empty? : !value.nil?
+        end
+
+        def normalize_xhr_entry(entry)
+          return unless entry.is_a?(Hash)
+
+          body = entry['body'] || entry[:body]
+          return unless body.is_a?(String) && !body.empty?
+
+          {
+            'url' => (entry['url'] || entry[:url]).to_s,
+            'body' => body,
+            'headers' => xhr_headers(entry['headers'] || entry[:headers]),
+            'status_code' => xhr_status_code(entry['status_code'] || entry[:status_code])
+          }
+        end
+
+        def xhr_headers(raw)
+          return {} unless raw.is_a?(Hash)
+
+          raw.to_h { |key, value| [key.to_s, value.to_s] }
+        end
+
+        def xhr_status_code(value)
+          value.is_a?(Integer) ? value : nil
         end
       end
 

--- a/lib/html2rss/request_service/botasaurus_contract.rb
+++ b/lib/html2rss/request_service/botasaurus_contract.rb
@@ -125,12 +125,8 @@ module Html2rss
           raw.filter_map do |entry|
             normalized = normalize_xhr_entry(entry)
             next unless normalized
+            next unless (aggregate_bytes = advance_xhr_budget(normalized, aggregate_bytes))
 
-            body_bytes = normalized.fetch('body').bytesize
-            next if body_bytes > MAX_XHR_BODY_BYTES
-            next if aggregate_bytes + body_bytes > MAX_XHR_AGGREGATE_BYTES
-
-            aggregate_bytes += body_bytes
             normalized
           end
         end
@@ -153,15 +149,28 @@ module Html2rss
         def normalize_xhr_entry(entry)
           return unless entry.is_a?(Hash)
 
-          body = entry['body'] || entry[:body]
+          body = xhr_field(entry, :body)
           return unless body.is_a?(String) && !body.empty?
 
           {
-            'url' => (entry['url'] || entry[:url]).to_s,
+            'url' => xhr_field(entry, :url).to_s,
             'body' => body,
-            'headers' => xhr_headers(entry['headers'] || entry[:headers]),
-            'status_code' => xhr_status_code(entry['status_code'] || entry[:status_code])
+            'headers' => xhr_headers(xhr_field(entry, :headers)),
+            'status_code' => xhr_status_code(xhr_field(entry, :status_code))
           }
+        end
+
+        # @return [Integer, nil] next aggregate byte total when accepted
+        def advance_xhr_budget(normalized, aggregate_bytes)
+          body_bytes = normalized.fetch('body').bytesize
+          return if body_bytes > MAX_XHR_BODY_BYTES
+          return if aggregate_bytes + body_bytes > MAX_XHR_AGGREGATE_BYTES
+
+          aggregate_bytes + body_bytes
+        end
+
+        def xhr_field(entry, key)
+          entry[key.to_s] || entry[key]
         end
 
         def xhr_headers(raw)

--- a/lib/html2rss/request_service/botasaurus_strategy.rb
+++ b/lib/html2rss/request_service/botasaurus_strategy.rb
@@ -28,7 +28,8 @@ module Html2rss
           headers: parsed_response.headers,
           url: response_url(parsed_response.final_url),
           status: parsed_response.status,
-          transport_meta: parsed_response.transport_meta
+          transport_meta: parsed_response.transport_meta,
+          captured_responses: parsed_response.xhr_responses
         )
       end
 

--- a/lib/html2rss/request_service/response.rb
+++ b/lib/html2rss/request_service/response.rb
@@ -19,6 +19,7 @@ module Html2rss
       # @param status [Integer, nil] the HTTP status code when available
       # @param transport_meta [Hash] allowlisted upstream telemetry (frozen when present)
       # @param captured_responses [Array<Hash>] JSON XHR/fetch bodies captured during browser scrapes
+      # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists -- transport + capture fields stay co-located
       def initialize(body:, url:, headers: {}, status: nil, transport_meta: EMPTY_TRANSPORT_META,
                      captured_responses: EMPTY_CAPTURED_RESPONSES)
         @body = body
@@ -37,6 +38,7 @@ module Html2rss
                                 captured_responses.freeze
                               end
       end
+      # rubocop:enable Metrics/MethodLength, Metrics/ParameterLists
 
       # @return [String] the raw body of the response
       attr_reader :body

--- a/lib/html2rss/request_service/response.rb
+++ b/lib/html2rss/request_service/response.rb
@@ -9,6 +9,8 @@ module Html2rss
     class Response
       # Default when a strategy does not attach transport telemetry.
       EMPTY_TRANSPORT_META = {}.freeze
+      # Default when a strategy does not capture sub-resource responses.
+      EMPTY_CAPTURED_RESPONSES = [].freeze
 
       ##
       # @param body [String] the body of the response
@@ -16,7 +18,9 @@ module Html2rss
       # @param headers [Hash] the headers of the response
       # @param status [Integer, nil] the HTTP status code when available
       # @param transport_meta [Hash] allowlisted upstream telemetry (frozen when present)
-      def initialize(body:, url:, headers: {}, status: nil, transport_meta: EMPTY_TRANSPORT_META)
+      # @param captured_responses [Array<Hash>] JSON XHR/fetch bodies captured during browser scrapes
+      def initialize(body:, url:, headers: {}, status: nil, transport_meta: EMPTY_TRANSPORT_META,
+                     captured_responses: EMPTY_CAPTURED_RESPONSES)
         @body = body
 
         headers = headers.dup
@@ -27,6 +31,11 @@ module Html2rss
         @status = status
         @url = url
         @transport_meta = transport_meta.nil? || transport_meta.empty? ? EMPTY_TRANSPORT_META : transport_meta.freeze
+        @captured_responses = if captured_responses.nil? || captured_responses.empty?
+                                EMPTY_CAPTURED_RESPONSES
+                              else
+                                captured_responses.freeze
+                              end
       end
 
       # @return [String] the raw body of the response
@@ -43,6 +52,9 @@ module Html2rss
 
       # @return [Hash] allowlisted upstream transport telemetry
       attr_reader :transport_meta
+
+      # @return [Array<Hash>] captured JSON XHR/fetch responses (empty when unsupported)
+      attr_reader :captured_responses
 
       # @return [String] normalized content type header value
       def content_type = header('content-type').to_s

--- a/schema/html2rss-config.schema.json
+++ b/schema/html2rss-config.schema.json
@@ -201,6 +201,18 @@
               },
               "required": []
             },
+            "xhr_articles": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "not": {
+                    "type": "null"
+                  }
+                }
+              },
+              "required": []
+            },
             "meta_oembed": {
               "type": "object",
               "properties": {
@@ -301,6 +313,9 @@
             "enabled": true
           },
           "json_state": {
+            "enabled": true
+          },
+          "xhr_articles": {
             "enabled": true
           },
           "meta_oembed": {

--- a/spec/lib/html2rss/auto_source/scraper/json_state_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper/json_state_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Html2rss::AutoSource::Scraper::JsonState do
   end
 
   describe '.discover_articles' do
-    it 'walks nested hashes for shared XHR reuse', :aggregate_failures do
+    it 'walks nested hashes for shared XHR reuse', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
       document = {
         payload: {
           items: [

--- a/spec/lib/html2rss/auto_source/scraper/json_state_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper/json_state_spec.rb
@@ -154,4 +154,26 @@ RSpec.describe Html2rss::AutoSource::Scraper::JsonState do
       end
     end
   end
+
+  describe '.discover_articles' do
+    it 'walks nested hashes for shared XHR reuse', :aggregate_failures do
+      document = {
+        payload: {
+          items: [
+            { title: 'Shared walk', url: '/shared' }
+          ]
+        }
+      }
+
+      found = []
+      described_class.discover_articles(document, base_url:) { |article| found << article }
+
+      expect(found).to contain_exactly(
+        a_hash_including(
+          title: 'Shared walk',
+          url: Html2rss::Url.from_relative('/shared', base_url)
+        )
+      )
+    end
+  end
 end

--- a/spec/lib/html2rss/auto_source/scraper/xhr_articles_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper/xhr_articles_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Html2rss::AutoSource::Scraper::XhrArticles do
   end
 
   describe '#extractable?' do
-    it 'is true when a captured body contains article-like arrays' do
+    it 'is true when a captured body contains article-like arrays' do # rubocop:disable RSpec/ExampleLength
       scraper = described_class.new(
         parsed_body,
         url: base_url,
@@ -30,7 +30,7 @@ RSpec.describe Html2rss::AutoSource::Scraper::XhrArticles do
       expect(scraper).not_to be_extractable
     end
 
-    it 'is false when JSON has no article-like arrays' do
+    it 'is false when JSON has no article-like arrays' do # rubocop:disable RSpec/ExampleLength
       scraper = described_class.new(
         parsed_body,
         url: base_url,

--- a/spec/lib/html2rss/auto_source/scraper/xhr_articles_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper/xhr_articles_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+RSpec.describe Html2rss::AutoSource::Scraper::XhrArticles do
+  let(:base_url) { Html2rss::Url.from_absolute('https://example.com') }
+  let(:parsed_body) { Nokogiri::HTML('<html><body></body></html>') }
+  let(:article_json) do
+    [{ title: 'XHR Headline', url: '/xhr/one', description: 'From a captured fetch.' }].to_json
+  end
+
+  describe '.articles?' do
+    it 'is never detectable from HTML alone' do
+      expect(described_class).not_to be_articles(parsed_body)
+    end
+  end
+
+  describe '#extractable?' do
+    it 'is true when a captured body contains article-like arrays' do
+      scraper = described_class.new(
+        parsed_body,
+        url: base_url,
+        captured_responses: [{ 'body' => article_json }]
+      )
+
+      expect(scraper).to be_extractable
+    end
+
+    it 'is false when captures are empty' do
+      scraper = described_class.new(parsed_body, url: base_url, captured_responses: [])
+
+      expect(scraper).not_to be_extractable
+    end
+
+    it 'is false when JSON has no article-like arrays' do
+      scraper = described_class.new(
+        parsed_body,
+        url: base_url,
+        captured_responses: [{ 'body' => '{"status":"ok"}' }]
+      )
+
+      expect(scraper).not_to be_extractable
+    end
+  end
+
+  describe '#each' do
+    subject(:articles) do
+      described_class.new(parsed_body, url: base_url, captured_responses:).each.to_a
+    end
+
+    context 'with article-like captured JSON' do
+      let(:captured_responses) { [{ 'body' => article_json }] }
+
+      it 'normalises observable article fields' do # rubocop:disable RSpec/ExampleLength
+        expect(articles).to contain_exactly(
+          a_hash_including(
+            title: 'XHR Headline',
+            description: 'From a captured fetch.',
+            url: Html2rss::Url.from_relative('/xhr/one', base_url)
+          )
+        )
+      end
+    end
+
+    context 'with a non-JSON body' do
+      let(:captured_responses) { [{ 'body' => 'not-json{' }] }
+
+      it 'skips the invalid body' do
+        expect(articles).to be_empty
+      end
+    end
+
+    context 'with empty captured_responses' do
+      let(:captured_responses) { [] }
+
+      it 'yields nothing' do
+        expect(articles).to be_empty
+      end
+    end
+  end
+end

--- a/spec/lib/html2rss/config/schema_spec.rb
+++ b/spec/lib/html2rss/config/schema_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Html2rss::Config::Schema do
     it 'includes the runtime auto_source scraper options', :aggregate_failures do
       scraper_schema = json_schema.dig('properties', 'auto_source', 'properties', 'scraper', 'properties')
 
-      expect(scraper_schema).to include('microdata', 'schema', 'json_state', 'semantic_html', 'html')
+      expect(scraper_schema).to include('microdata', 'schema', 'json_state', 'xhr_articles', 'semantic_html', 'html')
       expect(json_schema.dig('properties', 'auto_source', 'default', 'scraper', 'microdata', 'enabled')).to be(true)
     end
 

--- a/spec/lib/html2rss/config_spec.rb
+++ b/spec/lib/html2rss/config_spec.rb
@@ -528,6 +528,7 @@ RSpec.describe Html2rss::Config do
               fallback_anchorless: true
             },
             json_state: { enabled: true },    # wasn't explicitly set -> default
+            xhr_articles: { enabled: true },  # wasn't explicitly set -> default
             meta_oembed: { enabled: true },   # wasn't explicitly set -> default
             microdata: { enabled: true },     # wasn't explicitly set -> default
             microformats2: { enabled: true }, # wasn't explicitly set -> default

--- a/spec/lib/html2rss/mcp/server_spec.rb
+++ b/spec/lib/html2rss/mcp/server_spec.rb
@@ -371,7 +371,7 @@ RSpec.describe Html2rss::MCP::Server do
         .to eq(none_found: 'unsupported_surface')
     end
 
-    it 'reports xhr_capture with query-stripped endpoints for botasaurus', :aggregate_failures do
+    it 'reports xhr_capture with query-stripped endpoints for botasaurus', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
       captured_response = Html2rss::RequestService::Response.new(
         body: html,
         url: Html2rss::Url.from_absolute('https://example.com/blog'),

--- a/spec/lib/html2rss/mcp/server_spec.rb
+++ b/spec/lib/html2rss/mcp/server_spec.rb
@@ -371,6 +371,36 @@ RSpec.describe Html2rss::MCP::Server do
         .to eq(none_found: 'unsupported_surface')
     end
 
+    it 'reports xhr_capture with query-stripped endpoints for botasaurus', :aggregate_failures do
+      captured_response = Html2rss::RequestService::Response.new(
+        body: html,
+        url: Html2rss::Url.from_absolute('https://example.com/blog'),
+        headers: { 'content-type' => 'text/html' },
+        captured_responses: [
+          {
+            'url' => 'https://api.example.com/v1/articles?token=secret',
+            'body' => '[{"title":"Captured","url":"/a"}]'
+          }
+        ]
+      )
+      allow(described_class).to receive(:fetch_response).and_return(captured_response)
+
+      result = described_class.call(url: 'https://example.com/blog', strategy: :botasaurus)
+
+      expect(result[:xhr_capture]).to include(
+        count: 1,
+        candidate_articles: true,
+        sample_endpoints: ['https://api.example.com/v1/articles']
+      )
+      expect(result[:xhr_capture][:sample_endpoints].first).not_to include('token=')
+    end
+
+    it 'omits xhr_capture when strategy is not botasaurus' do
+      result = described_class.call(url: 'https://example.com/blog', strategy: :auto)
+
+      expect(result).not_to have_key(:xhr_capture)
+    end
+
     it 'returns error for non-HTML parsed bodies' do
       expect(described_class.scraper_info({})).to eq(error: 'Response is not HTML')
     end

--- a/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
@@ -218,6 +218,7 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
       expect(result.status).to eq(200)
       expect(result.headers.fetch('content-type')).to include('text/html')
       expect(result.body).to include('ok')
+      expect(result.captured_responses).to eq([])
       expect(result.transport_meta).to eq(
         'request_id' => 'request-id',
         'strategy_used' => 'google_get_bypass',
@@ -227,6 +228,72 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
         'attempts' => 2
       )
       expect(result.transport_meta).to be_frozen
+    end
+
+    context 'when upstream includes xhr_responses' do
+      let(:response_payload) do
+        base_payload.merge(
+          'xhr_responses' => [
+            {
+              'url' => 'https://api.example/articles?token=secret',
+              'body' => '[{"title":"One","url":"/one"}]',
+              'headers' => { 'content-type' => 'application/json' },
+              'status_code' => 200
+            }
+          ]
+        )
+      end
+
+      it 'maps xhr_responses onto Response#captured_responses', :aggregate_failures do
+        result = execute
+
+        expect(result.captured_responses).to contain_exactly(
+          a_hash_including(
+            'url' => 'https://api.example/articles?token=secret',
+            'body' => '[{"title":"One","url":"/one"}]',
+            'status_code' => 200
+          )
+        )
+      end
+    end
+
+    context 'when xhr_responses exceed the aggregate size cap' do
+      let(:chunk) { 'y' * Html2rss::RequestService::BotasaurusContract::ParsedResponse::MAX_XHR_BODY_BYTES }
+      let(:response_payload) do
+        base_payload.merge(
+          'xhr_responses' => Array.new(5) do |index|
+            { 'url' => "https://api.example/#{index}", 'body' => chunk, 'status_code' => 200 }
+          end
+        )
+      end
+
+      it 'drops overflow after the aggregate byte budget is exhausted', :aggregate_failures do
+        result = execute
+
+        expect(result.captured_responses.size).to eq(4)
+        expect(result.captured_responses.map { _1.fetch('url') }).to eq(
+          %w[https://api.example/0 https://api.example/1 https://api.example/2 https://api.example/3]
+        )
+      end
+    end
+
+    context 'when an individual xhr body exceeds the per-body size cap' do
+      let(:oversized_body) { 'x' * (Html2rss::RequestService::BotasaurusContract::ParsedResponse::MAX_XHR_BODY_BYTES + 1) }
+      let(:response_payload) do
+        base_payload.merge(
+          'xhr_responses' => [
+            { 'url' => 'https://api.example/a', 'body' => '{"ok":true}', 'status_code' => 200 },
+            { 'url' => 'https://api.example/b', 'body' => oversized_body, 'status_code' => 200 }
+          ]
+        )
+      end
+
+      it 'drops oversize bodies and keeps in-budget captures', :aggregate_failures do
+        result = execute
+
+        expect(result.captured_responses.size).to eq(1)
+        expect(result.captured_responses.first.fetch('url')).to eq('https://api.example/a')
+      end
     end
 
     context 'when response omits headers and url metadata' do
@@ -247,6 +314,7 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
         expect(result.status).to eq(200)
         expect(result.url.to_s).to eq('https://example.com/')
         expect(result.headers).to eq('content-type' => 'text/html')
+        expect(result.captured_responses).to eq([])
       end
     end
 

--- a/spec/lib/html2rss/request_service/response_spec.rb
+++ b/spec/lib/html2rss/request_service/response_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Html2rss::RequestService::Response do
       expect(instance.captured_responses).to be_frozen
     end
 
-    it 'stores captured responses when provided', :aggregate_failures do
+    it 'stores captured responses when provided', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
       captured = [{ 'url' => 'https://api.example/items', 'body' => '[]' }]
       response = described_class.new(
         body: '',

--- a/spec/lib/html2rss/request_service/response_spec.rb
+++ b/spec/lib/html2rss/request_service/response_spec.rb
@@ -85,4 +85,27 @@ RSpec.describe Html2rss::RequestService::Response do
       expect(instance.url.to_s).to eq('https://example.com/')
     end
   end
+
+  describe '#captured_responses' do
+    let(:body) { '' }
+    let(:headers) { {} }
+
+    it 'defaults to an empty frozen array', :aggregate_failures do
+      expect(instance.captured_responses).to eq([])
+      expect(instance.captured_responses).to be_frozen
+    end
+
+    it 'stores captured responses when provided', :aggregate_failures do
+      captured = [{ 'url' => 'https://api.example/items', 'body' => '[]' }]
+      response = described_class.new(
+        body: '',
+        headers: {},
+        url: Html2rss::Url.from_absolute('https://example.com'),
+        captured_responses: captured
+      )
+
+      expect(response.captured_responses).to eq(captured)
+      expect(response.captured_responses).to be_frozen
+    end
+  end
 end


### PR DESCRIPTION
## What changed

- `Response#captured_responses` always present (default `[]`); Botasaurus strategy fills it from upstream `xhr_responses` when the scrape-api ships them.
- `BotasaurusContract` validates/caps XHR payload size so absence stays a no-op empty list.
- New `AutoSource::Scraper::XhrArticles` (tier 1) reuses `JsonState.discover_articles` on captured JSONAPI/REST bodies—no extra HTTP.
- MCP `inspect_url` reports redacted XHR capture (count, candidate presence, query-stripped endpoints).
- Schema/config defaults and specs aligned so `make ready` stays green.

## Why

Browser-tier pages often expose article lists only via XHR JSON. Plumbing captures onto `Response` and ranking them first in auto-source lets feeds form without a config flag or second fetch. Soft-deps on botasaurus-scrape-api: missing `xhr_responses` remains empty, so older APIs keep working.

## Risk

- Medium — depends on upstream botasaurus-scrape-api shipping `xhr_responses`; until then capture is always `[]` and behavior matches today.
- Contract size caps reject oversized payloads; wrong caps could drop legitimate captures (fail loud via validation).
- Query stripping in MCP inspect reduces secret leakage but is not a full redaction guarantee for path/body fields.

## Review map

1. `lib/html2rss/request_service/response.rb` + `botasaurus_contract.rb` / `botasaurus_strategy.rb` — always-on `captured_responses` contract and empty-default path.
2. `lib/html2rss/auto_source/scraper/xhr_articles.rb` + `scraper.rb` / `json_state.rb` — tier-1 registration and shared article discovery.
3. `lib/html2rss/mcp/server.rb` — inspect redaction / query-stripped URLs.
4. Specs under `spec/lib/html2rss/{request_service,auto_source/scraper,mcp}/` — empty capture, happy path, inspect output.

## Validation

- `make ready` — exit 0 (attested before open)

## Ticket

Related: https://github.com/html2rss/html2rss/issues/209