### PR TITLE
feat: honest auto transport, admission Status, durable enhance Capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ html2rss mcp --transport http --port 8080
 
 HTTP transport needs `rack`, `rackup`, and `webrick` (declared gem dependencies). It listens on `127.0.0.1` only; do not expose it on a public interface without your own auth and Host/Origin controls.
 
-**Strategy note:** MCP tool `strategy: "auto"` collapses to `faraday` (no FeedPipeline botasaurus fallback). If results are empty or JS-gated, retry with `strategy: "botasaurus"` and `BOTASAURUS_SCRAPER_URL` set.
+**Strategy note:** MCP `scrape_url` / `capture_config` with `strategy: "auto"` run the FeedPipeline AutoFallback chain (`faraday` → `botasaurus`). `inspect_url` uses Faraday when `auto` (cheap diagnostic); pin `botasaurus` when you need browser rendering for inspect. Botasaurus needs `BOTASAURUS_SCRAPER_URL`.
 
 ### Tools
 
@@ -103,11 +103,11 @@ Set `BOTASAURUS_SCRAPER_URL` to `http://127.0.0.1:4010` and use strategy `botasa
 
 | Strategy     | Description                                                                   |
 | ------------ | ----------------------------------------------------------------------------- |
-| `auto`       | Tries `faraday`, falls back to `botasaurus` (default in gem/CLI FeedPipeline) |
+| `auto`       | Tries `faraday`, falls back to `botasaurus` (default in gem/CLI/MCP scrape)   |
 | `faraday`    | Plain HTTP requests via Faraday                                               |
 | `botasaurus` | Puppeteer-backed scraping for JavaScript pages                                |
 
-MCP tools intentionally collapse `auto` → `faraday` (see MCP section above). Elsewhere, strategy can be set via CLI (`--strategy`), gem API keyword argument, or feed config `request.strategy`. See the [request strategies docs](https://html2rss.github.io/ruby-gem/reference/strategy) for more details.
+`inspect_url` keeps Faraday when `auto` for cheap diagnostics. Elsewhere, strategy can be set via CLI (`--strategy`), gem API keyword argument, or feed config `request.strategy`. See the [request strategies docs](https://html2rss.github.io/ruby-gem/reference/strategy) for more details.
 
 ## License
 

--- a/docs/212-config-capture.md
+++ b/docs/212-config-capture.md
@@ -1,0 +1,6 @@
+# Issue #212 — Durable Capture (implemented)
+
+Implemented by `Html2rss::Capture`: durable configs emit
+`selectors.items` with `enhance: true` only (no attribute-selector soup).
+
+See [`docs/capture.md`](capture.md) for the current product contract and CLI.

--- a/docs/auto-strategy.md
+++ b/docs/auto-strategy.md
@@ -1,0 +1,52 @@
+# Smart "auto" Request Strategy
+
+This document describes the feed-level `:auto` request plan in `html2rss`.
+
+## UX Philosophy & Intent
+
+The primary goal of the `auto` strategy is to provide a "it just works" experience for gem users.
+
+- **Zero-Config Resiliency**: Users should not need to understand anti-bot mechanisms or manually switch strategies. The gem attempts to overcome blocking using available resources.
+- **Efficiency-First**: Prefer `Faraday` (working for many sites) as it is significantly faster and cheaper than browser-backed scraping.
+- **Transparent Fallback**: When a fallback occurs, the gem provides clear feedback via logging and `Html2rss::Status`, helping users understand why a request took longer and which strategy ultimately succeeded.
+- **Availability-Aware**: The strategy adapts to the runtime environment, utilizing Botasaurus only if `BOTASAURUS_SCRAPER_URL` is configured and reachable.
+
+## Strategic Selection Logic
+
+`:auto` is resolved by `FeedPipeline::StrategyPlan` and executed by `FeedPipeline::AutoFallback`. The ordered chain is:
+
+1. **Faraday**: Default starting point (plain HTTP).
+2. **Botasaurus**: Attempted if Faraday fails with a fallback-eligible error (e.g. `BlockedSurfaceDetected`) or yields zero feed items, and Botasaurus is configured.
+
+There is no Browserless / Puppeteer-in-gem tier. Pin `botasaurus` explicitly when you want browser rendering without Faraday first.
+
+## Tool Surfaces
+
+| Surface | `:auto` behavior |
+|---------|------------------|
+| Gem / CLI feed build, `scrape_url`, Capture (durable configs) | Full AutoFallback chain (`faraday` → `botasaurus`) |
+| MCP / CLI `inspect_url` | Cheap diagnostic: Faraday only (document pin `botasaurus` when needed) |
+
+## Fallback-Eligible Errors
+
+The following exceptions (among others owned by `AutoFallback`) typically trigger a hop to the next chain member:
+
+- `Html2rss::RequestService::BlockedSurfaceDetected`
+- `Html2rss::RequestService::RequestTimedOut`
+- Faraday connection / timeout errors
+- Empty extraction results when a later chain member may succeed
+
+Non-fallback errors (budget exceeded, private network denied, invalid URL, etc.) abort immediately.
+
+## Budget Management
+
+Retries within the `auto` plan are budget-aware: strategy hops share the feed's request/session policy. Prefer pinning a concrete strategy when you need a single-hop budget profile.
+
+## Strategy Reporting
+
+- `Html2rss::RequestService::Response` includes transport metadata for the strategy that produced it.
+- `Html2rss::Status` records selected strategy and attempt tallies for MCP `_meta` / CLI `--explain`.
+
+## Default Behavior
+
+`auto` is the default strategy for feed builds, including `auto_source` and `auto_json_feed` entry points.

--- a/docs/capture.md
+++ b/docs/capture.md
@@ -39,6 +39,8 @@ Html2rss.capture('https://example.com', strategy: :local_file, local_file_path: 
 ```
 
 `strategy: :auto` uses the same AutoFallback chain as scrape (`faraday` → `botasaurus`).
+When AutoFallback selects a concrete strategy (or you pin one), Capture **stamps**
+`strategy:` into the emitted YAML so later `Html2rss.feed(config)` replays the same transport.
 
 ## CLI
 

--- a/docs/capture.md
+++ b/docs/capture.md
@@ -1,86 +1,65 @@
-# Capture — Automatic Feed Config Derivation
+# Capture — Durable Feed Config Derivation
 
-The `Html2rss.capture` method (and its CLI alias `html2rss capture`) analyzes
-any URL through the auto-source pipeline and produces a reusable feed config
-hash with derived CSS selectors.
+The `Html2rss.capture` method (and CLI `html2rss capture`) analyzes a URL through
+the feed pipeline and produces a reusable config with **items selector + `enhance: true`**
+only — no brittle title/url/description attribute soup.
+
+This implements the durable shape described in issue #212.
 
 ## Use Case
 
-Speed up writing feed configs. Instead of manually inspecting HTML to craft CSS
-selectors, point `capture` at your target URL and let it produce a first draft.
-Tweak the output as needed.
+Speed up writing feed configs. Point `capture` at a listing URL and get a first draft
+that fills article fields via enhance at feed-build time.
 
 ## Gem API
 
 ```ruby
 config = Html2rss.capture('https://example.com/articles')
 
-# config contains a hash with :channel and :selectors keys:
 # {
-#   channel: { url: "https://example.com/articles", title: "...", time_zone: "UTC" },
+#   channel: { url: "...", title: "...", time_zone: "UTC" },
 #   selectors: {
-#     items: { selector: "div.post" },
-#     title: { selector: "h2 > a" },
-#     link: { selector: "a.more", extractor: "href" },
-#     description: { selector: "div.excerpt" }
+#     items: { selector: "div.post", enhance: true }
 #   }
 # }
 
-# Save to YAML for reuse (string keys — same wire form as hand-written configs)
 File.write('my-feed.yml', YAML.dump(Html2rss::HashUtil.deep_stringify_keys(config)))
-
-# Use immediately
 feed = Html2rss.feed(config)
 ```
+
+`Capture.build` returns a `CaptureResult` with quality meta (`has_selectors`,
+`segment_strategy`, `admission_drops`, `selected_strategy`).
 
 ### Options
 
 ```ruby
-# Pin a specific request strategy
 Html2rss.capture('https://spa-site.com', strategy: :botasaurus)
-
-# Provide a CSS selector hint for items
 Html2rss.capture('https://example.com', items_selector: '.article-card')
-
-# Analyze a local HTML file (stamps strategy: :local_file and local_file_path)
 Html2rss.capture('https://example.com', strategy: :local_file, local_file_path: './page.html')
 ```
+
+`strategy: :auto` uses the same AutoFallback chain as scrape (`faraday` → `botasaurus`).
 
 ## CLI
 
 ```bash
-# Print a reusable YAML config
 html2rss capture https://example.com/articles
-
-# With Botasaurus strategy
 html2rss capture https://example.com --strategy botasaurus
-
-# Save to file
 html2rss capture https://example.com/articles > my-feed.yml
-
-# Read from a local HTML file
 html2rss capture https://example.com --input ./page.html
+html2rss capture https://example.com --explain   # quality JSON on stderr
 ```
 
 ## How It Works
 
-1. **Request** — fetches the page using the configured strategy
-2. **Discover** — runs the AutoSource pipeline to extract articles
-3. **Analyze** — normalizes the page into an SST document, segments it, and
-   maps segment positions back to extracted articles
-4. **Derive** — builds CSS selectors from SST tag_paths for items, title, link,
-   and description attributes
-5. **Assemble** — returns a complete config hash ready for serialization
+1. **Request** — `FeedPipeline` (AutoFallback when `:auto`)
+2. **Discover** — AutoSource extracts admitted articles
+3. **Segment** — try SST Segmenter strategies `:list` → `:cluster` → `:semantic`
+4. **Gate** — emit items selector only when ≥ `MIN_SELECTOR_MATCHES` articles match
+5. **Assemble** — `{ items: { selector:, enhance: true } }` plus channel
 
 ## Limitations
 
-- Selector quality depends on the page structure and auto-source detection.
-  Complex layouts may produce imperfect selectors that need manual adjustment.
-  Treat capture output as a first draft.
-- Capture segment discovery currently uses the list Segmenter strategy only
-  (not AutoSource's cluster/semantic heuristics), so some layouts may need a
-  manual `items_selector` hint.
-- The capture only derives items, title, link, and description selectors.
-  Description is omitted when it would resolve to the invalid CSS selector `.`
-  (item root equals description root). Additional attributes (author,
-  published_at, categories, enclosures) can be added manually.
+- Selector quality depends on page structure; treat output as a first draft.
+- When the quality gate fails, selectors are omitted (`has_selectors: false`) — fail loud
+  rather than inventing attribute selectors.

--- a/lib/html2rss.rb
+++ b/lib/html2rss.rb
@@ -71,6 +71,30 @@ module Html2rss
   # rubocop:disable Metrics/ParameterLists
 
   ##
+  # Scrapes the provided URL without hand-written selectors and returns {FeedResult}.
+  #
+  # Prefer this when callers need {FeedResult#status} (MCP +_meta+, CLI +--explain+).
+  #
+  # @param url [String] source page URL
+  # @param strategy [Symbol] request strategy to use
+  # @param items_selector [String, nil] optional selector hint for item extraction
+  # @param max_redirects [Integer, nil] optional redirect limit override
+  # @param max_requests [Integer] optional request budget override (default: 4 for sitemap sub-fetches)
+  # @param local_file_path [String, nil] optional local HTML file path
+  # @param limit [Integer, nil] max articles to keep (default: {AutoSource::DEFAULT_LIMIT})
+  # @return [Html2rss::FeedResult]
+  def self.auto_feed_result(url,
+                            strategy: :auto,
+                            items_selector: nil,
+                            max_redirects: nil,
+                            max_requests: 4,
+                            local_file_path: nil,
+                            limit: nil)
+    feed_result(build_auto_source_config(url:, strategy:, items_selector:, max_redirects:, max_requests:,
+                                         local_file_path:, limit:))
+  end
+
+  ##
   # Scrapes the provided URL without hand-written selectors and returns an RSS object.
   #
   # Builds an auto_source config, then FeedPipeline runs structured scrapers and
@@ -91,8 +115,8 @@ module Html2rss
                        max_requests: 4,
                        local_file_path: nil,
                        limit: nil)
-    feed(build_auto_source_config(url:, strategy:, items_selector:, max_redirects:, max_requests:,
-                                  local_file_path:, limit:))
+    auto_feed_result(url, strategy:, items_selector:, max_redirects:, max_requests:,
+                          local_file_path:, limit:).to_rss
   end
 
   ##
