### PR TITLE
fix(capture): emit selectors.url instead of legacy :link

### DIFF
--- a/lib/html2rss/capture.rb
+++ b/lib/html2rss/capture.rb
@@ -210,7 +210,7 @@ module Html2rss
 
       attrs = {}.tap do |a|
         a[:title] = title_selector(root)
-        a[:link] = link_selector(first[:segment])
+        a[:url] = url_selector(first[:segment])
         a[:description] = description_selector(root, first[:segment])
       end.compact
 
@@ -277,7 +277,7 @@ module Html2rss
       { selector: relative }
     end
 
-    def link_selector(segment)
+    def url_selector(segment)
       return nil unless segment.primary_link
 
       relative = css_for_path(segment.primary_link.tag_path, segment.root_node.tag_path)

--- a/spec/lib/html2rss/capture_spec.rb
+++ b/spec/lib/html2rss/capture_spec.rb
@@ -28,8 +28,9 @@ RSpec.describe Html2rss::Capture do
         expect(result.config[:selectors]).to include(
           items: { selector: 'div.item' },
           title: { selector: 'h2' },
-          link: { selector: 'h2 > a', extractor: 'href' }
+          url: { selector: 'h2 > a', extractor: 'href' }
         )
+        expect(result.config[:selectors]).not_to have_key(:link)
         expect(result.config[:selectors]).not_to have_key(:description)
         expect(result.config[:channel]).to include(url:, title: a_string_matching(/\S/), time_zone: 'UTC')
         expect(result.channel_title).to eq(result.config.dig(:channel, :title))
@@ -122,6 +123,9 @@ RSpec.describe Html2rss::Capture do
       feed = Html2rss.feed(config)
       expect(feed.items.size).to eq(3)
       expect(feed.items.map(&:title)).to eq(['First Post Item', 'Second Post Item', 'Third Post Item'])
+      expect(feed.items.map(&:link)).to eq(
+        %w[https://example.com/post-1 https://example.com/post-2 https://example.com/post-3]
+      )
     end
   end
 

--- a/spec/lib/html2rss/mcp/server_spec.rb
+++ b/spec/lib/html2rss/mcp/server_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Html2rss::MCP::Server do
       selectors: {
         items: { selector: 'div.item' },
         title: { selector: 'h2' },
-        link: { selector: 'a', extractor: 'href' }
+        url: { selector: 'a', extractor: 'href' }
       }
     }
   end


### PR DESCRIPTION
## What changed

- `Html2rss::Capture` emits `selectors.url` (href extractor) instead of removed `selectors.link`
- Capture and MCP fixtures assert `:url` and reject `:link`
- Round-trip capture→feed asserts item links from the derived selector

## Why

### Root cause

`refactor(selectors)!: remove legacy :link selector alias` standardized configs on `:url`, but Capture still wrote `:link`, so captured configs did not populate item URLs unless enhance filled gaps.

## Risk

- Low — Capture output only; configs that already used `:url` unchanged
- Adjacent stale `:link` keys remain in a few non-Capture specs (out of scope)

## Review map

Review map: whole PR is small — start at `lib/html2rss/capture.rb`.

## Validation

- `make quick` (exit 0)
- `bundle exec rspec spec/lib/html2rss/capture_spec.rb spec/lib/html2rss/mcp/server_spec.rb` (40 examples, 0 failures)