### PR TITLE
feat(mcp): log daemon activity on stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ html2rss mcp
 html2rss mcp --transport http --port 8080
 ```
 
+stdio uses stdout for JSON-RPC, so the daemon logs to **stderr**. It defaults to `LOG_LEVEL=info` (the gem library default stays `warn`) so a foreground watcher sees the start banner, each tool call, and pipeline fallbacks. Use `LOG_LEVEL=debug` for more detail or `LOG_LEVEL=warn` to quiet it.
+
 HTTP transport needs `rack`, `rackup`, and `webrick` (declared gem dependencies). It listens on `127.0.0.1` only; do not expose it on a public interface without your own auth and Host/Origin controls.
 
 **Strategy note:** MCP `scrape_url` / `capture_config` with `strategy: "auto"` run the FeedPipeline AutoFallback chain (`faraday` → `botasaurus`). `inspect_url` uses Faraday when `auto` (cheap diagnostic); pin `botasaurus` when you need browser rendering for inspect. Botasaurus needs `BOTASAURUS_SCRAPER_URL`.

--- a/lib/html2rss/mcp/server.rb
+++ b/lib/html2rss/mcp/server.rb
@@ -24,19 +24,21 @@ module Html2rss
         ##
         # Starts the MCP server with the given transport.
         #
+        # Points {Html2rss.logger} at +$stderr+ so stdio JSON-RPC on stdout stays
+        # intact, and raises the process log level to +info+ unless +LOG_LEVEL+ is set.
+        # A foreground watcher then sees the start banner, tool calls, and pipeline warns.
+        #
         # @param transport [Symbol] +:stdio+ or +:http+
         # @param port [Integer] port for HTTP transport
         def start(transport: :stdio, port: 8080)
-          app = build
+          raise ArgumentError, "Unknown transport: #{transport.inspect}" unless %i[stdio http].include?(transport)
 
-          case transport
-          when :stdio
-            ::MCP::Server::Transports::StdioTransport.new(app).open
-          when :http
-            start_http(app, port:)
-          else
-            raise ArgumentError, "Unknown transport: #{transport.inspect}"
-          end
+          configure_daemon_logging!
+          app = build
+          Log.info(start_banner(transport:, port:))
+          return start_http(app, port:) if transport == :http
+
+          ::MCP::Server::Transports::StdioTransport.new(app).open
         end
 
         ##
@@ -47,7 +49,8 @@ module Html2rss
           ::MCP::Server.new(
             name: SERVER_NAME,
             version: SERVER_VERSION,
-            instructions: instructions_text
+            instructions: instructions_text,
+            configuration: protocol_configuration
           ).tap do |server|
             register_tools(server)
             register_resources(server)
@@ -68,10 +71,71 @@ module Html2rss
         # @param error [Exception]
         # @return [::MCP::Tool::Response]
         def error_response(error)
+          Log.error("mcp error #{error.class}: #{error.message}")
           text_response("Error: #{error.message}", error: true)
         end
 
         private
+
+        def configure_daemon_logging!
+          Html2rss.configure do |config|
+            config.logger = Logger.new($stderr)
+            config.log_level = ENV.fetch('LOG_LEVEL', :info)
+          end
+        end
+
+        def start_banner(transport:, port:)
+          bind = transport == :http ? " bind=#{HTTP_BIND_HOST}:#{port}" : ''
+          "html2rss MCP #{SERVER_VERSION} starting transport=#{transport}#{bind}"
+        end
+
+        def protocol_configuration
+          ::MCP::Configuration.new.tap do |config|
+            config.exception_reporter = method(:report_protocol_exception)
+            config.around_request = method(:around_protocol_request)
+          end
+        end
+
+        def report_protocol_exception(error, server_context)
+          detail = server_context.is_a?(Hash) && server_context[:error]
+          suffix = detail ? " (#{detail})" : ''
+          Log.error("#{error.class}: #{error.message}#{suffix}")
+        end
+
+        def around_protocol_request(data)
+          return yield unless log_protocol_request?(data)
+
+          started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          begin
+            Log.info(protocol_request_line('start', data))
+            yield
+          ensure
+            duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+            Log.info(protocol_request_line('done', data, duration:))
+          end
+        end
+
+        def log_protocol_request?(data)
+          method = data[:method]
+          method.is_a?(String) &&
+            method != ::MCP::Methods::PING &&
+            !::MCP::Methods.notification?(method)
+        end
+
+        def protocol_request_line(phase, data, duration: nil)
+          parts = ['mcp', phase, data[:method], *protocol_request_labels(data)]
+          parts << format('%.2fs', duration) if duration
+          parts << "error=#{data[:error]}" if data[:error]
+          parts.join(' ')
+        end
+
+        def protocol_request_labels(data)
+          [
+            data[:tool_name] && "tool=#{data[:tool_name]}",
+            data[:prompt_name] && "prompt=#{data[:prompt_name]}",
+            data[:resource_uri] && "uri=#{data[:resource_uri]}"
+          ].compact
+        end
 
         def start_http(app, port:) # rubocop:disable Metrics/MethodLength -- require + bind + LoadError message
           require 'rackup'

--- a/spec/lib/html2rss/mcp/server_spec.rb
+++ b/spec/lib/html2rss/mcp/server_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 require 'json'
 require 'mcp'
+require 'climate_control'
 
 RSpec.describe Html2rss::MCP::Server do
   subject(:protocol_server) { described_class.build }
@@ -192,12 +193,25 @@ RSpec.describe Html2rss::MCP::Server do
     end
 
     describe 'error paths' do
+      before do
+        allow(Html2rss::Log).to receive(:error)
+        allow(Html2rss::Log).to receive(:info)
+      end
+
       it 'marks scrape_url failures as isError', :aggregate_failures do
         allow(Html2rss).to receive(:auto_feed_result).and_raise(StandardError, 'scrape boom')
         result = call_tool.call('scrape_url', { url: 'https://example.com' })
 
         expect(result.dig(:result, :isError)).to be(true)
         expect(result.dig(:result, :content, 0, :text)).to include('scrape boom')
+      end
+
+      it 'logs tool exceptions to the gem logger' do
+        allow(Html2rss).to receive(:auto_feed_result).and_raise(StandardError, 'scrape boom')
+
+        call_tool.call('scrape_url', { url: 'https://example.com' })
+
+        expect(Html2rss::Log).to have_received(:error).with('mcp error StandardError: scrape boom')
       end
 
       it 'marks capture_config failures as isError' do
@@ -271,17 +285,73 @@ RSpec.describe Html2rss::MCP::Server do
     end
   end
 
+  describe 'foreground request logging' do
+    # rubocop:disable RSpec/ExampleLength -- start/done pair is one access-log story
+    it 'logs tools/call start and done without leaking arguments', :aggregate_failures do
+      allow(Html2rss::Log).to receive(:info)
+
+      call_tool.call('validate_config', { config: valid_config })
+
+      expect(Html2rss::Log).to have_received(:info).with('mcp start tools/call')
+      expect(Html2rss::Log).to have_received(:info).with(
+        a_string_matching(%r{\Amcp done tools/call tool=validate_config \d+\.\d+s\z})
+      )
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
+
   describe '.start' do
+    around do |example|
+      previous_logger = Html2rss.logger
+      previous_level = Html2rss.defaults.log_level
+      example.run
+    ensure
+      Html2rss.configure do |config|
+        config.logger = previous_logger
+        config.log_level = previous_level
+      end
+    end
+
     before do
       allow(MCP::Server::Transports::StdioTransport).to receive(:new).and_return(
         instance_double(MCP::Server::Transports::StdioTransport, open: nil)
       )
+      allow(Html2rss::Log).to receive(:info)
     end
 
     it 'opens stdio transport by default' do
       described_class.start(transport: :stdio)
 
       expect(MCP::Server::Transports::StdioTransport).to have_received(:new)
+    end
+
+    # rubocop:disable RSpec/ExampleLength -- stderr vs stdout split is the protocol contract
+    it 'writes the start banner to stderr so stdio JSON-RPC stays on stdout', :aggregate_failures do
+      allow(Html2rss::Log).to receive(:info).and_call_original
+      banner = "html2rss MCP #{Html2rss::VERSION} starting transport=stdio"
+
+      ClimateControl.modify(LOG_LEVEL: 'info') do
+        expect { described_class.start(transport: :stdio) }
+          .to output(a_string_including(banner)).to_stderr
+          .and output('').to_stdout
+      end
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    it 'defaults the daemon log level to info when LOG_LEVEL is unset' do
+      ClimateControl.modify(LOG_LEVEL: nil) do
+        described_class.start(transport: :stdio)
+
+        expect(Html2rss.defaults.log_level).to eq(Logger::INFO)
+      end
+    end
+
+    it 'honors LOG_LEVEL for the daemon' do
+      ClimateControl.modify(LOG_LEVEL: 'error') do
+        described_class.start(transport: :stdio)
+
+        expect(Html2rss.defaults.log_level).to eq(Logger::ERROR)
+      end
     end
 
     # rubocop:disable RSpec/ExampleLength -- Host/Port bind contract


### PR DESCRIPTION
## What changed

- `html2rss mcp` points `Html2rss.logger` at **stderr** (stdio JSON-RPC stays on stdout).
- Daemon log level defaults to `info` unless `LOG_LEVEL` is set; library default stays `warn`.
- Tool calls log `mcp start` / `mcp done` (method, tool name, duration) via the MCP SDK `around_request` hook; tool exceptions log at error.
- README documents the stderr / `LOG_LEVEL` contract.

## Why

A foreground watcher saw a silent daemon. Worse, warn-level pipeline logs used stdout and could corrupt the MCP stream. Protocol `notifications/message` logging is the wrong channel (deprecated in the Ruby MCP SDK; it goes to the client, not the terminal).

## Risk

- Low. Process-local logger rebind in `MCP.start` only; `LOG_LEVEL` still quiets the daemon.
- Access log omits tool arguments. Exception messages may still include transport URLs (same as returning them to the MCP client).
- Does not overlap `fix/logging-transport-info` (request-strategy log contents).

## Review map

Review map: whole PR is small — start at `lib/html2rss/mcp/server.rb`.

## Validation

- `make ready` (exit 0): RuboCop, YARD lint, RSpec 1413 examples / 0 failures, schema, fixture validate, yard doc, shellcheck