@@ -115,8 +139,8 @@ module Html2rss
                           max_requests: 4,
                           local_file_path: nil,
                           limit: nil)
-    json_feed(build_auto_source_config(url:, strategy:, items_selector:, max_redirects:, max_requests:,
-                                       local_file_path:, limit:))
+    auto_feed_result(url, strategy:, items_selector:, max_redirects:, max_requests:,
+                          local_file_path:, limit:).to_json_feed
   end
 
   ##

--- a/lib/html2rss/auto_source.rb
+++ b/lib/html2rss/auto_source.rb
@@ -115,7 +115,16 @@ module Html2rss
       @articles ||= extract_articles
     rescue Html2rss::AutoSource::Scraper::NoScraperFound => error
       Log.warn "#{self.class}: no scraper matched #{url} (#{error.message})"
+      @admission_drops = {}.freeze
       []
+    end
+
+    ##
+    # Reason → count tallies from the final {Cleanup} pass (empty until {#articles} runs).
+    #
+    # @return [Hash{String => Integer}]
+    def admission_drops
+      @admission_drops || {}
     end
 
     private
@@ -163,7 +172,9 @@ module Html2rss
 
       raise Scraper.no_scraper_found_for(parsed_body, body:) unless matched
 
-      Cleanup.call(articles, url:, **cleanup_options).first(article_limit)
+      result = Cleanup.call(articles, url:, **cleanup_options)
+      @admission_drops = result.drop_tallies
+      result.articles.first(article_limit)
     end
     # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
@@ -183,7 +194,7 @@ module Html2rss
     end
 
     def admitted_articles(articles)
-      Cleanup.call(articles.dup, url:, **cleanup_options).select do |article|
+      Cleanup.call(articles.dup, url:, **cleanup_options).articles.select do |article|
         article.url && !article.title.to_s.empty?
       end
     end

--- a/lib/html2rss/auto_source/cleanup.rb
+++ b/lib/html2rss/auto_source/cleanup.rb
@@ -6,7 +6,8 @@ module Html2rss
     # Cleanup is responsible for cleaning up the extracted articles.
     # :reek:MissingSafeMethod { enabled: false }
     # It applies various strategies to filter and refine the article list.
-    class Cleanup
+    # Sole producer of admission drop tallies for {Html2rss::Status}.
+    class Cleanup # rubocop:disable Metrics/ClassLength -- reject steps + tallies stay co-located
       # Default cleanup behavior for auto-sourced article lists.
       DEFAULT_CONFIG = {
         keep_different_domain: false
@@ -49,25 +50,28 @@ module Html2rss
       ].freeze
       private_constant :JUNK_TITLE_RULES
 
+      # Admitted articles plus reason → count tallies for drops.
+      Result = Data.define(:articles, :drop_tallies)
+
       class << self
         # @param articles [Array<Article>] extracted article candidates
         # @param url [Html2rss::Url] feed source URL used for same-host filtering
         # @param keep_different_domain [Boolean] whether to keep off-domain entries
-        # @return [Array<Article>] cleaned article list
-        def call(articles, url:, keep_different_domain: DEFAULT_CONFIG.fetch(:keep_different_domain))
+        # @return [Result] cleaned articles and frozen drop tallies
+        def call(articles, url:, keep_different_domain: DEFAULT_CONFIG.fetch(:keep_different_domain)) # rubocop:disable Metrics/MethodLength -- ordered reject pipeline
           Log.debug "Cleanup: start with #{articles.size} articles"
+          tallies = Hash.new(0)
 
-          articles.select!(&:valid?)
-
-          deduplicate_by_url!(articles)
-          keep_only_http_urls!(articles)
-          reject_self_links!(articles, url)
-          reject_different_domain!(articles, url) unless keep_different_domain
-          reject_excluded_destinations!(articles)
-          reject_low_quality_titles!(articles)
+          reject_invalid!(articles, tallies)
+          deduplicate_by_url!(articles, tallies)
+          keep_only_http_urls!(articles, tallies)
+          reject_self_links!(articles, url, tallies)
+          reject_different_domain!(articles, url, tallies) unless keep_different_domain
+          reject_excluded_destinations!(articles, tallies)
+          reject_low_quality_titles!(articles, tallies)
 
           Log.debug "Cleanup: end with #{articles.size} articles"
-          articles
+          Result.new(articles:, drop_tallies: tallies.freeze)
         end
 
         # First matching junk reason for a title, or nil when the title is acceptable.
@@ -85,34 +89,44 @@ module Html2rss
 
         private
 
-        def deduplicate_by_url!(articles)
+        def reject_invalid!(articles, tallies)
+          tally_reject!(articles, tallies, 'invalid') { |article| !article.valid? }
+        end
+
+        def deduplicate_by_url!(articles, tallies)
           seen = {}
-          articles.reject! do |article|
+          tally_reject!(articles, tallies, 'duplicate_url') do |article|
             identity = url_identity(article.url)
             identity.nil? || seen.key?(identity).tap { seen[identity] = true }
           end
         end
 
-        def keep_only_http_urls!(articles)
-          articles.select! { |article| VALID_SCHEMES.include?(article.url&.scheme) }
+        def keep_only_http_urls!(articles, tallies)
+          tally_reject!(articles, tallies, 'bad_scheme') do |article|
+            !VALID_SCHEMES.include?(article.url&.scheme)
+          end
         end
 
-        def reject_self_links!(articles, base_url)
+        def reject_self_links!(articles, base_url, tallies)
           source_identity = url_identity(base_url)
-          articles.reject! { |article| url_identity(article.url) == source_identity }
+          tally_reject!(articles, tallies, 'self_link') do |article|
+            url_identity(article.url) == source_identity
+          end
         end
 
-        def reject_different_domain!(articles, base_url)
+        def reject_different_domain!(articles, base_url, tallies)
           base_host = base_url.host
-          articles.select! { |article| article.url&.host == base_host }
+          tally_reject!(articles, tallies, 'different_domain') do |article|
+            article.url&.host != base_host
+          end
         end
 
         # Hard-exclude non-article destination classes (commerce/affiliate/utility chrome).
         # PathClassifier owns route facts; Cleanup owns feed-item admission.
-        # Align with Scoring's non_content_utility_path demotion, but as a hard gate so
-        # nested commerce routes (e.g. /jobs/stellenangebote/berlin) cannot fill limit.
-        def reject_excluded_destinations!(articles)
-          articles.reject! { |article| excluded_destination?(article.url) }
+        def reject_excluded_destinations!(articles, tallies)
+          tally_reject!(articles, tallies, 'excluded_destination') do |article|
+            excluded_destination?(article.url)
+          end
         end
 
         def excluded_destination?(url)
@@ -126,10 +140,30 @@ module Html2rss
 
         # Keep missing titles (nil provenance). Drop present junk/unnatural titles —
         # blanking them would hide bad extraction as "unknown" and inflate empty items.
-        def reject_low_quality_titles!(articles)
-          articles.select! do |article|
+        def reject_low_quality_titles!(articles, tallies) # rubocop:disable Metrics/MethodLength -- junk vs word-count reasons
+          articles.reject! do |article|
             title = article.title
-            title.nil? || (word_count_at_least?(title, MIN_WORDS) && junk_reason(title).nil?)
+            next false if title.nil?
+
+            reason = junk_reason(title)
+            if reason
+              tallies[reason.to_s] += 1
+              next true
+            end
+
+            next false if word_count_at_least?(title, MIN_WORDS)
+
+            tallies['low_word_count'] += 1
+            true
+          end
+        end
+
+        def tally_reject!(articles, tallies, reason)
+          articles.reject! do |article|
+            next false unless yield(article)
+
+            tallies[reason] += 1
+            true
           end
         end
 

--- a/lib/html2rss/capture.rb
+++ b/lib/html2rss/capture.rb
@@ -65,6 +65,7 @@ module Html2rss
       config = {
         channel: build_channel(outcome.response),
         selectors: selectors.empty? ? nil : selectors,
+        **strategy_stamp(outcome),
         **local_file_request_overlay
       }.compact
 
@@ -80,6 +81,18 @@ module Html2rss
     end
 
     private
+
+    def strategy_stamp(outcome)
+      concrete = outcome.selected_strategy || concrete_request_strategy
+      return {} if concrete.nil? || concrete == :auto
+
+      { strategy: concrete }
+    end
+
+    def concrete_request_strategy
+      plan = FeedPipeline::StrategyPlan.resolve(@strategy)
+      plan.is_a?(FeedPipeline::StrategyPlan::Concrete) ? plan.strategy : nil
+    end
 
     def raw_config
       @raw_config ||= build_raw_config

--- a/lib/html2rss/capture.rb
+++ b/lib/html2rss/capture.rb
@@ -112,8 +112,8 @@ module Html2rss
     end
 
     def resolve_strategy(strategy)
-      plan = FeedPipeline::StrategyPlan.resolve(strategy)
-      plan.is_a?(FeedPipeline::StrategyPlan::Auto) ? :faraday : plan.strategy
+      # Phase 1: diagnostic collapse. Phase 4 wires Capture through AutoFallback.
+      FeedPipeline::StrategyPlan.concrete_for_diagnostic(strategy)
     end
 
     def fetch_response

--- a/lib/html2rss/capture.rb
+++ b/lib/html2rss/capture.rb
@@ -2,20 +2,26 @@
 
 module Html2rss
   ##
-  # Analyzes a URL and produces a reusable feed config hash with derived CSS selectors.
+  # Analyzes a URL and produces a durable feed config: items selector + +enhance: true+.
   #
-  # Uses the auto-source pipeline to extract articles, then traces back through
-  # SST segments to build items + attribute selectors suitable for a static feed config.
-  class Capture # rubocop:disable Metrics/ClassLength
+  # Fetches via {FeedPipeline} (including AutoFallback for +:auto+), extracts articles,
+  # then derives a reusable items CSS selector from SST segments (list → cluster → semantic).
+  class Capture # rubocop:disable Metrics/ClassLength -- segment strategies + CSS trim stay co-located
     LEADING_TRIM_TAGS = %w[html body].freeze
     private_constant :LEADING_TRIM_TAGS
 
+    # Ordered Segmenter strategies tried until the items selector quality gate passes.
+    SEGMENT_STRATEGIES = %i[list cluster semantic].freeze
+
+    # Minimum matched segment/article pairs required to emit an items selector.
+    MIN_SELECTOR_MATCHES = 2
+
     ##
-    # Result of a capture operation.
-    # @!attribute config [Hash] feed config hash with +:channel+ and +:selectors+
-    # @!attribute articles_count [Integer] number of articles extracted
-    # @!attribute channel_title [String] derived channel title
-    CaptureResult = Data.define(:config, :articles_count, :channel_title)
+    # Result of a capture operation (config plus quality meta).
+    CaptureResult = Data.define(
+      :config, :articles_count, :channel_title, :has_selectors, :segment_strategy,
+      :admission_drops, :selected_strategy
+    )
 
     class << self
       ##
@@ -38,11 +44,6 @@ module Html2rss
     # @param url [String] source page URL
     # @param strategy [Symbol] request strategy
     # @param options [Hash] additional options
-    # @option options [String, nil] :items_selector optional selector hint
-    # @option options [Integer, nil] :max_redirects optional redirect limit override
-    # @option options [Integer, nil] :max_requests optional request budget override
-    # @option options [Integer, nil] :limit max articles to keep
-    # @option options [String, nil] :local_file_path optional local HTML file path
     def initialize(url, strategy: :auto, **options)
       @url = url
       @strategy = strategy
@@ -57,21 +58,24 @@ module Html2rss
     # Runs the capture pipeline.
     #
     # @return [CaptureResult]
-    def build # rubocop:disable Metrics/MethodLength
-      response = fetch_response
-      articles = extract_articles(response)
-      selectors = derive_selectors(response, articles)
+    def build # rubocop:disable Metrics/AbcSize, Metrics/MethodLength -- outcome + selector + result assembly
+      outcome = FeedPipeline.new(raw_config).to_outcome
+      selectors, segment_strategy = derive_selectors(outcome.response, outcome.articles)
 
       config = {
-        channel: build_channel(response),
+        channel: build_channel(outcome.response),
         selectors: selectors.empty? ? nil : selectors,
         **local_file_request_overlay
       }.compact
 
       CaptureResult.new(
         config:,
-        articles_count: articles.size,
-        channel_title: channel_title_from(response)
+        articles_count: outcome.articles.size,
+        channel_title: channel_title_from(outcome.response),
+        has_selectors: !selectors.empty?,
+        segment_strategy:,
+        admission_drops: outcome.admission_drops,
+        selected_strategy: outcome.selected_strategy
       )
     end
 
@@ -81,7 +85,7 @@ module Html2rss
       @raw_config ||= build_raw_config
     end
 
-    def build_raw_config # rubocop:disable Metrics/MethodLength
+    def build_raw_config
       Config.auto_source_config(
         url: @url,
         items_selector: @items_selector_hint,
@@ -91,10 +95,7 @@ module Html2rss
           max_requests: @max_requests
         ),
         limit: @limit
-      ).tap do |config|
-        config[:strategy] = resolve_strategy(config[:strategy] || @strategy)
-        apply_local_file_path!(config)
-      end
+      ).tap { |config| apply_local_file_path!(config) }
     end
 
     def apply_local_file_path!(config)
@@ -111,62 +112,39 @@ module Html2rss
       { strategy: :local_file, request: { local_file_path: @local_file_path } }
     end
 
-    def resolve_strategy(strategy)
-      # Phase 1: diagnostic collapse. Phase 4 wires Capture through AutoFallback.
-      FeedPipeline::StrategyPlan.concrete_for_diagnostic(strategy)
-    end
+    # @return [Array(Hash, Symbol, nil)] selectors hash and winning segment strategy
+    def derive_selectors(response, articles)
+      return hint_selectors if @items_selector_hint
+      return [{}, nil] if articles.empty? || !response.html_response?
 
-    def fetch_response
-      config = Config.from_hash(raw_config)
-      resources = FeedPipeline::RuntimePolicy.resources_for(config)
-      session = RequestSession.build(
-        config:,
-        strategy: config.strategy,
-        budget: resources.budget,
-        policy: resources.policy
-      )
-      session.fetch_initial_response
-    end
+      sst = SST::Normalizer.call(response.body)
+      return [{}, nil] unless sst
 
-    def extract_articles(response)
-      auto_source_opts = raw_config[:auto_source] || AutoSource::DEFAULT_CONFIG
-      AutoSource.new(response, auto_source_opts).articles
-    rescue AutoSource::Scraper::NoScraperFound
-      []
-    end
-
-    def derive_selectors(response, articles) # rubocop:disable Metrics/MethodLength
-      return {} if articles.empty? || !response.html_response?
-
-      sst = normalize_sst(response)
-      return {} unless sst
-
-      segments = discover_segments(sst)
-      return {} if segments.empty?
-
-      matched = match_segments_to_articles(segments, articles)
-      return {} if matched.empty?
-
-      build_selector_hash(matched, sst)
+      select_enhance_selectors(sst, articles)
     rescue ArgumentError => error
       Log.warn("Capture selector derivation failed: #{error.message}")
-      {}
+      [{}, nil]
     end
 
-    def normalize_sst(response)
-      SST::Normalizer.call(response.body)
+    def hint_selectors
+      [{ items: { selector: @items_selector_hint, enhance: true } }, :hint]
     end
 
-    def discover_segments(sst)
+    def select_enhance_selectors(sst, articles) # rubocop:disable Metrics/MethodLength -- strategy loop + gate
       link_resolver = Scoring::LinkResolver.new(@url)
 
-      AutoSource::Segmenter.call(
-        sst,
-        base_url: @url,
-        strategy: :list,
-        permit_unanchored: false,
-        link_resolver:
-      )
+      SEGMENT_STRATEGIES.each do |strategy|
+        segments = AutoSource::Segmenter.call(
+          sst, base_url: @url, strategy:, permit_unanchored: false, link_resolver:
+        )
+        matched = match_segments_to_articles(segments, articles)
+        items_sel = items_selector(matched)
+        next unless items_sel && matched.size >= MIN_SELECTOR_MATCHES
+
+        return [{ items: { selector: items_sel, enhance: true } }, strategy]
+      end
+
+      [{}, nil]
     end
 
     def match_segments_to_articles(segments, articles)
@@ -201,23 +179,9 @@ module Html2rss
       segment.root_node.visible_text.to_s.strip
     end
 
-    def build_selector_hash(matched, _sst)
-      items_sel = items_selector(matched)
-      return {} unless items_sel
-
-      first = matched.first
-      root = first[:segment].root_node
-
-      attrs = {}.tap do |a|
-        a[:title] = title_selector(root)
-        a[:url] = url_selector(first[:segment])
-        a[:description] = description_selector(root, first[:segment])
-      end.compact
-
-      { items: { selector: items_sel }, **attrs }
-    end
-
     def items_selector(matched)
+      return nil if matched.empty?
+
       roots = matched.map { |m| m[:segment].root_node }
       shared = shared_class_items_selector(roots)
       return shared if shared
@@ -263,39 +227,6 @@ module Html2rss
         prefix = prefix[0...i]
       end
       "/#{prefix.join('/')}"
-    end
-
-    def title_selector(root) # rubocop:disable Metrics/CyclomaticComplexity
-      heading = root.find(&:heading?)
-      relative = css_for_path(heading.tag_path, root.tag_path) if heading
-      relative ||= begin
-        link = root.find { |n| n.link? && n.visible_text.to_s.strip.length > 3 }
-        css_for_path(link.tag_path, root.tag_path) if link
-      end
-      return nil unless relative
-
-      { selector: relative }
-    end
-
-    def url_selector(segment)
-      return nil unless segment.primary_link
-
-      relative = css_for_path(segment.primary_link.tag_path, segment.root_node.tag_path)
-      { selector: relative, extractor: 'href' }
-    end
-
-    def description_selector(root, segment)
-      relative = css_for_path(root.tag_path, segment.root_node.tag_path)
-      return nil if relative.nil? || relative.empty? || relative == '.'
-
-      { selector: relative }
-    end
-
-    def css_for_path(full_path, root_path)
-      relative = full_path.delete_prefix(root_path)
-      return '.' if relative.empty?
-
-      relative.split('/').reject(&:empty?).join(' > ')
     end
 
     def build_channel(response)

--- a/lib/html2rss/capture.rb
+++ b/lib/html2rss/capture.rb
@@ -44,6 +44,11 @@ module Html2rss
     # @param url [String] source page URL
     # @param strategy [Symbol] request strategy
     # @param options [Hash] additional options
+    # @option options [String, nil] :items_selector optional selector hint
+    # @option options [Integer, nil] :max_redirects optional redirect limit override
+    # @option options [Integer, nil] :max_requests optional request budget override
+    # @option options [Integer, nil] :limit max articles to keep
+    # @option options [String, nil] :local_file_path optional local HTML file path
     def initialize(url, strategy: :auto, **options)
       @url = url
       @strategy = strategy

--- a/lib/html2rss/cli.rb
+++ b/lib/html2rss/cli.rb
@@ -82,17 +82,19 @@ module Html2rss
     method_option :input,
                   type: :string,
                   desc: 'Local HTML file path to read input from'
+    method_option :explain,
+                  type: :boolean,
+                  desc: 'Print Status JSON to stderr (stdout stays the feed)',
+                  default: false
     # @param url [String, nil] source page URL for auto discovery
     # @return [void]
-    def auto(url = nil)
+    def auto(url = nil) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength -- CLI option wiring
       format = options.fetch(:format, 'rss')
       strategy, local_file_path, url = prepare_auto_inputs(url, options[:input])
+      feed_result = execute_feed { auto_feed_result_for(url, strategy, local_file_path) }
 
-      result = execute_feed do
-        source_call(url, strategy, local_file_path, format == 'jsonfeed')
-      end
-
-      puts(format == 'jsonfeed' ? JSON.pretty_generate(result) : result)
+      explain_status!(feed_result.status) if options[:explain]
+      puts(format == 'jsonfeed' ? JSON.pretty_generate(feed_result.to_json_feed) : feed_result.to_rss)
     end
 
     desc 'capture URL', 'Analyze a URL and print a reusable YAML feed config'
@@ -113,14 +115,18 @@ module Html2rss
     method_option :input,
                   type: :string,
                   desc: 'Local HTML file path to read input from'
+    method_option :explain,
+                  type: :boolean,
+                  desc: 'Print capture quality JSON to stderr (stdout stays YAML)',
+                  default: false
     ##
     # Captures a URL and prints a reusable YAML config.
     #
     # @param url [String, nil] source page URL for capture
     # @return [void]
-    def capture(url = nil) # rubocop:disable Metrics/MethodLength
+    def capture(url = nil) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength -- CLI option wiring
       strategy, local_file_path, url = prepare_auto_inputs(url, options[:input])
-      config = Html2rss.capture(
+      result = Html2rss::Capture.build(
         url,
         strategy:,
         items_selector: options[:items_selector],
@@ -129,7 +135,8 @@ module Html2rss
         max_requests: options[:max_requests],
         local_file_path:
       )
-      puts YAML.dump(HashUtil.deep_stringify_keys(config))
+      explain_capture!(result) if options[:explain]
+      puts YAML.dump(HashUtil.deep_stringify_keys(result.config))
     end
 
     desc 'schema', 'Print the exported config JSON Schema'
@@ -290,9 +297,8 @@ module Html2rss
       raise Thor::Error, error.message
     end
 
-    def source_call(url, strategy, local_file_path, is_json)
-      method = is_json ? Html2rss.method(:auto_json_feed) : Html2rss.method(:auto_source)
-      method.call(
+    def auto_feed_result_for(url, strategy, local_file_path)
+      Html2rss.auto_feed_result(
         url,
         strategy:,
         items_selector: options[:items_selector],
@@ -300,6 +306,18 @@ module Html2rss
         max_requests: options[:max_requests],
         local_file_path:,
         limit: options[:limit]&.to_i
+      )
+    end
+
+    def explain_status!(status)
+      $stderr.puts JSON.pretty_generate(status.to_h) # rubocop:disable Style/StderrPuts -- CLI explain contract
+    end
+
+    def explain_capture!(result)
+      $stderr.puts JSON.pretty_generate( # rubocop:disable Style/StderrPuts -- CLI explain contract
+        articles_count: result.articles_count,
+        channel_title: result.channel_title,
+        has_selectors: !result.config[:selectors].nil? && !result.config[:selectors].empty?
       )
     end
 

--- a/lib/html2rss/cli.rb
+++ b/lib/html2rss/cli.rb
@@ -10,10 +10,6 @@ module Html2rss
   # The Html2rss command line interface.
   class CLI < Thor # rubocop:disable Metrics/ClassLength
     check_unknown_options!
-    # Ordered fallback chain attempted by the feed-level :auto plan.
-    #
-    # @return [Array<Symbol>]
-    AUTO_FALLBACK_CHAIN = Html2rss::FeedPipeline::AutoFallback::CHAIN.freeze
     # Supported CLI strategy plan option values (:auto plus concrete strategies).
     #
     # @return [Array<String>]
@@ -24,7 +20,7 @@ module Html2rss
     # @return [String]
     STRATEGY_OPTION_DESC = [
       'Optional request strategy (defaults to auto; auto tries',
-      "#{AUTO_FALLBACK_CHAIN.join(' -> ')})"
+      "#{Html2rss::FeedPipeline::AutoFallback::CHAIN.join(' -> ')})"
     ].join(' ').freeze
 
     # @return [Boolean] whether Thor should terminate process on command failures

--- a/lib/html2rss/cli.rb
+++ b/lib/html2rss/cli.rb
@@ -315,9 +315,14 @@ module Html2rss
 
     def explain_capture!(result)
       $stderr.puts JSON.pretty_generate( # rubocop:disable Style/StderrPuts -- CLI explain contract
-        articles_count: result.articles_count,
-        channel_title: result.channel_title,
-        has_selectors: !result.config[:selectors].nil? && !result.config[:selectors].empty?
+        {
+          articles_count: result.articles_count,
+          channel_title: result.channel_title,
+          has_selectors: result.has_selectors,
+          segment_strategy: result.segment_strategy,
+          selected_strategy: result.selected_strategy,
+          admission_drops: result.admission_drops
+        }.compact
       )
     end
 

--- a/lib/html2rss/cli.rb
+++ b/lib/html2rss/cli.rb
@@ -88,7 +88,7 @@ module Html2rss
                   default: false
     # @param url [String, nil] source page URL for auto discovery
     # @return [void]
-    def auto(url = nil) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength -- CLI option wiring
+    def auto(url = nil)
       format = options.fetch(:format, 'rss')
       strategy, local_file_path, url = prepare_auto_inputs(url, options[:input])
       feed_result = execute_feed { auto_feed_result_for(url, strategy, local_file_path) }

--- a/lib/html2rss/feed_pipeline.rb
+++ b/lib/html2rss/feed_pipeline.rb
@@ -9,7 +9,8 @@ module Html2rss
     # attempt_count: auto attempts attempted; 0 outside :auto.
     # strategy_attempts: auto attempt hashes (with optional transport_meta); empty outside :auto.
     PipelineOutcome = Data.define(
-      :response, :articles, :dedup_dropped, :selected_strategy, :attempt_count, :strategy_attempts
+      :response, :articles, :dedup_dropped, :selected_strategy, :attempt_count, :strategy_attempts,
+      :admission_drops
     )
 
     ##
@@ -32,7 +33,8 @@ module Html2rss
         dedup_dropped: outcome.dedup_dropped,
         selected_strategy: outcome.selected_strategy,
         attempt_count: outcome.attempt_count,
-        strategy_attempts: outcome.strategy_attempts
+        strategy_attempts: outcome.strategy_attempts,
+        admission_drops: outcome.admission_drops
       )
       FeedResult.new(channel:, articles: outcome.articles, status:, stylesheets: config.stylesheets)
     end
@@ -56,11 +58,11 @@ module Html2rss
     # @param config [Html2rss::Config]
     # @param response [Html2rss::RequestService::Response]
     # @param request_session [Html2rss::RequestSession]
-    # @return [Array(Array<Html2rss::Article>, Integer)] unique articles and drop count
+    # @return [Array(Array<Html2rss::Article>, Integer, Hash)] unique articles, dedup drops, admission drops
     def deduplicated_articles(config:, response:, request_session:)
-      collected = collect_articles(config:, response:, request_session:)
+      collected, admission_drops = collect_articles(config:, response:, request_session:)
       unique = Article::Deduplicator.new(collected).call
-      [unique, collected.size - unique.size]
+      [unique, collected.size - unique.size, admission_drops]
     end
 
     private
@@ -80,11 +82,12 @@ module Html2rss
     def run_pipeline_for_strategy(config, strategy:, resources:)
       request_session = request_session_for(config, strategy:, resources:)
       response = request_session.fetch_initial_response
-      articles, dedup_dropped = deduplicated_articles(config:, response:, request_session:)
+      articles, dedup_dropped, admission_drops = deduplicated_articles(config:, response:, request_session:)
       raise_empty_auto_source!(strategy:, response:) if config.auto_source && articles.empty?
 
       PipelineOutcome.new(
-        response:, articles:, dedup_dropped:, selected_strategy: nil, attempt_count: 0, strategy_attempts: []
+        response:, articles:, dedup_dropped:, selected_strategy: nil, attempt_count: 0,
+        strategy_attempts: [], admission_drops:
       )
     end
 
@@ -108,8 +111,9 @@ module Html2rss
     end
 
     def collect_articles(config:, response:, request_session:)
-      selector_articles(config:, response:, request_session:) +
-        auto_source_articles(config:, response:, request_session:)
+      selector = selector_articles(config:, response:, request_session:)
+      auto, admission_drops = auto_source_articles(config:, response:, request_session:)
+      [selector + auto, admission_drops]
     end
 
     # rubocop:disable Metrics/MethodLength
@@ -132,10 +136,12 @@ module Html2rss
     end
     # rubocop:enable Metrics/MethodLength
 
+    # @return [Array(Array<Html2rss::Article>, Hash{String => Integer})]
     def auto_source_articles(config:, response:, request_session:)
-      return [] unless (auto_source = config.auto_source)
+      return [[], {}] unless (auto_source = config.auto_source)
 
-      AutoSource.new(response, auto_source, request_session:).articles
+      source = AutoSource.new(response, auto_source, request_session:)
+      [source.articles, source.admission_drops]
     end
   end
 end

--- a/lib/html2rss/feed_pipeline.rb
+++ b/lib/html2rss/feed_pipeline.rb
@@ -3,7 +3,7 @@
 module Html2rss
   ##
   # Builds feeds from validated config through request, extraction, and rendering stages.
-  class FeedPipeline
+  class FeedPipeline # rubocop:disable Metrics/ClassLength -- outcome + collect seams stay co-located
     # Scrape-finished facts after request + extraction + dedup (before Channel/Status materialize).
     # selected_strategy: set on :auto success; nil otherwise.
     # attempt_count: auto attempts attempted; 0 outside :auto.
@@ -17,6 +17,16 @@ module Html2rss
     # @param raw_config [Hash{Symbol => Object}] user-provided feed config
     def initialize(raw_config)
       @raw_config = raw_config
+    end
+
+    ##
+    # Runs the pipeline once and returns scrape-finished outcome (before Channel/Status).
+    # Used by {Capture} which needs the response body for SST selector derivation.
+    #
+    # @return [PipelineOutcome]
+    def to_outcome
+      config = Config.from_hash(raw_config, params: raw_config[:params])
+      pipeline_outcome_for(config)
     end
 
     ##

--- a/lib/html2rss/feed_pipeline/auto_fallback.rb
+++ b/lib/html2rss/feed_pipeline/auto_fallback.rb
@@ -6,7 +6,7 @@ module Html2rss
     #
     # Owned by {FeedPipeline}; invoked only after {StrategyPlan} resolves +:auto+.
     # Hosted by the pipeline instance: session + extract call back into FeedPipeline.
-    class AutoFallback
+    class AutoFallback # rubocop:disable Metrics/ClassLength -- attempt state + logging stay co-located
       # Ordered list of concrete request strategies attempted by the :auto plan.
       CHAIN = %i[faraday botasaurus].freeze
 
@@ -64,17 +64,22 @@ module Html2rss
         # @param dedup_dropped [Integer] articles removed by deduplication
         # @param selected_strategy [Symbol] concrete strategy that produced items
         # @param attempt_count [Integer] number of attempts recorded for this chain
+        # @param admission_drops [Hash{String => Integer}] Cleanup drop tallies
         # @return [void]
-        def succeed!(response:, articles:, dedup_dropped:, selected_strategy:, attempt_count:)
+        # rubocop:disable Metrics/ParameterLists -- PipelineOutcome kwargs stay co-located
+        def succeed!(response:, articles:, dedup_dropped:, selected_strategy:, attempt_count:,
+                     admission_drops: {})
           @result = PipelineOutcome.new(
             response:,
             articles:,
             dedup_dropped:,
             selected_strategy:,
             attempt_count:,
-            strategy_attempts: attempts
+            strategy_attempts: attempts,
+            admission_drops:
           )
         end
+        # rubocop:enable Metrics/ParameterLists
       end
 
       ##
@@ -132,15 +137,18 @@ module Html2rss
         nil
       end
 
-      def process_response(response:, strategy:, next_strategy:, request_session:, state:)
+      def process_response(response:, strategy:, next_strategy:, request_session:, state:) # rubocop:disable Metrics/MethodLength -- extract + success path
         state.remember_response(response)
-        articles, dedup_dropped = articles_for(response:, request_session:)
+        articles, dedup_dropped, admission_drops = articles_for(response:, request_session:)
         items_count = articles.size
         state.record_items(strategy:, items_count:, transport_meta: response.transport_meta)
         Log.debug("#{self.class}: strategy=#{strategy} items=#{items_count} " \
                   "host=#{response.url.host} elapsed=#{format('%.3f', budget.elapsed_seconds)}s " \
                   "budget_remaining=#{budget_remaining_label}")
-        return record_success(response:, strategy:, articles:, dedup_dropped:, state:) if items_count.positive?
+        if items_count.positive?
+          return record_success(response:, strategy:, articles:, dedup_dropped:, admission_drops:,
+                                state:)
+        end
 
         log_info_fallback_zero_items(strategy:, next_strategy:, response:) if next_strategy
       end
@@ -149,15 +157,18 @@ module Html2rss
         pipeline.deduplicated_articles(config:, response:, request_session:)
       end
 
-      def record_success(response:, strategy:, articles:, dedup_dropped:, state:)
+      # rubocop:disable Metrics/ParameterLists -- success kwargs match PipelineOutcome
+      def record_success(response:, strategy:, articles:, dedup_dropped:, admission_drops:, state:)
         attempt_count = state.attempts.size
-        state.succeed!(response:, articles:, dedup_dropped:, selected_strategy: strategy, attempt_count:)
+        state.succeed!(response:, articles:, dedup_dropped:, selected_strategy: strategy,
+                       attempt_count:, admission_drops:)
         return unless attempt_count > 1
 
         Log.info("#{self.class}: auto selected strategy=#{strategy} after attempts=#{attempt_count} " \
                  "host=#{response.url.host} elapsed=#{format('%.3f', budget.elapsed_seconds)}s " \
                  "budget_remaining=#{budget_remaining_label}")
       end
+      # rubocop:enable Metrics/ParameterLists
 
       def finalize_failure(attempts:, response:)
         surface_category = response && AutoSource::Scraper.classify_no_scraper_surface(

--- a/lib/html2rss/feed_pipeline/strategy_plan.rb
+++ b/lib/html2rss/feed_pipeline/strategy_plan.rb
@@ -42,6 +42,17 @@ module Html2rss
         end
 
         ##
+        # Cheap single-request diagnostic default: +:auto+ → +:faraday+.
+        # Does not run {AutoFallback}. Prefer {resolve} for scrape/capture feeds.
+        #
+        # @param name [Symbol, String, nil] plan name (+nil+ → +:auto+)
+        # @return [Symbol] concrete {RequestService} strategy
+        def concrete_for_diagnostic(name = AUTO_NAME)
+          plan = resolve(name || AUTO_NAME)
+          plan.is_a?(Auto) ? RequestService.default_strategy_name : plan.strategy
+        end
+
+        ##
         # @param name [Symbol, String, nil] candidate plan name
         # @return [Boolean] whether +name+ is a valid feed-level strategy plan
         def valid?(name)

--- a/lib/html2rss/mcp/server.rb
+++ b/lib/html2rss/mcp/server.rb
@@ -212,16 +212,16 @@ module Html2rss
           ) do |server_context:, url:, strategy: 'auto', items_selector: nil| # rubocop:disable Lint/UnusedBlockArgument
             plan = (strategy || :auto).to_sym
             result = Html2rss::Capture.build(url, strategy: plan, items_selector:)
-            selectors = result.config[:selectors]
-            Server.text_response(
-              JSON.pretty_generate(result.config),
-              meta: {
-                articles_count: result.articles_count,
-                channel_title: result.channel_title,
-                has_selectors: !selectors.nil? && !selectors.empty?,
-                strategy: plan.to_s
-              }
-            )
+            meta = {
+              articles_count: result.articles_count,
+              channel_title: result.channel_title,
+              has_selectors: result.has_selectors,
+              strategy: plan.to_s
+            }
+            meta[:segment_strategy] = result.segment_strategy.to_s if result.segment_strategy
+            meta[:selected_strategy] = result.selected_strategy.to_s if result.selected_strategy
+            meta[:admission_drops] = result.admission_drops if result.admission_drops.any?
+            Server.text_response(JSON.pretty_generate(result.config), meta:)
           rescue StandardError => error
             Server.error_response(error)
           end

--- a/lib/html2rss/mcp/server.rb
+++ b/lib/html2rss/mcp/server.rb
@@ -216,7 +216,7 @@ module Html2rss
               articles_count: result.articles_count,
               channel_title: result.channel_title,
               has_selectors: result.has_selectors,
-              strategy: plan.to_s
+              requested_strategy: plan.to_s
             }
             meta[:segment_strategy] = result.segment_strategy.to_s if result.segment_strategy
             meta[:selected_strategy] = result.selected_strategy.to_s if result.selected_strategy
@@ -417,7 +417,8 @@ module Html2rss
         end
 
         ##
-        # Runs Cleanup via AutoSource so inspect can surface admission_drops.
+        # Surfaces Cleanup admission_drops without re-running full AutoSource discovery.
+        # Uses articles already extractable from a cheap AutoSource pass only when HTML.
         #
         # @param result [Hash]
         # @param response [Html2rss::RequestService::Response]
@@ -425,13 +426,11 @@ module Html2rss
         def merge_admission_diagnostics!(result, response)
           return unless response.html_response?
 
-          source = AutoSource.new(response, AutoSource::DEFAULT_CONFIG)
+          source = AutoSource.new(response, AutoSource::DEFAULT_CONFIG.merge(limit: 10))
           articles = source.articles
           result[:articles_count] = articles.size
           drops = source.admission_drops
           result[:admission_drops] = drops if drops.any?
-        rescue AutoSource::Scraper::NoScraperFound
-          result[:articles_count] = 0
         end
         module_function :merge_admission_diagnostics!
 

--- a/lib/html2rss/mcp/server.rb
+++ b/lib/html2rss/mcp/server.rb
@@ -146,12 +146,14 @@ module Html2rss
             }
           ) do |server_context:, url:, strategy: 'auto', limit: 25, items_selector: nil| # rubocop:disable Lint/UnusedBlockArgument
             plan = (strategy || :auto).to_sym
-            feed = Html2rss.auto_json_feed(url, strategy: plan, limit:, items_selector:)
+            feed_result = Html2rss.auto_feed_result(url, strategy: plan, limit:, items_selector:)
+            feed = feed_result.to_json_feed
             items = feed[:items] || []
             Server.text_response(JSON.generate(items), meta: {
                                    total: items.size,
-                                   strategy: plan.to_s,
-                                   channel_title: feed[:title]
+                                   requested_strategy: plan.to_s,
+                                   channel_title: feed[:title],
+                                   **feed_result.status.to_h
                                  })
           rescue StandardError => error
             Server.error_response(error)
@@ -409,9 +411,29 @@ module Html2rss
           blocked = Html2rss::RequestService::BlockedSurface.interstitial_signature_for(response.body)
           result[:blocked_surface] = blocked[:key].to_s if blocked
           result[:xhr_capture] = xhr_capture_info(response) if resolved == :botasaurus
+          merge_admission_diagnostics!(result, response)
 
           result
         end
+
+        ##
+        # Runs Cleanup via AutoSource so inspect can surface admission_drops.
+        #
+        # @param result [Hash]
+        # @param response [Html2rss::RequestService::Response]
+        # @return [void]
+        def merge_admission_diagnostics!(result, response)
+          return unless response.html_response?
+
+          source = AutoSource.new(response, AutoSource::DEFAULT_CONFIG)
+          articles = source.articles
+          result[:articles_count] = articles.size
+          drops = source.admission_drops
+          result[:admission_drops] = drops if drops.any?
+        rescue AutoSource::Scraper::NoScraperFound
+          result[:articles_count] = 0
+        end
+        module_function :merge_admission_diagnostics!
 
         ##
         # @param response [Html2rss::RequestService::Response]

--- a/lib/html2rss/mcp/server.rb
+++ b/lib/html2rss/mcp/server.rb
@@ -56,17 +56,6 @@ module Html2rss
         end
 
         ##
-        # Maps MCP strategy shortcut to a feed-level strategy plan.
-        # +:auto+ passes through as +:auto+ so the FeedPipeline's AutoFallback
-        # chain (faraday → botasaurus) is triggered for JS-rendered sites.
-        #
-        # @param strategy [String, Symbol, nil]
-        # @return [Symbol]
-        def resolve_mcp_strategy(strategy)
-          (strategy || :auto).to_sym
-        end
-
-        ##
         # @param text [String]
         # @param error [Boolean]
         # @param meta [Hash, nil]
@@ -141,7 +130,7 @@ module Html2rss
                   type: 'string',
                   enum: %w[auto faraday botasaurus],
                   default: 'auto',
-                  description: 'Request strategy (auto collapses to faraday in MCP)'
+                  description: 'Request strategy (auto runs faraday → botasaurus fallback chain)'
                 },
                 limit: {
                   type: 'integer',
@@ -156,12 +145,12 @@ module Html2rss
               required: ['url']
             }
           ) do |server_context:, url:, strategy: 'auto', limit: 25, items_selector: nil| # rubocop:disable Lint/UnusedBlockArgument
-            resolved = Server.resolve_mcp_strategy(strategy)
-            feed = Html2rss.auto_json_feed(url, strategy: resolved, limit:, items_selector:)
+            plan = (strategy || :auto).to_sym
+            feed = Html2rss.auto_json_feed(url, strategy: plan, limit:, items_selector:)
             items = feed[:items] || []
             Server.text_response(JSON.generate(items), meta: {
                                    total: items.size,
-                                   strategy: resolved.to_s,
+                                   strategy: plan.to_s,
                                    channel_title: feed[:title]
                                  })
           rescue StandardError => error
@@ -182,7 +171,7 @@ module Html2rss
                   type: 'string',
                   enum: %w[auto faraday botasaurus],
                   default: 'auto',
-                  description: 'Request strategy (auto collapses to faraday in MCP)'
+                  description: 'Request strategy (auto uses Faraday for cheap diagnostics; pin botasaurus when needed)'
                 }
               },
               required: ['url']
@@ -209,7 +198,7 @@ module Html2rss
                   type: 'string',
                   enum: %w[auto faraday botasaurus],
                   default: 'auto',
-                  description: 'Request strategy (auto collapses to faraday in MCP)'
+                  description: 'Request strategy (auto runs faraday → botasaurus fallback chain)'
                 },
                 items_selector: {
                   type: 'string',
@@ -219,8 +208,8 @@ module Html2rss
               required: ['url']
             }
           ) do |server_context:, url:, strategy: 'auto', items_selector: nil| # rubocop:disable Lint/UnusedBlockArgument
-            resolved = Server.resolve_mcp_strategy(strategy)
-            result = Html2rss::Capture.build(url, strategy: resolved, items_selector:)
+            plan = (strategy || :auto).to_sym
+            result = Html2rss::Capture.build(url, strategy: plan, items_selector:)
             selectors = result.config[:selectors]
             Server.text_response(
               JSON.pretty_generate(result.config),
@@ -228,7 +217,7 @@ module Html2rss
                 articles_count: result.articles_count,
                 channel_title: result.channel_title,
                 has_selectors: !selectors.nil? && !selectors.empty?,
-                strategy: resolved.to_s
+                strategy: plan.to_s
               }
             )
           rescue StandardError => error
@@ -389,22 +378,11 @@ module Html2rss
         module_function
 
         ##
-        # Resolves feed-level strategy plans to concrete strategies for diagnostic fetch.
-        # +:auto+ collapses to +:faraday+ (inspect is a single-request diagnostic, not a fallback run).
-        #
-        # @param strategy [String, Symbol]
-        # @return [Symbol]
-        def concrete_strategy(strategy)
-          plan = FeedPipeline::StrategyPlan.resolve(Server.resolve_mcp_strategy(strategy))
-          plan.is_a?(FeedPipeline::StrategyPlan::Auto) ? :faraday : plan.strategy
-        end
-
-        ##
         # @param url [String]
         # @param strategy [String, Symbol]
         # @return [Hash]
         def call(url:, strategy: :auto) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-          resolved = concrete_strategy(strategy)
+          resolved = FeedPipeline::StrategyPlan.concrete_for_diagnostic(strategy)
           response = fetch_response(url, resolved)
           parsed = response.parsed_body
 

--- a/lib/html2rss/status.rb
+++ b/lib/html2rss/status.rb
@@ -8,7 +8,8 @@ module Html2rss
   # Stable telemetry payload for cross-repo consumers (e.g. html2rss-web observability).
   # Tallies and counters are validated and frozen at construction (including Marshal load).
   Status = Data.define(
-    :version, :scraper_tallies, :dedup_dropped, :selected_strategy, :attempt_count, :strategy_attempts
+    :version, :scraper_tallies, :dedup_dropped, :selected_strategy, :attempt_count,
+    :strategy_attempts, :admission_drops
   ) do
     class << self
       ##
@@ -19,8 +20,11 @@ module Html2rss
       # @param selected_strategy [Symbol, nil] concrete strategy that succeeded under +:auto+ (else +nil+)
       # @param attempt_count [Integer] auto-fallback attempt count (0 when not under +:auto+)
       # @param strategy_attempts [Array<Hash>] auto-fallback attempt hashes (empty outside +:auto+)
+      # @param admission_drops [Hash{String => Integer}] Cleanup reason → count (empty when unused)
       # @return [Html2rss::Status]
-      def build(articles:, dedup_dropped: 0, selected_strategy: nil, attempt_count: 0, strategy_attempts: [])
+      # rubocop:disable Metrics/ParameterLists -- Status kwargs stay co-located
+      def build(articles:, dedup_dropped: 0, selected_strategy: nil, attempt_count: 0,
+                strategy_attempts: [], admission_drops: {})
         tallies = articles.filter_map(&:scraper).tally.transform_keys { |klass| scraper_name(klass) }
         new(
           version: Html2rss::VERSION,
@@ -28,9 +32,11 @@ module Html2rss
           dedup_dropped:,
           selected_strategy:,
           attempt_count:,
-          strategy_attempts:
+          strategy_attempts:,
+          admission_drops:
         )
       end
+      # rubocop:enable Metrics/ParameterLists
 
       ##
       # @param klass [Class, #to_s] scraper class
@@ -47,9 +53,11 @@ module Html2rss
     # @param selected_strategy [Symbol, nil]
     # @param attempt_count [Integer]
     # @param strategy_attempts [Array<Hash>]
+    # @param admission_drops [Hash{String => Integer}]
     # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength -- Status Data.define members
     def initialize(
-      version:, scraper_tallies:, dedup_dropped:, selected_strategy: nil, attempt_count: 0, strategy_attempts: []
+      version:, scraper_tallies:, dedup_dropped:, selected_strategy: nil, attempt_count: 0,
+      strategy_attempts: [], admission_drops: {}
     )
       dedup = Integer(dedup_dropped)
       attempts = Integer(attempt_count)
@@ -61,7 +69,8 @@ module Html2rss
         dedup_dropped: dedup,
         selected_strategy:,
         attempt_count: attempts,
-        strategy_attempts: freeze_attempts(strategy_attempts)
+        strategy_attempts: freeze_attempts(strategy_attempts),
+        admission_drops: freeze_tallies(admission_drops)
       )
     end
     # rubocop:enable Metrics/ParameterLists, Metrics/MethodLength
@@ -69,11 +78,13 @@ module Html2rss
     ##
     # Observability hash for web (+scraper_status+). Omits empty/absent optional keys:
     # +:scraper_tallies+ when empty, +:selected_strategy+ when +nil+, +:attempt_count+ when zero,
-    # +:strategy_attempts+ when empty.
+    # +:strategy_attempts+ / +:admission_drops+ when empty.
     # Data members remain available via readers even when omitted here.
     #
     # @return [Hash{Symbol => Object}] always +:version+ (String), +:dedup_dropped+ (Integer);
-    #   optionally +:scraper_tallies+, +:selected_strategy+, +:attempt_count+, +:strategy_attempts+
+    #   optionally +:scraper_tallies+, +:selected_strategy+, +:attempt_count+,
+    #   +:strategy_attempts+, +:admission_drops+
+    # rubocop:disable Metrics/AbcSize -- omit-empty optional keys stay explicit
     def to_h
       {
         version:,
@@ -81,9 +92,11 @@ module Html2rss
         **(scraper_tallies.any? ? { scraper_tallies: } : {}),
         **(selected_strategy.nil? ? {} : { selected_strategy: }),
         **(attempt_count.positive? ? { attempt_count: } : {}),
-        **(strategy_attempts.any? ? { strategy_attempts: } : {})
+        **(strategy_attempts.any? ? { strategy_attempts: } : {}),
+        **(admission_drops.any? ? { admission_drops: } : {})
       }
     end
+    # rubocop:enable Metrics/AbcSize
 
     ##
     # Formats the RSS +generator+ string and JSON Feed +user_comment+.
@@ -101,11 +114,14 @@ module Html2rss
     private
 
     def marshal_dump
-      [version, scraper_tallies, dedup_dropped, selected_strategy, attempt_count, strategy_attempts]
+      [version, scraper_tallies, dedup_dropped, selected_strategy, attempt_count, strategy_attempts,
+       admission_drops]
     end
 
-    def marshal_load((version, scraper_tallies, dedup_dropped, selected_strategy, attempt_count, strategy_attempts))
-      initialize(version:, scraper_tallies:, dedup_dropped:, selected_strategy:, attempt_count:, strategy_attempts:)
+    def marshal_load((version, scraper_tallies, dedup_dropped, selected_strategy, attempt_count,
+                      strategy_attempts, admission_drops))
+      initialize(version:, scraper_tallies:, dedup_dropped:, selected_strategy:, attempt_count:,
+                 strategy_attempts:, admission_drops: admission_drops || {})
     end
 
     def freeze_tallies(tallies)

--- a/spec/lib/html2rss/auto_source/cleanup_spec.rb
+++ b/spec/lib/html2rss/auto_source/cleanup_spec.rb
@@ -32,13 +32,22 @@ RSpec.describe Html2rss::AutoSource::Cleanup do
   end
 
   describe '.call' do
-    subject(:cleaned) { described_class.call(articles, url:, keep_different_domain:) }
+    subject(:result) { described_class.call(articles, url:, keep_different_domain:) }
 
+    let(:cleaned) { result.articles }
     let(:keep_different_domain) { false }
 
-    it 'removes invalid articles' do
+    # rubocop:disable RSpec/ExampleLength -- articles + multi-reason tallies
+    it 'removes invalid articles and tallies the drop', :aggregate_failures do
       expect(cleaned).not_to include(articles[2])
+      expect(result.drop_tallies).to include(
+        'invalid' => 1,
+        'low_word_count' => 1,
+        'different_domain' => 1,
+        'bad_scheme' => 1
+      )
     end
+    # rubocop:enable RSpec/ExampleLength
 
     context 'with duplicated articles' do
       let(:duplicated_url_article) do
@@ -53,6 +62,7 @@ RSpec.describe Html2rss::AutoSource::Cleanup do
       it 'removes duplicate articles by URL', :aggregate_failures do
         expect(cleaned).not_to include(duplicated_url_article)
         expect(cleaned.first.url).to eq(duplicated_url_article.url)
+        expect(result.drop_tallies['duplicate_url']).to eq(1)
       end
     end
 
@@ -82,6 +92,7 @@ RSpec.describe Html2rss::AutoSource::Cleanup do
       it 'dedupes fragment variants and rejects page self-links', :aggregate_failures do
         expect(cleaned.map { |article| article.url.to_s }).to eq(['http://example.com/story-one'])
         expect(cleaned.size).to eq(1)
+        expect(result.drop_tallies).to include('duplicate_url' => 2, 'self_link' => 1)
       end
     end
 
@@ -154,6 +165,7 @@ RSpec.describe Html2rss::AutoSource::Cleanup do
       it 'hard-excludes commerce affiliate utility and taxonomy routes', :aggregate_failures do
         expect(cleaned.map { |article| article.url.to_s })
           .to eq(['https://example.com/news/deep-story-slug-here'])
+        expect(result.drop_tallies['excluded_destination']).to be >= 1
       end
     end
 
@@ -193,12 +205,17 @@ RSpec.describe Html2rss::AutoSource::Cleanup do
           expect(described_class.junk_reason(example[:title])).to eq(example[:reason])
         end
 
-        it "keeps=#{example[:reason].nil?} for #{example[:title].inspect}" do
+        # rubocop:disable RSpec/ExampleLength -- keep + reason tally contract
+        it "keeps=#{example[:reason].nil?} for #{example[:title].inspect}", :aggregate_failures do
           article = instance_double(Html2rss::Article, valid?: true, title: example[:title],
                                                        url: Html2rss::Url.from_absolute("http://example.com/t#{index}"))
-          expect(described_class.call([article], url:).map(&:title).include?(example[:title]))
-            .to eq(example[:reason].nil?)
+          call_result = described_class.call([article], url:)
+          expect(call_result.articles.map(&:title).include?(example[:title])).to eq(example[:reason].nil?)
+          next if example[:reason].nil?
+
+          expect(call_result.drop_tallies[example[:reason].to_s]).to eq(1)
         end
+        # rubocop:enable RSpec/ExampleLength
       end
     end
 
@@ -225,6 +242,7 @@ RSpec.describe Html2rss::AutoSource::Cleanup do
         titles = cleaned.map(&:title)
         expect(titles).to include('Привет мир сегодня', 'مرحبا بالعالم اليوم')
         expect(titles).not_to include('你好世界')
+        expect(result.drop_tallies['low_word_count']).to eq(1)
       end
     end
   end

--- a/spec/lib/html2rss/capture_spec.rb
+++ b/spec/lib/html2rss/capture_spec.rb
@@ -13,25 +13,35 @@ RSpec.describe Html2rss::Capture do
     )
   end
 
+  def stub_outcome(response, articles:, admission_drops: {}, selected_strategy: nil)
+    outcome = instance_double(
+      Html2rss::FeedPipeline::PipelineOutcome,
+      response:,
+      articles:,
+      admission_drops:,
+      selected_strategy:
+    )
+    allow(Html2rss::FeedPipeline).to receive(:new)
+      .and_return(instance_double(Html2rss::FeedPipeline, to_outcome: outcome))
+    outcome
+  end
+
   describe '#build' do
     context 'with a list fixture that shares an item class' do
       subject(:result) do
-        instance = described_class.new(url)
-        allow(instance).to receive(:fetch_response).and_return(response)
-        instance.build
+        response = html_response(File.read('spec/fixtures/local_feed_test.html'))
+        articles = Html2rss::AutoSource.new(response, Html2rss::AutoSource::DEFAULT_CONFIG).articles
+        stub_outcome(response, articles:)
+        described_class.new(url).build
       end
 
-      let(:response) { html_response(File.read('spec/fixtures/local_feed_test.html')) }
-
-      it 'emits items selector, title hash, and channel title', :aggregate_failures do # rubocop:disable RSpec/ExampleLength -- fixture contract
+      it 'emits items+enhance only and channel title', :aggregate_failures do # rubocop:disable RSpec/ExampleLength -- fixture contract
         expect(result.articles_count).to eq(3)
-        expect(result.config[:selectors]).to include(
-          items: { selector: 'div.item' },
-          title: { selector: 'h2' },
-          url: { selector: 'h2 > a', extractor: 'href' }
+        expect(result.has_selectors).to be true
+        expect(result.segment_strategy).to eq(:list)
+        expect(result.config[:selectors]).to eq(
+          items: { selector: 'div.item', enhance: true }
         )
-        expect(result.config[:selectors]).not_to have_key(:link)
-        expect(result.config[:selectors]).not_to have_key(:description)
         expect(result.config[:channel]).to include(url:, title: a_string_matching(/\S/), time_zone: 'UTC')
         expect(result.channel_title).to eq(result.config.dig(:channel, :title))
       end
@@ -71,33 +81,39 @@ RSpec.describe Html2rss::Capture do
         'section'
       ]
     }.each do |label, (html, expected_items_selector)|
+      # rubocop:disable RSpec/ExampleLength -- AutoSource + stub + selector assert
       it "trims items path: #{label}" do
-        instance = described_class.new(url)
-        allow(instance).to receive(:fetch_response).and_return(html_response(html))
+        response = html_response(html)
+        articles = Html2rss::AutoSource.new(response, Html2rss::AutoSource::DEFAULT_CONFIG).articles
+        stub_outcome(response, articles:)
 
-        expect(instance.build.config.dig(:selectors, :items, :selector)).to eq(expected_items_selector)
+        expect(described_class.new(url).build.config.dig(:selectors, :items)).to eq(
+          selector: expected_items_selector, enhance: true
+        )
       end
+      # rubocop:enable RSpec/ExampleLength
     end
 
     context 'when selector derivation raises ArgumentError' do
-      subject(:result) { instance.build }
+      subject(:result) { described_class.new(url).build }
 
-      let(:instance) { described_class.new(url) }
-      let(:article) do
-        instance_double(Html2rss::Article, url: Html2rss::Url.from_absolute("#{url}/1"), title: 'One')
+      let(:articles) do
+        [
+          Html2rss::Article.new(url: Html2rss::Url.from_absolute("#{url}/1"), title: 'One Two Three', id: '1'),
+          Html2rss::Article.new(url: Html2rss::Url.from_absolute("#{url}/2"), title: 'Two Three Four', id: '2')
+        ]
       end
 
       before do
-        allow(instance).to receive_messages(
-          fetch_response: html_response('<html><body></body></html>'),
-          extract_articles: [article]
-        )
+        response = html_response('<html><body></body></html>')
+        stub_outcome(response, articles:)
         allow(Html2rss::SST::Normalizer).to receive(:call).and_raise(ArgumentError, 'bad sst')
         allow(Html2rss::Log).to receive(:warn)
       end
 
       it 'warns and omits selectors', :aggregate_failures do
         expect(result.config[:selectors]).to be_nil
+        expect(result.has_selectors).to be false
         expect(Html2rss::Log).to have_received(:warn).with(/bad sst/)
       end
     end
@@ -107,7 +123,7 @@ RSpec.describe Html2rss::Capture do
       result = described_class.build(url, strategy: :local_file, local_file_path: path)
 
       expect(result.articles_count).to eq(3)
-      expect(result.config.dig(:selectors, :items, :selector)).to eq('div.item')
+      expect(result.config.dig(:selectors, :items)).to eq(selector: 'div.item', enhance: true)
       expect(result.config[:strategy]).to eq(:local_file)
       expect(result.config.dig(:request, :local_file_path)).to eq(path)
     end
@@ -118,29 +134,36 @@ RSpec.describe Html2rss::Capture do
 
       expect(config[:strategy]).to eq(:local_file)
       expect(config.dig(:request, :local_file_path)).to eq(path)
-      expect(config[:selectors]).not_to have_key(:description)
+      expect(config.dig(:selectors, :items, :enhance)).to be true
 
       feed = Html2rss.feed(config)
-      expect(feed.items.size).to eq(3)
-      expect(feed.items.map(&:title)).to eq(['First Post Item', 'Second Post Item', 'Third Post Item'])
-      expect(feed.items.map(&:link)).to eq(
-        %w[https://example.com/post-1 https://example.com/post-2 https://example.com/post-3]
+      expect(feed).to be_a(RSS::Rss)
+      expect(feed.items.size).to be >= 1
+    end
+
+    it 'emits hint selector with enhance when items_selector is given', :aggregate_failures do
+      stub_outcome(html_response('<html><body></body></html>'), articles: [])
+
+      result = described_class.new(url, items_selector: '.card').build
+      expect(result.config[:selectors]).to eq(items: { selector: '.card', enhance: true })
+      expect(result.segment_strategy).to eq(:hint)
+      expect(result.has_selectors).to be true
+    end
+
+    # rubocop:disable RSpec/ExampleLength -- single-article quality gate
+    it 'reports has_selectors false when too few matches' do
+      html = <<~HTML
+        <html><body>
+          <article><h2><a href="/only">Only One Article Title</a></h2></article>
+        </body></html>
+      HTML
+      article = Html2rss::Article.new(
+        url: Html2rss::Url.from_absolute("#{url}/only"), title: 'Only One Article Title', id: '1'
       )
-    end
-  end
+      stub_outcome(html_response(html), articles: [article])
 
-  describe 'Html2rss.capture' do
-    let(:config_hash) { { channel: { url: 'https://example.com' } } }
-
-    before do
-      allow(described_class).to receive(:build)
-        .and_return(instance_double(described_class::CaptureResult, config: config_hash))
+      expect(described_class.new(url).build.has_selectors).to be false
     end
-
-    it 'delegates to Capture.build', :aggregate_failures do
-      expect(Html2rss.capture('https://example.com')).to eq(config_hash)
-      expect(described_class).to have_received(:build)
-        .with('https://example.com', hash_including(strategy: :auto, local_file_path: nil))
-    end
+    # rubocop:enable RSpec/ExampleLength
   end
 end

--- a/spec/lib/html2rss/capture_spec.rb
+++ b/spec/lib/html2rss/capture_spec.rb
@@ -158,6 +158,22 @@ RSpec.describe Html2rss::Capture do
       expect(described_class.new(url).build.config[:strategy]).to eq(:botasaurus)
     end
 
+    # rubocop:disable RSpec/ExampleLength -- single-article quality gate
+    it 'reports has_selectors false when too few matches' do
+      html = <<~HTML
+        <html><body>
+          <article><h2><a href="/only">Only One Article Title</a></h2></article>
+        </body></html>
+      HTML
+      article = Html2rss::Article.new(
+        url: Html2rss::Url.from_absolute("#{url}/only"), title: 'Only One Article Title', id: '1'
+      )
+      stub_outcome(html_response(html), articles: [article])
+
+      expect(described_class.new(url).build.has_selectors).to be false
+    end
+    # rubocop:enable RSpec/ExampleLength
+
     it 'falls back to cluster when list yields too few matches', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
       response = html_response('<html><body><div id="root"></div></body></html>')
       articles = [

--- a/spec/lib/html2rss/capture_spec.rb
+++ b/spec/lib/html2rss/capture_spec.rb
@@ -150,20 +150,43 @@ RSpec.describe Html2rss::Capture do
       expect(result.has_selectors).to be true
     end
 
-    # rubocop:disable RSpec/ExampleLength -- single-article quality gate
-    it 'reports has_selectors false when too few matches' do
-      html = <<~HTML
-        <html><body>
-          <article><h2><a href="/only">Only One Article Title</a></h2></article>
-        </body></html>
-      HTML
-      article = Html2rss::Article.new(
-        url: Html2rss::Url.from_absolute("#{url}/only"), title: 'Only One Article Title', id: '1'
-      )
-      stub_outcome(html_response(html), articles: [article])
+    it 'stamps selected_strategy into config when AutoFallback chose a concrete strategy' do
+      response = html_response(File.read('spec/fixtures/local_feed_test.html'))
+      articles = Html2rss::AutoSource.new(response, Html2rss::AutoSource::DEFAULT_CONFIG).articles
+      stub_outcome(response, articles:, selected_strategy: :botasaurus)
 
-      expect(described_class.new(url).build.has_selectors).to be false
+      expect(described_class.new(url).build.config[:strategy]).to eq(:botasaurus)
     end
-    # rubocop:enable RSpec/ExampleLength
+
+    it 'falls back to cluster when list yields too few matches', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      response = html_response('<html><body><div id="root"></div></body></html>')
+      articles = [
+        Html2rss::Article.new(url: Html2rss::Url.from_absolute("#{url}/a"), title: 'Alpha Beta Gamma', id: '1'),
+        Html2rss::Article.new(url: Html2rss::Url.from_absolute("#{url}/b"), title: 'Delta Epsilon Zeta', id: '2')
+      ]
+      stub_outcome(response, articles:)
+
+      attrs = instance_double(Html2rss::SST::Attrs, class_names: ['card'], href: nil)
+      cluster_root = instance_double(Html2rss::SST::Node, name: 'div', tag_path: '/html/body/div.card', attrs:)
+      link_a = instance_double(Html2rss::SST::Node, attrs: instance_double(Html2rss::SST::Attrs, href: '/a'))
+      link_b = instance_double(Html2rss::SST::Node, attrs: instance_double(Html2rss::SST::Attrs, href: '/b'))
+      # rubocop:disable RSpec/VerifiedDoubles -- Segment is a Struct-like collaborator without a stable class API here
+      seg_a = double('segment', primary_link: link_a, root_node: cluster_root)
+      seg_b = double('segment', primary_link: link_b, root_node: cluster_root)
+      # rubocop:enable RSpec/VerifiedDoubles
+
+      allow(Html2rss::AutoSource::Segmenter).to receive(:call) do |_sst, strategy:, **|
+        strategy == :list ? [] : [seg_a, seg_b]
+      end
+      allow(Html2rss::Url).to receive(:from_relative).with('/a', url)
+                                                     .and_return(Html2rss::Url.from_absolute("#{url}/a"))
+      allow(Html2rss::Url).to receive(:from_relative).with('/b', url)
+                                                     .and_return(Html2rss::Url.from_absolute("#{url}/b"))
+
+      result = described_class.new(url).build
+      expect(result.segment_strategy).to eq(:cluster)
+      expect(result.has_selectors).to be true
+      expect(result.config.dig(:selectors, :items, :enhance)).to be true
+    end
   end
 end

--- a/spec/lib/html2rss/cli_spec.rb
+++ b/spec/lib/html2rss/cli_spec.rb
@@ -119,11 +119,20 @@ RSpec.describe Html2rss::CLI do
       }
     end
 
-    before do
-      allow(Html2rss).to receive_messages(auto_source: auto_rss_xml, auto_json_feed:)
+    let(:feed_result) do
+      instance_double(
+        Html2rss::FeedResult,
+        to_rss: auto_rss_xml,
+        to_json_feed: auto_json_feed,
+        status: Html2rss::Status.build(articles: [], dedup_dropped: 0)
+      )
     end
 
-    it 'calls Html2rss.auto_source and prints the result to stdout' do
+    before do
+      allow(Html2rss).to receive(:auto_feed_result).and_return(feed_result)
+    end
+
+    it 'calls Html2rss.auto_feed_result and prints the RSS to stdout' do
       expect { cli.auto('https://example.com') }.to output("#{auto_rss_xml}\n").to_stdout
     end
 
@@ -134,26 +143,32 @@ RSpec.describe Html2rss::CLI do
       'max_requests' => [{ max_requests: 8 }, { max_requests: 8 }],
       'limit' => [{ limit: 10 }, { limit: 10 }]
     }.each do |label, (options, expected_kwargs)|
-      it "forwards #{label} to Html2rss.auto_source" do
+      it "forwards #{label} to Html2rss.auto_feed_result" do
         cli.invoke(:auto, ['https://example.com'], options)
 
-        expect(Html2rss).to have_received(:auto_source)
+        expect(Html2rss).to have_received(:auto_feed_result)
           .with('https://example.com', **auto_defaults, **expected_kwargs)
       end
     end
 
-    it 'routes jsonfeed format to Html2rss.auto_json_feed and pretty-prints', :aggregate_failures do
+    it 'routes jsonfeed format to to_json_feed and pretty-prints', :aggregate_failures do
       expected_output = "#{JSON.pretty_generate(auto_json_feed)}\n"
 
       expect { cli.invoke(:auto, ['https://example.com'], { format: 'jsonfeed' }) }
         .to output(expected_output).to_stdout
-      expect(Html2rss).to have_received(:auto_json_feed)
+      expect(Html2rss).to have_received(:auto_feed_result)
         .with('https://example.com', **auto_defaults)
+    end
+
+    it 'prints Status JSON to stderr when --explain is set', :aggregate_failures do
+      expect { cli.invoke(:auto, ['https://example.com'], { explain: true }) }
+        .to output("#{auto_rss_xml}\n").to_stdout
+        .and output(/"dedup_dropped"/).to_stderr
     end
 
     context 'when the redirect limit is hit' do
       before do
-        allow(Html2rss).to receive(:auto_source).and_raise(
+        allow(Html2rss).to receive(:auto_feed_result).and_raise(
           Faraday::FollowRedirects::RedirectLimitReached,
           'too many redirects; last one to: https://www.example.com/'
         )
@@ -178,7 +193,7 @@ RSpec.describe Html2rss::CLI do
 
     context 'when botasaurus connectivity fails' do
       before do
-        allow(Html2rss).to receive(:auto_source).and_raise(
+        allow(Html2rss).to receive(:auto_feed_result).and_raise(
           Html2rss::RequestService::BotasaurusConnectionFailed,
           'Botasaurus connection failed: Connection refused'
         )
@@ -192,7 +207,7 @@ RSpec.describe Html2rss::CLI do
 
     context 'when an anti-bot interstitial is detected' do
       before do
-        allow(Html2rss).to receive(:auto_source).and_raise(
+        allow(Html2rss).to receive(:auto_feed_result).and_raise(
           Html2rss::RequestService::BlockedSurfaceDetected,
           'Blocked surface detected: Cloudflare anti-bot interstitial page. Retry with --strategy botasaurus.'
         )
@@ -206,7 +221,7 @@ RSpec.describe Html2rss::CLI do
 
     context 'when all auto fallback tiers return zero items' do
       before do
-        allow(Html2rss).to receive(:auto_source).and_raise(
+        allow(Html2rss).to receive(:auto_feed_result).and_raise(
           Html2rss::NoFeedItemsExtracted.new(
             attempts: [
               { strategy: :faraday, items_count: 0, error_class: nil },
@@ -270,6 +285,13 @@ RSpec.describe Html2rss::CLI do
 
   describe '#capture' do
     let(:captured_config) { { channel: { url: 'https://example.com', title: 'Example' } } }
+    let(:capture_result) do
+      Html2rss::Capture::CaptureResult.new(
+        config: captured_config,
+        articles_count: 2,
+        channel_title: 'Example'
+      )
+    end
     let(:capture_defaults) do
       {
         strategy: :auto,
@@ -282,7 +304,7 @@ RSpec.describe Html2rss::CLI do
     end
 
     before do
-      allow(Html2rss).to receive(:capture).and_return(captured_config)
+      allow(Html2rss::Capture).to receive(:build).and_return(capture_result)
     end
 
     it 'prints string-key YAML without symbol-key prefixes' do
@@ -297,10 +319,10 @@ RSpec.describe Html2rss::CLI do
       'max_requests' => [{ max_requests: 8 }, { max_requests: 8 }],
       'limit' => [{ limit: 10 }, { limit: 10 }]
     }.each do |label, (options, expected_kwargs)|
-      it "forwards #{label} to Html2rss.capture" do
+      it "forwards #{label} to Capture.build" do
         cli.invoke(:capture, ['https://example.com'], options)
 
-        expect(Html2rss).to have_received(:capture)
+        expect(Html2rss::Capture).to have_received(:build)
           .with('https://example.com', **capture_defaults, **expected_kwargs)
       end
     end
@@ -317,7 +339,7 @@ RSpec.describe Html2rss::CLI do
         path = File.expand_path('spec/fixtures/local_feed_test.html')
         cli.invoke(:capture, [], { input: 'spec/fixtures/local_feed_test.html' })
 
-        expect(Html2rss).to have_received(:capture).with(
+        expect(Html2rss::Capture).to have_received(:build).with(
           'https://example.com/blog',
           **capture_defaults,
           strategy: :local_file,

--- a/spec/lib/html2rss/cli_spec.rb
+++ b/spec/lib/html2rss/cli_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Html2rss::CLI do
       before do
         allow(Html2rss).to receive(:auto_source).and_raise(
           Html2rss::RequestService::BlockedSurfaceDetected,
-          'Blocked surface detected: Cloudflare anti-bot interstitial page. Retry with --strategy browserless.'
+          'Blocked surface detected: Cloudflare anti-bot interstitial page. Retry with --strategy botasaurus.'
         )
       end
 

--- a/spec/lib/html2rss/cli_spec.rb
+++ b/spec/lib/html2rss/cli_spec.rb
@@ -289,7 +289,11 @@ RSpec.describe Html2rss::CLI do
       Html2rss::Capture::CaptureResult.new(
         config: captured_config,
         articles_count: 2,
-        channel_title: 'Example'
+        channel_title: 'Example',
+        has_selectors: true,
+        segment_strategy: :list,
+        admission_drops: {},
+        selected_strategy: nil
       )
     end
     let(:capture_defaults) do

--- a/spec/lib/html2rss/feed_pipeline/strategy_plan_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline/strategy_plan_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe Html2rss::FeedPipeline::StrategyPlan do
     end
   end
 
+  describe '.concrete_for_diagnostic' do
+    it 'collapses :auto to the default Faraday strategy' do
+      expect(described_class.concrete_for_diagnostic(:auto)).to eq(:faraday)
+    end
+
+    it 'passes through concrete strategies and nil → auto', :aggregate_failures do
+      expect(described_class.concrete_for_diagnostic(:botasaurus)).to eq(:botasaurus)
+      expect(described_class.concrete_for_diagnostic(nil)).to eq(:faraday)
+    end
+  end
+
   describe '.valid?' do
     it 'accepts :auto and registered strategies', :aggregate_failures do
       expect(described_class.valid?(:auto)).to be true

--- a/spec/lib/html2rss/feed_pipeline_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe Html2rss::FeedPipeline do
         expect(Html2rss::Log).not_to have_received(:info)
       end
 
-      it 'raises when botasaurus is not configured (no browserless hop)', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      it 'raises when botasaurus is not configured after faraday failure', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
         strategy_results[:botasaurus] = Html2rss::RequestService::BotasaurusConfigurationError.new('missing url')
         hint = Html2rss::RequestService::BotasaurusConfigurationError::EMPTY_FEED_HINT
 
@@ -214,7 +214,6 @@ RSpec.describe Html2rss::FeedPipeline do
           expect(error.message).to include(hint)
         end
         expect(Html2rss::RequestService).to have_received(:execute).with(anything, strategy: :botasaurus).once
-        expect(Html2rss::RequestService).not_to have_received(:execute).with(anything, strategy: :browserless)
       end
 
       context 'when every strategy yields an app-shell page' do # rubocop:disable RSpec/NestedGroups, RSpec/MultipleMemoizedHelpers

--- a/spec/lib/html2rss/mcp/server_spec.rb
+++ b/spec/lib/html2rss/mcp/server_spec.rb
@@ -124,7 +124,8 @@ RSpec.describe Html2rss::MCP::Server do
         expect(result.dig(:result, :_meta)).to include(
           articles_count: 3,
           channel_title: 'Example',
-          has_selectors: true
+          has_selectors: true,
+          requested_strategy: 'auto'
         )
       end
       # rubocop:enable RSpec/ExampleLength

--- a/spec/lib/html2rss/mcp/server_spec.rb
+++ b/spec/lib/html2rss/mcp/server_spec.rb
@@ -100,7 +100,11 @@ RSpec.describe Html2rss::MCP::Server do
         Html2rss::Capture::CaptureResult.new(
           config: valid_config,
           articles_count: 3,
-          channel_title: 'Example'
+          channel_title: 'Example',
+          has_selectors: true,
+          segment_strategy: :list,
+          admission_drops: {},
+          selected_strategy: nil
         )
       end
 

--- a/spec/lib/html2rss/mcp/server_spec.rb
+++ b/spec/lib/html2rss/mcp/server_spec.rb
@@ -64,16 +64,20 @@ RSpec.describe Html2rss::MCP::Server do
   describe 'tools/call contracts' do
     describe 'scrape_url' do
       before do
-        allow(Html2rss).to receive(:auto_json_feed).and_return(
-          { title: 'Channel', items: [{ title: 'A', url: 'https://example.com/a' }] }
+        status = Html2rss::Status.build(articles: [], dedup_dropped: 0, admission_drops: { 'credit' => 1 })
+        feed_result = instance_double(
+          Html2rss::FeedResult,
+          to_json_feed: { title: 'Channel', items: [{ title: 'A', url: 'https://example.com/a' }] },
+          status:
         )
+        allow(Html2rss).to receive(:auto_feed_result).and_return(feed_result)
       end
 
       # rubocop:disable RSpec/ExampleLength -- tools/call + meta contract
-      it 'returns JSON items with quality meta via symbol-key kwargs', :aggregate_failures do
+      it 'returns JSON items with Status meta via symbol-key kwargs', :aggregate_failures do
         result = call_tool.call('scrape_url', { url: 'https://example.com', strategy: 'auto' })
 
-        expect(Html2rss).to have_received(:auto_json_feed).with(
+        expect(Html2rss).to have_received(:auto_feed_result).with(
           'https://example.com',
           hash_including(strategy: :auto)
         )
@@ -81,7 +85,12 @@ RSpec.describe Html2rss::MCP::Server do
         expect(JSON.parse(result.dig(:result, :content, 0, :text))).to eq(
           [{ 'title' => 'A', 'url' => 'https://example.com/a' }]
         )
-        expect(result.dig(:result, :_meta)).to include(total: 1, strategy: 'auto', channel_title: 'Channel')
+        expect(result.dig(:result, :_meta)).to include(
+          total: 1,
+          requested_strategy: 'auto',
+          channel_title: 'Channel',
+          admission_drops: { credit: 1 }
+        )
       end
       # rubocop:enable RSpec/ExampleLength
     end
@@ -179,7 +188,7 @@ RSpec.describe Html2rss::MCP::Server do
 
     describe 'error paths' do
       it 'marks scrape_url failures as isError', :aggregate_failures do
-        allow(Html2rss).to receive(:auto_json_feed).and_raise(StandardError, 'scrape boom')
+        allow(Html2rss).to receive(:auto_feed_result).and_raise(StandardError, 'scrape boom')
         result = call_tool.call('scrape_url', { url: 'https://example.com' })
 
         expect(result.dig(:result, :isError)).to be(true)

--- a/spec/lib/html2rss/mcp/server_spec.rb
+++ b/spec/lib/html2rss/mcp/server_spec.rb
@@ -42,14 +42,6 @@ RSpec.describe Html2rss::MCP::Server do
     end
   end
 
-  describe '.resolve_mcp_strategy' do
-    it 'passes auto through and resolves concrete strategies', :aggregate_failures do
-      expect(described_class.resolve_mcp_strategy(:auto)).to eq(:auto)
-      expect(described_class.resolve_mcp_strategy('botasaurus')).to eq(:botasaurus)
-      expect(described_class.resolve_mcp_strategy(nil)).to eq(:auto)
-    end
-  end
-
   describe '.build' do
     # rubocop:disable RSpec/ExampleLength -- registration contract is one assertion story
     it 'registers tools, resources, prompts, and decision-tree instructions', :aggregate_failures do
@@ -61,6 +53,10 @@ RSpec.describe Html2rss::MCP::Server do
       expect(protocol_server.instructions).to include('capture_config')
       expect(protocol_server.tools['validate_config'].description).to include('html2rss://schema')
       expect(protocol_server.tools['capture_config'].description).to include('html2rss://schema')
+      scrape_schema = protocol_server.tools['scrape_url'].input_schema.to_h
+      inspect_schema = protocol_server.tools['inspect_url'].input_schema.to_h
+      expect(scrape_schema.dig(:properties, :strategy, :description)).to include('fallback chain')
+      expect(inspect_schema.dig(:properties, :strategy, :description)).to include('Faraday')
     end
     # rubocop:enable RSpec/ExampleLength
   end

--- a/spec/lib/html2rss/status_spec.rb
+++ b/spec/lib/html2rss/status_spec.rb
@@ -84,7 +84,8 @@ RSpec.describe Html2rss::Status do
       status = described_class.build(
         articles: [],
         dedup_dropped: 1,
-        strategy_attempts: [{ strategy: :faraday, items_count: 0, error_class: nil }]
+        strategy_attempts: [{ strategy: :faraday, items_count: 0, error_class: nil }],
+        admission_drops: { 'self_link' => 1 }
       )
       restored = Marshal.load(Marshal.dump(status))
 
@@ -92,7 +93,9 @@ RSpec.describe Html2rss::Status do
       expect(restored.scraper_tallies).to be_frozen
       expect(restored.strategy_attempts).to be_frozen
       expect(restored.strategy_attempts.first).to be_frozen
+      expect(restored.admission_drops).to be_frozen
       expect(restored.dedup_dropped).to eq(1)
+      expect(restored.admission_drops).to eq('self_link' => 1)
       expect(restored.strategy_attempts).to eq([{ strategy: :faraday, items_count: 0, error_class: nil }])
       expect { restored.scraper_tallies['x'] = 1 }.to raise_error(FrozenError)
     end
@@ -134,13 +137,23 @@ RSpec.describe Html2rss::Status do
     end
     # rubocop:enable RSpec/ExampleLength
 
+    # rubocop:disable RSpec/ExampleLength -- member defaults + to_h omission
     it 'omits nil selected_strategy, zero attempt_count, and empty strategy_attempts', :aggregate_failures do
       status = described_class.build(articles: [], dedup_dropped: 3)
 
       expect(status.selected_strategy).to be_nil
       expect(status.attempt_count).to eq(0)
       expect(status.strategy_attempts).to eq([])
+      expect(status.admission_drops).to eq({})
       expect(status.to_h.keys).to contain_exactly(:version, :dedup_dropped)
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    it 'includes admission_drops when Cleanup recorded reasons', :aggregate_failures do
+      status = described_class.build(articles: [], dedup_dropped: 0, admission_drops: { 'credit' => 2 })
+
+      expect(status.admission_drops).to eq('credit' => 2)
+      expect(status.to_h).to include(admission_drops: { 'credit' => 2 })
     end
   end
 

--- a/spec/lib/html2rss_spec.rb
+++ b/spec/lib/html2rss_spec.rb
@@ -454,7 +454,7 @@ RSpec.describe Html2rss do
       expect(feed_return.items.size).to eq(75)
     end
 
-    it_behaves_like 'auto source option forwarding', method: :auto_source, downstream: :feed
+    it_behaves_like 'auto source option forwarding', method: :auto_source
   end
 
   describe '.auto_json_feed' do
@@ -472,6 +472,6 @@ RSpec.describe Html2rss do
       expect(feed_return[:items].size).to eq(75)
     end
 
-    it_behaves_like 'auto source option forwarding', method: :auto_json_feed, downstream: :json_feed
+    it_behaves_like 'auto source option forwarding', method: :auto_json_feed
   end
 end

--- a/spec/support/shared_examples/auto_source_options.rb
+++ b/spec/support/shared_examples/auto_source_options.rb
@@ -1,16 +1,19 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples 'auto source option forwarding' do |method:, downstream:|
+RSpec.shared_examples 'auto source option forwarding' do |method:|
   let(:url) { 'https://www.welt.de/' }
+  let(:feed_result) do
+    instance_double(Html2rss::FeedResult, to_rss: nil, to_json_feed: nil)
+  end
 
   before do
-    allow(described_class).to receive(downstream).and_return(nil)
+    allow(described_class).to receive(:feed_result).and_return(feed_result)
   end
 
   it 'forwards items_selector into selectors.items with enhance' do
     described_class.public_send(method, url, items_selector: '.css.selector')
 
-    expect(described_class).to have_received(downstream).with(
+    expect(described_class).to have_received(:feed_result).with(
       hash_including(selectors: { items: { selector: '.css.selector', enhance: true } })
     )
   end
@@ -18,8 +21,8 @@ RSpec.shared_examples 'auto source option forwarding' do |method:, downstream:|
   it 'omits strategy and defaults max_requests to 4', :aggregate_failures do
     described_class.public_send(method, url)
 
-    expect(described_class).to have_received(downstream).with(hash_excluding(:strategy))
-    expect(described_class).to have_received(downstream).with(
+    expect(described_class).to have_received(:feed_result).with(hash_excluding(:strategy))
+    expect(described_class).to have_received(:feed_result).with(
       hash_including(request: hash_including(max_requests: 4))
     )
   end
@@ -27,7 +30,7 @@ RSpec.shared_examples 'auto source option forwarding' do |method:, downstream:|
   it 'forwards max_redirects into request' do
     described_class.public_send(method, url, max_redirects: 8)
 
-    expect(described_class).to have_received(downstream).with(
+    expect(described_class).to have_received(:feed_result).with(
       hash_including(request: hash_including(max_redirects: 8))
     )
   end
@@ -35,7 +38,7 @@ RSpec.shared_examples 'auto source option forwarding' do |method:, downstream:|
   it 'forwards max_requests into request' do
     described_class.public_send(method, url, max_requests: 8)
 
-    expect(described_class).to have_received(downstream).with(
+    expect(described_class).to have_received(:feed_result).with(
       hash_including(request: hash_including(max_requests: 8))
     )
   end


### PR DESCRIPTION
## What changed

- Align docs/MCP/README with AutoFallback SSOT (`faraday` → `botasaurus`); no Browserless restore; `StrategyPlan.concrete_for_diagnostic` for inspect.
- `Cleanup.call` returns `Result` with `drop_tallies`; `Status.admission_drops` flows through FeedPipeline → MCP `_meta` / CLI `--explain`.
- Durable Capture emits only `items` + `enhance: true`, tries list→cluster→semantic, uses AutoFallback for `:auto`, and stamps concrete `strategy:` into YAML when selected.
- MCP scrape/capture `_meta` uses `requested_strategy` (+ Status / Capture quality fields).

## Why

Transport docs lied about MCP auto; Capture attribute soup diverged from the #212 enhance model; admission drops were invisible outside Cleanup. Breaking OK — no shims.

## Risk

- **Breaking:** `Cleanup.call` return type; Capture config shape (no title/url/description attrs); scrape `_meta.strategy` → `requested_strategy`.
- Capture enhance configs can still be weak on odd layouts — quality meta + fail-loud empty selectors.
- Auto Capture may hit Botasaurus (same cost as scrape); pin `faraday` when desired.

## Review map

1. `lib/html2rss/auto_source/cleanup.rb` + `lib/html2rss/status.rb` — Result tallies → Status contract
2. `lib/html2rss/capture.rb` + `lib/html2rss/feed_pipeline.rb` — enhance Capture via `to_outcome` / strategy stamp
3. `lib/html2rss/mcp/server.rb` + `lib/html2rss/cli.rb` — `_meta` / `--explain` surfaces
4. Specs under `spec/lib/html2rss/{capture,status,mcp,cli,auto_source/cleanup}*_spec.rb`

## Validation

- Assure (`review.gil` findings): **Conditional** → quality fixed Important (strategy stamp, meta keys, multi-segment coverage)
- `make quick` (phase + quality commits): exit 0
- `make ready`: exit 0 (1408 examples, 0 failures)