### PR TITLE
feat: Botasaurus OpenAPI 2.0 client, leftover CardWalk, Faraday HTML

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,7 +12,7 @@ Whether a response document is HTML is owned by `RequestService::Response#html_r
 
 ## Botasaurus scrape contract
 
-OpenAPI `ScrapeRequest` / `ScrapeResponse` (sibling `botasaurus-scrape-api/openapi.yaml`) is the wire authority. Closed sets, wait bounds, and request option keys live on `RequestService::BotasaurusContract`. `Config::Validator::BotasaurusRequestConfig` consumes those constants for YAML admission. `BotasaurusStrategy` is Faraday `POST /scrape` plus gem error mapping (`challenge_block` → `BlockedSurfaceDetected`, `timeout` / 504 → `RequestTimedOut`). Do not reintroduce FastAPI `detail` parsing or client default overrides of published OpenAPI defaults.
+OpenAPI 2.0 `ScrapeRequest` / `ScrapeSuccess` / `ScrapeError` (sibling `botasaurus-scrape-api/openapi.yaml`) is the wire authority. There is no `ScrapeResponse` alias. Closed sets, wait bounds, request option keys, and `window_size` `{width, height}` live on `RequestService::BotasaurusContract`. `Config::Validator::BotasaurusRequestConfig` consumes those constants for YAML admission (`scroll` is scroll-to-bottom; there is no `scroll_to_bottom`). `BotasaurusStrategy` is Faraday `POST /scrape` plus gem error mapping: 200 → `Success`; 4xx/5xx → `Error` (`challenge_block` → `BlockedSurfaceDetected`, `timeout` / 504 → `RequestTimedOut`, otherwise `BotasaurusServiceError`). `Response#transport_meta` is `diagnostics` plus success-only `metadata_error`. Do not flatten old 1.x field names, parse FastAPI `detail`, or override published OpenAPI defaults.
 
 ## DOM chrome
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -10,9 +10,9 @@ Shared wall-clock and HTTP request meters for one feed build. Constructed via `R
 
 Whether a response document is HTML is owned by `RequestService::Response#html_response?` (Content-Type `text/html`, or a non-JSON body matching `Response::HTML_BODY_SNIFF`). `content_type` stays the wire header. Capture, Channel, and MCP Inspect all call that one predicate — do not reintroduce a parallel `html_document?`. Gzip/brotli inflate stays on `CompressedBody`, called only from the Faraday adapter; unlabeled octet-stream inflate must not grow onto Botasaurus or LocalFile.
 
-## Botasaurus option keys
+## Botasaurus scrape contract
 
-Types and the closed key set live on `Config::Validator::BotasaurusRequestConfig`. `BotasaurusContract#filtered_options` reads `key_map` at call time (no load-time `OPTION_KEYS` — the validator already references `BotasaurusContract::MAX_WAIT_TIMEOUT_SECONDS`). Wait ceiling and 422 clamp stay on Contract.
+OpenAPI `ScrapeRequest` / `ScrapeResponse` (sibling `botasaurus-scrape-api/openapi.yaml`) is the wire authority. Closed sets, wait bounds, and request option keys live on `RequestService::BotasaurusContract`. `Config::Validator::BotasaurusRequestConfig` consumes those constants for YAML admission. `BotasaurusStrategy` is Faraday `POST /scrape` plus gem error mapping (`challenge_block` → `BlockedSurfaceDetected`, `timeout` / 504 → `RequestTimedOut`). Do not reintroduce FastAPI `detail` parsing or client default overrides of published OpenAPI defaults.
 
 ## DOM chrome
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -6,6 +6,14 @@ Contributor map for the four Strong module deepenings on this branch. Prefer the
 
 Shared wall-clock and HTTP request meters for one feed build. Constructed via `RequestSession::RuntimePolicy.resources_for(config)` (policy + budget from one expansion); `budget_for` remains a thin alias. `FeedPipeline` builds sessions with `RequestSession.build` (Context normalizes once — no `RuntimeInput` passthrough). `RequestService::Context` requires an explicit `budget:`. Adapter attempt timeouts resolve through `Budget#effective_timeout_seconds` / `#effective_timeout_ms` — strategies must not reimplement `remaining || policy.total`. Auto fallback run state lives on `FeedPipeline::AutoFallback::AttemptState`. Article collection threads `FeedPipeline::ExtractionContext`.
 
+## HTML-ness
+
+Whether a response document is HTML is owned by `RequestService::Response#html_response?` (Content-Type `text/html`, or a non-JSON body matching `Response::HTML_BODY_SNIFF`). `content_type` stays the wire header. Capture, Channel, and MCP Inspect all call that one predicate — do not reintroduce a parallel `html_document?`. Gzip/brotli inflate stays on `CompressedBody`, called only from the Faraday adapter; unlabeled octet-stream inflate must not grow onto Botasaurus or LocalFile.
+
+## Botasaurus option keys
+
+Types and the closed key set live on `Config::Validator::BotasaurusRequestConfig`. `BotasaurusContract#filtered_options` reads `key_map` at call time (no load-time `OPTION_KEYS` — the validator already references `BotasaurusContract::MAX_WAIT_TIMEOUT_SECONDS`). Wait ceiling and 422 clamp stay on Contract.
+
 ## DOM chrome
 
 Layout noise and primary-link recognition for the **manual selector** path: ignored container tags/paths, class-clustering exclusions, utility landmarks, heading tags, main-anchor CSS, and visible-text extraction. Owned by `Html2rss::Html::Navigator` (+ `TextExtractor`). `Html::ArticleExtractor` serves selectors only.
@@ -26,7 +34,11 @@ Whether an extracted candidate may become a feed item. Owned by `Html2rss::AutoS
 
 ## Enhance leftover fields
 
-Visible leftover after excluding heading/anchor/kicker/`time` is split once on block newlines. Keep/drop (CTA, date-shaped, field labels, type chips, title echo, listing section names) is owned only by `Html2rss::Html::ArticleRules::Description`. Dates stay on `ArticleRules::Date` (datetime attrs + date-shaped leftover lines, channel `time_zone`; invalid identifiers fall back to UTC so extract does not raise). Categories stay on `ArticleRules::Category` (class tokens, not layout `label`/`section` substrings) and reject Description keepers except type chips, which are leftover chrome rather than taxonomy. Both `Html::ArticleExtractor` and `Html::SstArticleExtractor` call those modules — do not copy leftover denylists into `Cleanup.junk_reason`. Heading-only items and wrapping `<a>` cards (heading or `p` inside) may walk ancestors via `Navigator.parent_until_condition` / `SST::Index#parent_until`, skipping thin heading wrappers and landmarks/`html`/`body`, and aborting when the parent has more than one heading or eligible link.
+Visible leftover after excluding heading/anchor/kicker/`time` is split once on block newlines. Keep/drop (CTA, date-shaped, field labels, type chips, title echo, listing section names) is owned only by `Html2rss::Html::ArticleRules::Description`. Dates stay on `ArticleRules::Date` (datetime attrs + date-shaped leftover lines, channel `time_zone`; invalid identifiers fall back to UTC so extract does not raise). Categories stay on `ArticleRules::Category` (class tokens, not layout `label`/`section` substrings) and reject Description keepers except type chips, which are leftover chrome rather than taxonomy. Both `Html::ArticleExtractor` and `Html::SstArticleExtractor` call those modules — do not copy leftover denylists into `Cleanup.junk_reason`.
+
+## Leftover parent-card walk
+
+When a heading-only item or wrapping `<a>` lacks leftover description and date, extractors climb via `Navigator.parent_until_condition` / `SST::Index#parent_until`. Walk policy (`miss?` / `thin_wrapper?` / `crowded?` from heading count + distinct main hrefs) is owned by `Html2rss::Html::CardWalk`. Adapters still traverse. Capture's items-selector lift is a second job: it shares only `Navigator.usable_card_parent?` stop tags and aborts with `contains_other_root?` (listing-root set). Do not fold Capture lift into CardWalk.
 
 ## DOM candidate clustering
 

--- a/lib/html2rss/auto_source/cleanup.rb
+++ b/lib/html2rss/auto_source/cleanup.rb
@@ -40,6 +40,7 @@ module Html2rss
         [:credit, /\bHandout\b.+\b(?:#{AGENCY_ALT})\b|\b(?:#{AGENCY_ALT})\b.+\bHandout\b/ix],
         [:credit, /\A(?:Live\s+Updates|Analysis)\s*[•·.:-]?\s*.*\b(?:#{AGENCY_ALT})\b/ix],
         [:cms_token, /\A(?:lucy\.\w[\w.-]*|methode[-.][\w.-]+)\z/i],
+        [:json_blob, /\A\{\s*["']?text["']?\s*:/],
         [:slug, /\A\p{Alnum}+(?:[-_]\p{Alnum}+){2,}\z/],
         [:date_prefix, /\A\d{4}(?:[\s.-]+\d{1,2}){2}\b/],
         [:titleized_path, /\A(?:\d+|\p{Lu}[\p{L}\p{M}]*)(?:\s+(?:\d+|\p{Lu}[\p{L}\p{M}]*))*\s+\d{6,}\z/],
@@ -115,9 +116,9 @@ module Html2rss
         end
 
         def reject_different_domain!(articles, base_url, tallies)
-          base_host = base_url.host
+          base_domain = base_url.domain
           tally_reject!(articles, tallies, 'different_domain') do |article|
-            article.url&.host != base_host
+            article.url&.domain != base_domain
           end
         end
 

--- a/lib/html2rss/capture.rb
+++ b/lib/html2rss/capture.rb
@@ -202,7 +202,7 @@ module Html2rss
     def items_selector(matched)
       return nil if matched.empty?
 
-      roots = matched.map { |m| m[:segment].root_node }
+      roots = lift_heading_link_roots(matched.map { |m| m[:segment].root_node })
       shared = shared_class_items_selector(roots)
       return shared if shared
 
@@ -212,6 +212,58 @@ module Html2rss
       return nil if tag_path.empty?
 
       css_from_trimmed_tag_path(tag_path)
+    end
+
+    def lift_heading_link_roots(roots)
+      roots.map { |root| lift_heading_link_root(root, roots) }
+    end
+
+    def lift_heading_link_root(root, all_roots)
+      return root unless heading_or_inner_title_link?(root)
+
+      index = SST::Index.for_node(root)
+      return root unless index
+
+      walk_usable_card(root, index, all_roots)
+    end
+
+    def walk_usable_card(root, index, all_roots)
+      candidate = root
+      parent = index.parent_of(root)
+      while parent && Html::Navigator.usable_card_parent?(parent)
+        break if contains_other_root?(parent, root, all_roots)
+
+        candidate = parent
+        parent = index.parent_of(parent)
+      end
+      candidate
+    end
+
+    def heading_or_inner_title_link?(node)
+      name = node.name.to_s
+      return false if wrapping_anchor_root?(node)
+
+      Html::Navigator::HEADING_TAGS.include?(name) || name == 'a'
+    end
+
+    def wrapping_anchor_root?(node)
+      return false unless node.name.to_s == 'a'
+      return false unless node.respond_to?(:find)
+
+      tags = Html::Navigator::WRAPPING_ANCHOR_CHILD_TAGS
+      node.find { |child| !child.equal?(node) && tags.include?(child.name.to_s) }
+    end
+
+    def contains_other_root?(parent, root, all_roots)
+      all_roots.any? do |other|
+        next if other.equal?(root)
+
+        other.equal?(parent) || sst_descendant?(other, parent)
+      end
+    end
+
+    def sst_descendant?(child, ancestor)
+      SST::Index.for_node(child)&.descendant_of?(child, ancestor)
     end
 
     def shared_class_items_selector(roots)

--- a/lib/html2rss/config/schema.rb
+++ b/lib/html2rss/config/schema.rb
@@ -92,6 +92,7 @@ module Html2rss
           exported = Html2rss::Config::Validator::BotasaurusRequestExport
                      .new.schema.json_schema(loose: true).except(:$schema)
           exported[:additionalProperties] = false
+          exported.fetch(:properties).fetch(:window_size)[:additionalProperties] = false
           request[:botasaurus] = exported
         end
 

--- a/lib/html2rss/config/schema.rb
+++ b/lib/html2rss/config/schema.rb
@@ -82,6 +82,17 @@ module Html2rss
 
           topics = schema.dig(:properties, :directory, :properties, :topics)
           topics[:minItems] = 1 if topics.is_a?(Hash)
+          apply_botasaurus_schema!(schema)
+        end
+
+        def apply_botasaurus_schema!(schema)
+          request = schema.dig(:properties, :request, :properties)
+          return unless request.is_a?(Hash)
+
+          exported = Html2rss::Config::Validator::BotasaurusRequestExport
+                     .new.schema.json_schema(loose: true).except(:$schema)
+          exported[:additionalProperties] = false
+          request[:botasaurus] = exported
         end
 
         # @return [Hash{Symbol => Hash}] catalog under $defs.post_processors / $defs.extractors

--- a/lib/html2rss/config/validator.rb
+++ b/lib/html2rss/config/validator.rb
@@ -45,16 +45,18 @@ module Html2rss
         optional(:media).maybe(:string)
       end
 
-      # Contract for Botasaurus-specific request options.
+      # Contract for Botasaurus-specific request options (OpenAPI ScrapeRequest minus url).
       BotasaurusRequestConfig = Dry::Schema.Params do
         config.validate_keys = true
 
-        optional(:execution_mode).filled(:string, included_in?: %w[auto request browser])
-        optional(:navigation_mode).filled(:string, included_in?: %w[auto get google_get google_get_bypass organic_get])
-        optional(:max_retries).filled(:integer, gteq?: 0, lteq?: 3)
+        botasaurus = Html2rss::RequestService::BotasaurusContract
+
+        optional(:execution_mode).filled(:string, included_in?: botasaurus::EXECUTION_MODES)
+        optional(:navigation_mode).filled(:string, included_in?: botasaurus::NAVIGATION_MODES)
+        optional(:max_retries).filled(:integer, gteq?: 0, lteq?: botasaurus::MAX_RETRIES)
         optional(:wait_for_selector).maybe(:string)
         optional(:wait_timeout_seconds).filled(
-          :integer, gt?: 0, lteq?: Html2rss::RequestService::BotasaurusContract::MAX_WAIT_TIMEOUT_SECONDS
+          :integer, gteq?: botasaurus::MIN_WAIT_TIMEOUT_SECONDS, lteq?: botasaurus::MAX_WAIT_TIMEOUT_SECONDS
         )
         optional(:scroll).filled(:bool)
         optional(:scroll_to_bottom).filled(:bool)
@@ -65,7 +67,9 @@ module Html2rss
         optional(:headless).filled(:bool)
         optional(:proxy).filled(:string)
         optional(:user_agent).filled(:string)
-        optional(:window_size).value(:array, min_size?: 2, max_size?: 2).each(:integer, gt?: 0)
+        optional(:window_size).value(
+          :array, min_size?: botasaurus::WINDOW_SIZE_LENGTH, max_size?: botasaurus::WINDOW_SIZE_LENGTH
+        ).each(:integer, gt?: 0)
         optional(:lang).filled(:string)
         optional(:cookies).hash
         optional(:headers).hash

--- a/lib/html2rss/config/validator.rb
+++ b/lib/html2rss/config/validator.rb
@@ -53,7 +53,9 @@ module Html2rss
         optional(:navigation_mode).filled(:string, included_in?: %w[auto get google_get google_get_bypass organic_get])
         optional(:max_retries).filled(:integer, gteq?: 0, lteq?: 3)
         optional(:wait_for_selector).maybe(:string)
-        optional(:wait_timeout_seconds).filled(:integer, gt?: 0)
+        optional(:wait_timeout_seconds).filled(
+          :integer, gt?: 0, lteq?: Html2rss::RequestService::BotasaurusContract::MAX_WAIT_TIMEOUT_SECONDS
+        )
         optional(:scroll).filled(:bool)
         optional(:scroll_to_bottom).filled(:bool)
         optional(:block_images).filled(:bool)

--- a/lib/html2rss/config/validator.rb
+++ b/lib/html2rss/config/validator.rb
@@ -59,7 +59,6 @@ module Html2rss
           :integer, gteq?: botasaurus::MIN_WAIT_TIMEOUT_SECONDS, lteq?: botasaurus::MAX_WAIT_TIMEOUT_SECONDS
         )
         optional(:scroll).filled(:bool)
-        optional(:scroll_to_bottom).filled(:bool)
         optional(:block_images).filled(:bool)
         optional(:block_images_and_css).filled(:bool)
         optional(:block_trackers).filled(:bool)
@@ -67,12 +66,19 @@ module Html2rss
         optional(:headless).filled(:bool)
         optional(:proxy).filled(:string)
         optional(:user_agent).filled(:string)
-        optional(:window_size).value(
-          :array, min_size?: botasaurus::WINDOW_SIZE_LENGTH, max_size?: botasaurus::WINDOW_SIZE_LENGTH
-        ).each(:integer, gt?: 0)
+        optional(:window_size).hash do
+          botasaurus::WINDOW_SIZE_PROPERTIES.each do |key|
+            required(key).filled(:integer, gt?: 0)
+          end
+        end
         optional(:lang).filled(:string)
         optional(:cookies).hash
         optional(:headers).hash
+      end
+
+      # JSON Schema export adapter for +BotasaurusRequestConfig+ (params schemas have no json_schema).
+      class BotasaurusRequestExport < Dry::Validation::Contract
+        params(BotasaurusRequestConfig)
       end
 
       # Contract for the top-level `request` section.
@@ -80,7 +86,7 @@ module Html2rss
         optional(:max_redirects).filled(:integer, gteq?: 0)
         optional(:max_requests).filled(:integer, gt?: 0)
         optional(:total_timeout_seconds).filled(:integer, gt?: 0)
-        optional(:botasaurus).hash(BotasaurusRequestConfig)
+        optional(:botasaurus).hash
         optional(:local_file_path).filled(:string)
       end
 
@@ -127,6 +133,17 @@ module Html2rss
 
         errors = Config::SelectorsValidator.call(value).errors
         errors.each { |error| key(:selectors).failure(error.text) } unless errors.empty?
+      end
+
+      rule(request: :botasaurus) do
+        next unless value
+
+        result = BotasaurusRequestConfig.call(value)
+        next if result.success?
+
+        result.errors.each do |error|
+          key([:request, :botasaurus, *error.path]).failure(error.text)
+        end
       end
 
       # URL validation delegated to Url class

--- a/lib/html2rss/feed_pipeline/README.md
+++ b/lib/html2rss/feed_pipeline/README.md
@@ -29,7 +29,7 @@ These typically hop to the next chain member (among other `StandardError`s `Auto
 - Faraday connection / timeout errors
 - Empty extraction results when a later chain member may succeed
 
-These abort immediately (`AutoFallback::NON_FALLBACK_ERRORS`): unknown strategy, invalid URL, unsupported scheme or content type, budget exceeded, private network denied, cross-origin follow-up denied, response too large.
+These abort immediately (`AutoFallback::NON_FALLBACK_ERRORS`): unknown strategy, invalid URL, unsupported scheme, budget exceeded, private network denied, cross-origin follow-up denied, response too large.
 
 Retries share the feed's request/session policy. Pin a concrete strategy when you need a single-hop budget profile.
 

--- a/lib/html2rss/feed_pipeline/auto_fallback.rb
+++ b/lib/html2rss/feed_pipeline/auto_fallback.rb
@@ -15,7 +15,6 @@ module Html2rss
         RequestService::UnknownStrategy,
         RequestService::InvalidUrl,
         RequestService::UnsupportedUrlScheme,
-        RequestService::UnsupportedResponseContentType,
         RequestService::RequestBudgetExceeded,
         RequestService::PrivateNetworkDenied,
         RequestService::CrossOriginFollowUpDenied,
@@ -125,6 +124,9 @@ module Html2rss
         return unless response
 
         process_response(response:, strategy:, next_strategy:, request_session:, state:)
+      rescue RequestService::UnsupportedResponseContentType => error
+        state.record_error(strategy:, error:)
+        log_fallback_error(strategy:, next_strategy:, error:, request_session:) if next_strategy
       end
 
       def fetch_response(request_session:, strategy:, next_strategy:, state:)
@@ -138,8 +140,8 @@ module Html2rss
       end
 
       def process_response(response:, strategy:, next_strategy:, request_session:, state:) # rubocop:disable Metrics/MethodLength -- extract + success path
-        state.remember_response(response)
         articles, dedup_dropped, admission_drops = articles_for(response:, request_session:)
+        state.remember_response(response)
         items_count = articles.size
         state.record_items(strategy:, items_count:, transport_meta: response.transport_meta)
         Log.debug("#{self.class}: strategy=#{strategy} items=#{items_count} " \

--- a/lib/html2rss/html/article_extractor.rb
+++ b/lib/html2rss/html/article_extractor.rb
@@ -130,17 +130,11 @@ module Html2rss
       end
 
       def heading_or_anchor_item?
-        heading_item? || wrapping_anchor_item?
+        heading_item? || article_tag.name.to_s == 'a'
       end
 
       def heading_item?
         Navigator::HEADING_TAGS.include?(article_tag.name.to_s)
-      end
-
-      def wrapping_anchor_item?
-        return false unless article_tag.name.to_s == 'a'
-
-        article_tag.at_css(Navigator::WRAPPING_ANCHOR_CHILD_TAGS.join(','))
       end
 
       def heading_or_anchor_miss?(title, lines, published_at)
@@ -179,7 +173,11 @@ module Html2rss
 
       def crowded_card?(node)
         node.css(Navigator::HEADING_TAGS.join(',')).size > 1 ||
-          node.css(Navigator::MAIN_ANCHOR_SELECTOR).size > 1
+          distinct_main_hrefs(node) > 1
+      end
+
+      def distinct_main_hrefs(node)
+        node.css(Navigator::MAIN_ANCHOR_SELECTOR).map { |anchor| anchor['href'] }.uniq.size
       end
 
       def generate_id

--- a/lib/html2rss/html/article_extractor.rb
+++ b/lib/html2rss/html/article_extractor.rb
@@ -5,7 +5,7 @@ module Html2rss
     ##
     # ArticleExtractor is responsible for extracting details (headline, url, images, etc.)
     # from an article_tag DOM node. DOM chrome helpers live on {Navigator}.
-    # rubocop:disable Metrics/ClassLength -- leftover + parent-card walk colocated with field extractors
+    # rubocop:disable Metrics/ClassLength -- leftover re-extract stays with field extractors
     class ArticleExtractor
       class << self
         ##
@@ -138,15 +138,18 @@ module Html2rss
       end
 
       def heading_or_anchor_miss?(title, lines, published_at)
-        heading_or_anchor_item? && published_at.nil? &&
-          ArticleRules::Description.from_lines(lines, title:).nil?
+        CardWalk.miss?(
+          heading_or_anchor_item: heading_or_anchor_item?,
+          published_at:,
+          description: ArticleRules::Description.from_lines(lines, title:)
+        )
       end
 
       def parent_card_fields(title, lines, published_at)
         return article_tag, lines, published_at unless heading_or_anchor_miss?(title, lines, published_at)
 
         parent = immediate_card_parent
-        if !parent || crowded_card?(parent)
+        if !parent || crowded_parent?(parent)
           Log.debug { "parent-walk abort at #{article_tag.parent&.name}" }
           return article_tag, lines, published_at
         end
@@ -166,14 +169,18 @@ module Html2rss
       end
 
       def thin_heading_wrapper?(node)
-        node.element_children.none? do |child|
-          !child.equal?(article_tag) && !Navigator.descendant_of?(article_tag, child)
-        end
+        CardWalk.thin_wrapper?(
+          children: node.element_children,
+          item: article_tag,
+          descendant_of: ->(item, child) { Navigator.descendant_of?(item, child) }
+        )
       end
 
-      def crowded_card?(node)
-        node.css(Navigator::HEADING_TAGS.join(',')).size > 1 ||
-          distinct_main_hrefs(node) > 1
+      def crowded_parent?(node)
+        CardWalk.crowded?(
+          heading_count: node.css(Navigator::HEADING_TAGS.join(',')).size,
+          distinct_main_hrefs: distinct_main_hrefs(node)
+        )
       end
 
       def distinct_main_hrefs(node)

--- a/lib/html2rss/html/article_rules/description.rb
+++ b/lib/html2rss/html/article_rules/description.rb
@@ -17,8 +17,14 @@ module Html2rss
         MAX_DATE_CHARS = 128
         # Optional type-chip / clock separators (ASCII/en/em dash, pipe, bullet).
         CHIP_SEPARATORS = [' - ', ' – ', ' — ', ' | ', ' • '].freeze
-        # Trailing clock plus optional AM/PM and timezone label (not ISO T-offset).
-        CLOCK_ZONE = /\A\d{1,2}:\d{2}(?::\d{2})?(?:\s*(?:AM|PM))?(?:\s+\S.*)?\z/i
+        # Trailing clock plus optional AM/PM and one timezone/offset token (IANA, GMT/UTC offset, or abbrev).
+        CLOCK_ZONE = %r{
+          \A
+          \d{1,2}:\d{2}(?::\d{2})?
+          (?:\s*(?:AM|PM))?
+          (?:\s+(?:[A-Za-z]+(?:/[A-Za-z_]+)+|(?:GMT|UTC)[+-]\d{1,2}(?::\d{2})?|[A-Za-z]{2,5}))?
+          \z
+        }ix
         # Whole-line date shapes after normalize (ISO, numeric, day-month, month-day).
         DATE_SHAPES = [
           /\A\d{4}-\d{1,2}-\d{1,2}(?:[T ]\d{1,2}:\d{2}(?::\d{2})?(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)?\z/i,

--- a/lib/html2rss/html/article_rules/description.rb
+++ b/lib/html2rss/html/article_rules/description.rb
@@ -15,14 +15,16 @@ module Html2rss
         SECTION_NAMES = Set['press releases'].freeze
         # Skip date detection / DateTime.parse above this length.
         MAX_DATE_CHARS = 128
-        # Optional " - News article" suffix separators (ASCII/en/em dash).
-        CHIP_SEPARATORS = [' - ', ' – ', ' — '].freeze
+        # Optional type-chip / clock separators (ASCII/en/em dash, pipe, bullet).
+        CHIP_SEPARATORS = [' - ', ' – ', ' — ', ' | ', ' • '].freeze
+        # Trailing clock plus optional AM/PM and timezone label (not ISO T-offset).
+        CLOCK_ZONE = /\A\d{1,2}:\d{2}(?::\d{2})?(?:\s*(?:AM|PM))?(?:\s+\S.*)?\z/i
         # Whole-line date shapes after normalize (ISO, numeric, day-month, month-day).
         DATE_SHAPES = [
           /\A\d{4}-\d{1,2}-\d{1,2}(?:[T ]\d{1,2}:\d{2}(?::\d{2})?(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)?\z/i,
           %r{\A\d{1,2}[./-]\d{1,2}[./-]\d{2,4}(?: \d{1,2}:\d{2}(?::\d{2})?)?\z},
-          /\A\d{1,2}\.? \p{L}{3,9}\.? \d{4}(?: \d{1,2}:\d{2}(?::\d{2})?)?\z/i,
-          /\A\p{L}{3,9}\.? \d{1,2},? \d{4}(?: \d{1,2}:\d{2}(?::\d{2})?)?\z/i
+          /\A\d{1,2}\.? \p{L}{3,9}\.?\s*,?\s*\d{4}(?: \d{1,2}:\d{2}(?::\d{2})?)?\z/i,
+          /\A\p{L}{3,9}\.? \d{1,2}\s*,?\s*\d{4}(?: \d{1,2}:\d{2}(?::\d{2})?)?\z/i
         ].freeze
 
         class << self
@@ -70,11 +72,8 @@ module Html2rss
           def date_core(line)
             normalized = normalize(line)
             CHIP_SEPARATORS.each do |sep|
-              idx = normalized.rindex(sep)
-              next unless idx
-
-              suffix = normalized[(idx + sep.length)..].downcase
-              return normalized[0, idx] if TYPE_CHIPS.include?(suffix)
+              peeled = peel_separator(normalized, sep)
+              return peeled if peeled
             end
             normalized
           end
@@ -82,6 +81,22 @@ module Html2rss
           private
 
           def normalize(line) = line.to_s.gsub(/[[:space:]]+/, ' ').strip
+
+          def peel_separator(normalized, sep)
+            idx = normalized.rindex(sep)
+            return unless idx
+
+            left = normalized[0, idx]
+            right = normalized[(idx + sep.length)..]
+            return left if type_chip?(right) || clock_zone?(right)
+            return right if type_chip?(left)
+
+            nil
+          end
+
+          def type_chip?(text) = TYPE_CHIPS.include?(text.downcase)
+
+          def clock_zone?(text) = text.match?(CLOCK_ZONE)
 
           def chrome?(normalized, title:, type_chips:)
             key = normalized.downcase

--- a/lib/html2rss/html/card_walk.rb
+++ b/lib/html2rss/html/card_walk.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Html2rss
+  module Html
+    ##
+    # Leftover parent-card walk policy shared by Nokogiri and SST extractors.
+    # Adapters traverse; this module decides miss / thin wrapper / crowded abort.
+    # Keep/drop stays on {ArticleRules::Description}. Capture's selector lift is a
+    # separate job (set-aware abort) and is not encoded here.
+    module CardWalk
+      class << self
+        ##
+        # @param heading_or_anchor_item [Boolean] true when the extract root is a heading or wrapping +a+
+        # @param published_at [Object, nil]
+        # @param description [String, nil] leftover description after Description keep/drop
+        # @return [Boolean] whether to climb to a parent card
+        def miss?(heading_or_anchor_item:, published_at:, description:)
+          heading_or_anchor_item && published_at.nil? && description.nil?
+        end
+
+        ##
+        # @param children [Enumerable] immediate children of the candidate parent
+        # @param item [Object] heading/anchor being extracted
+        # @param descendant_of [Proc] +(item, child)+ — whether +item+ sits inside +child+
+        # @return [Boolean] true when the parent only wraps the item (no sibling content)
+        def thin_wrapper?(children:, item:, descendant_of:)
+          children.none? do |child|
+            !child.equal?(item) && !descendant_of.call(item, child)
+          end
+        end
+
+        ##
+        # @param heading_count [Integer] headings inside the candidate parent
+        # @param distinct_main_hrefs [Integer] unique eligible main-article hrefs
+        # @return [Boolean] true when the parent looks like a listing, not one card
+        def crowded?(heading_count:, distinct_main_hrefs:)
+          heading_count > 1 || distinct_main_hrefs > 1
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/html/sst_article_extractor.rb
+++ b/lib/html2rss/html/sst_article_extractor.rb
@@ -192,14 +192,7 @@ module Html2rss
       end
 
       def heading_or_anchor_item?
-        @root.heading? || wrapping_anchor_item?
-      end
-
-      def wrapping_anchor_item?
-        return false unless @root.name == :a
-
-        tags = Navigator::WRAPPING_ANCHOR_CHILD_TAGS
-        @root.find { |n| !n.equal?(@root) && tags.include?(n.name.to_s) }
+        @root.heading? || @root.name == :a
       end
 
       def heading_or_anchor_miss?(title, lines, published_at)
@@ -238,7 +231,11 @@ module Html2rss
       end
 
       def crowded_card?(node)
-        node.each_node.count(&:heading?) > 1 || node.each_node.count(&:link?) > 1
+        node.each_node.count(&:heading?) > 1 || distinct_main_hrefs(node) > 1
+      end
+
+      def distinct_main_hrefs(node)
+        node.each_node.filter_map { |candidate| candidate.attrs.href if candidate.link? }.uniq.size
       end
 
       def sst_parent

--- a/lib/html2rss/html/sst_article_extractor.rb
+++ b/lib/html2rss/html/sst_article_extractor.rb
@@ -196,15 +196,18 @@ module Html2rss
       end
 
       def heading_or_anchor_miss?(title, lines, published_at)
-        heading_or_anchor_item? && published_at.nil? &&
-          ArticleRules::Description.from_lines(lines, title:).nil?
+        CardWalk.miss?(
+          heading_or_anchor_item: heading_or_anchor_item?,
+          published_at:,
+          description: ArticleRules::Description.from_lines(lines, title:)
+        )
       end
 
       def parent_card_fields(title, lines, published_at)
         return @root, lines, published_at unless heading_or_anchor_miss?(title, lines, published_at)
 
         parent = immediate_card_parent
-        if !parent || crowded_card?(parent)
+        if !parent || crowded_parent?(parent)
           Log.debug { "parent-walk abort at #{sst_parent&.name}" }
           return @root, lines, published_at
         end
@@ -225,13 +228,18 @@ module Html2rss
       end
 
       def thin_heading_wrapper?(node)
-        node.children.none? do |child|
-          !child.equal?(@root) && !descendant_of?(@root, child)
-        end
+        CardWalk.thin_wrapper?(
+          children: node.children,
+          item: @root,
+          descendant_of: ->(item, child) { descendant_of?(item, child) }
+        )
       end
 
-      def crowded_card?(node)
-        node.each_node.count(&:heading?) > 1 || distinct_main_hrefs(node) > 1
+      def crowded_parent?(node)
+        CardWalk.crowded?(
+          heading_count: node.each_node.count(&:heading?),
+          distinct_main_hrefs: distinct_main_hrefs(node)
+        )
       end
 
       def distinct_main_hrefs(node)

--- a/lib/html2rss/request_service/botasaurus_contract.rb
+++ b/lib/html2rss/request_service/botasaurus_contract.rb
@@ -8,9 +8,11 @@ module Html2rss
     # Maps html2rss request/response handling to botasaurus-scrape-api OpenAPI 2.0
     # +ScrapeRequest+ / +ScrapeSuccess+ / +ScrapeError+ (sibling +openapi.yaml+).
     class BotasaurusContract # rubocop:disable Metrics/ClassLength -- Success/Error envelopes stay with the owner
-      # Closed sets from OpenAPI ExecutionMode / NavigationMode / ErrorCategory.
+      # Closed set from OpenAPI ExecutionMode.
       EXECUTION_MODES = %w[auto request browser].freeze
+      # Closed set from OpenAPI NavigationMode.
       NAVIGATION_MODES = %w[auto get google_get google_get_bypass organic_get].freeze
+      # Closed set from OpenAPI ErrorCategory.
       ERROR_CATEGORIES = %w[timeout challenge_block navigation_error metadata_error validation].freeze
 
       # ScrapeRequest properties except +url+ (html2rss supplies the target URL).
@@ -23,10 +25,11 @@ module Html2rss
       # OpenAPI WindowSize required keys (positive integers).
       WINDOW_SIZE_PROPERTIES = %i[width height].freeze
 
-      # Published wait default, plus the API clamp ceiling (`[1, 20]` in OpenAPI description).
-      # Config admission rejects waits above the ceiling instead of sending values that would be clamped.
+      # Published wait clamp floor (`[1, 20]` in OpenAPI description).
       MIN_WAIT_TIMEOUT_SECONDS = 1
+      # Published wait clamp ceiling; YAML values above this are rejected.
       MAX_WAIT_TIMEOUT_SECONDS = 20
+      # OpenAPI wait_timeout_seconds default (omitted from the client payload).
       DEFAULT_WAIT_TIMEOUT_SECONDS = 15
 
       # OpenAPI max_retries maximum (default 2 is applied upstream when omitted).
@@ -34,6 +37,7 @@ module Html2rss
 
       # Allowlisted ScrapeDiagnostics keys nested under diagnostics.
       DIAGNOSTICS_KEYS = %w[request_id attempts strategy_used render_ms execution_tier challenge].freeze
+      # Allowlisted ChallengeSignal keys nested under diagnostics.challenge.
       CHALLENGE_KEYS = %w[blocked detected marker].freeze
 
       # Remaining seconds at or below which Botasaurus retries are disabled.

--- a/lib/html2rss/request_service/botasaurus_contract.rb
+++ b/lib/html2rss/request_service/botasaurus_contract.rb
@@ -61,9 +61,9 @@ module Html2rss
         # @return [Boolean] true when upstream classified request as challenge blocked
         def challenge_block? = error_category == 'challenge_block'
 
-        # @return [Boolean] true when upstream returned non-200 or an error payload
+        # @return [Boolean] true when scrape transport is not 200 or error is present
         def upstream_failure?
-          transport_status != 200 || status != 200 || error_message?
+          transport_status != 200 || error_message?
         end
 
         # @return [String] normalized challenge error message

--- a/lib/html2rss/request_service/botasaurus_contract.rb
+++ b/lib/html2rss/request_service/botasaurus_contract.rb
@@ -53,7 +53,7 @@ module Html2rss
       MAX_WAIT_TIMEOUT_SECONDS = 20
 
       # Parsed Botasaurus response wrapper.
-      class ParsedResponse
+      class ParsedResponse # rubocop:disable Metrics/ClassLength -- payload accessors stay with 422 detail parse
         # Fallback headers when upstream omits response headers.
         DEFAULT_HEADERS = { 'content-type' => 'text/html' }.freeze
         # Per-body size cap for captured XHR JSON (defense-in-depth vs upstream).

--- a/lib/html2rss/request_service/botasaurus_contract.rb
+++ b/lib/html2rss/request_service/botasaurus_contract.rb
@@ -5,20 +5,37 @@ require 'json'
 module Html2rss
   class RequestService
     ##
-    # Maps html2rss request/response handling to the botasaurus-scrape-api contract.
+    # Maps html2rss request/response handling to botasaurus-scrape-api OpenAPI
+    # +ScrapeRequest+ / +ScrapeResponse+ (see sibling +openapi.yaml+).
     class BotasaurusContract
-      # Default Botasaurus scrape options when no explicit config is provided.
-      DEFAULT_OPTIONS = {
-        execution_mode: 'auto',
-        navigation_mode: 'auto',
-        max_retries: 1,
-        headless: false
-      }.freeze
+      # Closed sets from OpenAPI ScrapeRequest / ScrapeResponse.error_category.
+      EXECUTION_MODES = %w[auto request browser].freeze
+      NAVIGATION_MODES = %w[auto get google_get google_get_bypass organic_get].freeze
+      ERROR_CATEGORIES = %w[timeout challenge_block navigation_error metadata_error].freeze
 
-      # Allowlisted upstream response keys exposed as Response#transport_meta.
+      # ScrapeRequest properties except +url+ (html2rss supplies the target URL).
+      REQUEST_OPTION_KEYS = %i[
+        execution_mode navigation_mode max_retries wait_for_selector wait_timeout_seconds
+        scroll scroll_to_bottom block_images block_images_and_css block_trackers
+        wait_for_complete_page_load user_agent headers cookies window_size lang headless proxy
+      ].freeze
+
+      # Published wait default, plus the API clamp ceiling (`[1, 20]` in OpenAPI description).
+      # Config admission rejects waits above the ceiling instead of sending values that would be clamped.
+      MIN_WAIT_TIMEOUT_SECONDS = 1
+      MAX_WAIT_TIMEOUT_SECONDS = 20
+      DEFAULT_WAIT_TIMEOUT_SECONDS = 15
+
+      # OpenAPI max_retries maximum (default 2 is applied upstream when omitted).
+      MAX_RETRIES = 3
+
+      # OpenAPI window_size runtime constraint (exactly two positive integers).
+      WINDOW_SIZE_LENGTH = 2
+
+      # Allowlisted ScrapeResponse diagnostic keys exposed as Response#transport_meta.
       META_KEYS = %w[
-        request_id strategy_used render_ms challenge_detected blocked_detected attempts error_category
-        execution_tier detected_challenge
+        request_id strategy_used render_ms challenge_detected blocked_detected attempts
+        error_category execution_tier detected_challenge metadata_error
       ].freeze
 
       # Remaining seconds at or below which Botasaurus retries are disabled.
@@ -27,31 +44,14 @@ module Html2rss
       # Seconds reserved from remaining budget before setting wait_timeout_seconds.
       BUDGET_WAIT_RESERVE_SECONDS = 2
 
-      # Botasaurus scrape API Field(..., le=DEFAULT_SCRAPE_TIMEOUT_SECONDS) ceiling.
-      MAX_WAIT_TIMEOUT_SECONDS = 20
-
-      class << self
-        ##
-        # Validator-owned request.botasaurus keys, resolved lazily to avoid a load-time
-        # cycle with {Config::Validator::BotasaurusRequestConfig} (which references
-        # {MAX_WAIT_TIMEOUT_SECONDS}).
-        #
-        # @return [Array<Symbol>]
-        def option_keys
-          Config::Validator::BotasaurusRequestConfig.key_map.map { |schema_key| schema_key.name.to_sym }
-        end
-      end
-
-      # Parsed Botasaurus response wrapper.
-      class ParsedResponse # rubocop:disable Metrics/ClassLength -- payload accessors stay with 422 detail parse
-        # Fallback headers when upstream omits response headers.
-        DEFAULT_HEADERS = { 'content-type' => 'text/html' }.freeze
+      # Parsed Botasaurus ScrapeResponse wrapper.
+      class ParsedResponse
         # Per-body size cap for captured XHR JSON (defense-in-depth vs upstream).
         MAX_XHR_BODY_BYTES = 500_000
         # Aggregate size cap across all captured XHR bodies.
         MAX_XHR_AGGREGATE_BYTES = 2_000_000
 
-        # @param payload [Hash{String => Object}] parsed Botasaurus response payload
+        # @param payload [Hash{String => Object}] parsed ScrapeResponse object
         # @param transport_status [Integer] HTTP status returned by Botasaurus
         def initialize(payload:, transport_status:)
           @payload = payload
@@ -60,6 +60,11 @@ module Html2rss
 
         # @return [Boolean] true when upstream classified request as challenge blocked
         def challenge_block? = error_category == 'challenge_block'
+
+        # @return [Boolean] true when the scrape envelope reports a timeout
+        def timeout?
+          transport_status == 504 || error_category == 'timeout'
+        end
 
         # @return [Boolean] true when scrape transport is not 200 or error is present
         def upstream_failure?
@@ -77,23 +82,16 @@ module Html2rss
           details << "error_category=#{error_category}" if error_category
           details << "error=#{error}" if error
           details << "request_id=#{request_id}" if request_id
-          details.concat(validation_detail_parts)
           "Botasaurus scrape failed (#{details.join(', ')})."
         end
 
-        # @return [String] rendered HTML body from Botasaurus
-        # @raise [BotasaurusServiceError] when html is missing
-        def html
-          value = payload['html']
-          raise BotasaurusServiceError, "Botasaurus response missing required 'html' field" if value.nil?
+        # @return [String] rendered HTML body (OpenAPI default is empty string)
+        def html = payload.fetch('html', '').to_s
 
-          value.to_s
-        end
-
-        # @return [Hash{String => String}] normalized response headers
+        # @return [Hash{String => String}] normalized response headers (null → {})
         def headers
           raw_headers = payload['headers']
-          return DEFAULT_HEADERS.dup unless raw_headers.is_a?(Hash) && raw_headers.any?
+          return {} unless raw_headers.is_a?(Hash) && raw_headers.any?
 
           raw_headers.to_h { |key, value| [key.to_s, value.to_s] }
         end
@@ -138,26 +136,6 @@ module Html2rss
         def error_message?
           value = error
           value.is_a?(String) ? !value.empty? : !value.nil?
-        end
-
-        def validation_detail_parts
-          raw = payload['detail']
-          return ["detail=#{raw}"] if raw.is_a?(String) && !raw.empty?
-          return [] unless raw.is_a?(Array)
-
-          raw.filter_map { |entry| format_detail_entry(entry) }
-        end
-
-        def format_detail_entry(entry)
-          return unless entry.is_a?(Hash)
-
-          field = Array(entry['loc']).last
-          msg = entry['msg']
-          return if field.nil? && msg.nil?
-
-          summary = [field, msg].compact.join(': ')
-          input = entry['input']
-          input.nil? ? summary : "#{summary} (input=#{input})"
         end
 
         def normalize_xhr_entry(entry)
@@ -226,17 +204,17 @@ module Html2rss
         @remaining_timeout_seconds = remaining_timeout_seconds
       end
 
-      # @return [Hash] payload for POST /scrape (budget-clamped when remaining is known)
+      # @return [Hash] payload for POST /scrape (explicit options plus budget clamp-downs)
       def request_payload
-        payload = DEFAULT_OPTIONS.merge(filtered_options)
+        payload = { url: url.to_s }.merge(filtered_options)
         forwarded_headers = merged_headers
         payload[:headers] = forwarded_headers if forwarded_headers&.any?
-        payload.merge(url: url.to_s).then { clamp_for_budget(_1) }
+        clamp_for_budget(payload)
       end
 
       # @param transport_response [Faraday::Response] upstream HTTP response
       # @return [ParsedResponse]
-      # @raise [BotasaurusServiceError] when payload is not valid JSON object
+      # @raise [BotasaurusServiceError] when payload is not a JSON object
       def parse_response(transport_response)
         payload = JSON.parse(transport_response.body.to_s)
         raise BotasaurusServiceError, 'Botasaurus response must be a JSON object' unless payload.is_a?(Hash)
@@ -258,22 +236,39 @@ module Html2rss
       end
 
       def filtered_options
-        self.class.option_keys.each_with_object({}) do |key, normalized|
+        REQUEST_OPTION_KEYS.each_with_object({}) do |key, normalized|
           normalized[key] = options[key] if options.key?(key)
         end
       end
 
       def clamp_for_budget(payload)
-        clamped = payload.dup
         remaining = remaining_timeout_seconds
+        clamped = payload.dup
         unless remaining.nil?
-          clamped[:max_retries] = 0 if remaining <= TIGHT_BUDGET_SECONDS
-          budget_wait = [1, (remaining - BUDGET_WAIT_RESERVE_SECONDS).floor].max
-          configured = clamped[:wait_timeout_seconds]
-          clamped[:wait_timeout_seconds] = configured ? [configured, budget_wait].min : budget_wait
+          apply_tight_retries!(clamped, remaining)
+          apply_budget_wait!(clamped, remaining)
         end
         cap_wait_timeout!(clamped)
         clamped
+      end
+
+      def apply_tight_retries!(payload, remaining)
+        payload[:max_retries] = 0 if remaining <= TIGHT_BUDGET_SECONDS
+      end
+
+      def apply_budget_wait!(payload, remaining)
+        budget_wait = budget_wait_seconds(remaining)
+        configured = payload[:wait_timeout_seconds]
+        if configured
+          payload[:wait_timeout_seconds] = [configured, budget_wait].min
+        elsif budget_wait < DEFAULT_WAIT_TIMEOUT_SECONDS
+          payload[:wait_timeout_seconds] = budget_wait
+        end
+      end
+
+      def budget_wait_seconds(remaining)
+        reserved = [MIN_WAIT_TIMEOUT_SECONDS, (remaining - BUDGET_WAIT_RESERVE_SECONDS).floor].max
+        [reserved, MAX_WAIT_TIMEOUT_SECONDS].min
       end
 
       def cap_wait_timeout!(payload)

--- a/lib/html2rss/request_service/botasaurus_contract.rb
+++ b/lib/html2rss/request_service/botasaurus_contract.rb
@@ -49,6 +49,9 @@ module Html2rss
       # Seconds reserved from remaining budget before setting wait_timeout_seconds.
       BUDGET_WAIT_RESERVE_SECONDS = 2
 
+      # Botasaurus scrape API Field(..., le=DEFAULT_SCRAPE_TIMEOUT_SECONDS) ceiling.
+      MAX_WAIT_TIMEOUT_SECONDS = 20
+
       # Parsed Botasaurus response wrapper.
       class ParsedResponse
         # Fallback headers when upstream omits response headers.
@@ -84,6 +87,7 @@ module Html2rss
           details << "error_category=#{error_category}" if error_category
           details << "error=#{error}" if error
           details << "request_id=#{request_id}" if request_id
+          details.concat(validation_detail_parts)
           "Botasaurus scrape failed (#{details.join(', ')})."
         end
 
@@ -144,6 +148,26 @@ module Html2rss
         def error_message?
           value = error
           value.is_a?(String) ? !value.empty? : !value.nil?
+        end
+
+        def validation_detail_parts
+          raw = payload['detail']
+          return ["detail=#{raw}"] if raw.is_a?(String) && !raw.empty?
+          return [] unless raw.is_a?(Array)
+
+          raw.filter_map { |entry| format_detail_entry(entry) }
+        end
+
+        def format_detail_entry(entry)
+          return unless entry.is_a?(Hash)
+
+          field = Array(entry['loc']).last
+          msg = entry['msg']
+          return if field.nil? && msg.nil?
+
+          summary = [field, msg].compact.join(': ')
+          input = entry['input']
+          input.nil? ? summary : "#{summary} (input=#{input})"
         end
 
         def normalize_xhr_entry(entry)
@@ -250,15 +274,23 @@ module Html2rss
       end
 
       def clamp_for_budget(payload)
-        remaining = remaining_timeout_seconds
-        return payload if remaining.nil?
-
         clamped = payload.dup
-        clamped[:max_retries] = 0 if remaining <= TIGHT_BUDGET_SECONDS
-        budget_wait = [1, (remaining - BUDGET_WAIT_RESERVE_SECONDS).floor].max
-        configured = clamped[:wait_timeout_seconds]
-        clamped[:wait_timeout_seconds] = configured ? [configured, budget_wait].min : budget_wait
+        remaining = remaining_timeout_seconds
+        unless remaining.nil?
+          clamped[:max_retries] = 0 if remaining <= TIGHT_BUDGET_SECONDS
+          budget_wait = [1, (remaining - BUDGET_WAIT_RESERVE_SECONDS).floor].max
+          configured = clamped[:wait_timeout_seconds]
+          clamped[:wait_timeout_seconds] = configured ? [configured, budget_wait].min : budget_wait
+        end
+        cap_wait_timeout!(clamped)
         clamped
+      end
+
+      def cap_wait_timeout!(payload)
+        wait = payload[:wait_timeout_seconds]
+        return unless wait
+
+        payload[:wait_timeout_seconds] = [wait, MAX_WAIT_TIMEOUT_SECONDS].min
       end
     end
   end

--- a/lib/html2rss/request_service/botasaurus_contract.rb
+++ b/lib/html2rss/request_service/botasaurus_contract.rb
@@ -5,20 +5,23 @@ require 'json'
 module Html2rss
   class RequestService
     ##
-    # Maps html2rss request/response handling to botasaurus-scrape-api OpenAPI
-    # +ScrapeRequest+ / +ScrapeResponse+ (see sibling +openapi.yaml+).
-    class BotasaurusContract
-      # Closed sets from OpenAPI ScrapeRequest / ScrapeResponse.error_category.
+    # Maps html2rss request/response handling to botasaurus-scrape-api OpenAPI 2.0
+    # +ScrapeRequest+ / +ScrapeSuccess+ / +ScrapeError+ (sibling +openapi.yaml+).
+    class BotasaurusContract # rubocop:disable Metrics/ClassLength -- Success/Error envelopes stay with the owner
+      # Closed sets from OpenAPI ExecutionMode / NavigationMode / ErrorCategory.
       EXECUTION_MODES = %w[auto request browser].freeze
       NAVIGATION_MODES = %w[auto get google_get google_get_bypass organic_get].freeze
-      ERROR_CATEGORIES = %w[timeout challenge_block navigation_error metadata_error].freeze
+      ERROR_CATEGORIES = %w[timeout challenge_block navigation_error metadata_error validation].freeze
 
       # ScrapeRequest properties except +url+ (html2rss supplies the target URL).
       REQUEST_OPTION_KEYS = %i[
         execution_mode navigation_mode max_retries wait_for_selector wait_timeout_seconds
-        scroll scroll_to_bottom block_images block_images_and_css block_trackers
+        scroll block_images block_images_and_css block_trackers
         wait_for_complete_page_load user_agent headers cookies window_size lang headless proxy
       ].freeze
+
+      # OpenAPI WindowSize required keys (positive integers).
+      WINDOW_SIZE_PROPERTIES = %i[width height].freeze
 
       # Published wait default, plus the API clamp ceiling (`[1, 20]` in OpenAPI description).
       # Config admission rejects waits above the ceiling instead of sending values that would be clamped.
@@ -29,14 +32,9 @@ module Html2rss
       # OpenAPI max_retries maximum (default 2 is applied upstream when omitted).
       MAX_RETRIES = 3
 
-      # OpenAPI window_size runtime constraint (exactly two positive integers).
-      WINDOW_SIZE_LENGTH = 2
-
-      # Allowlisted ScrapeResponse diagnostic keys exposed as Response#transport_meta.
-      META_KEYS = %w[
-        request_id strategy_used render_ms challenge_detected blocked_detected attempts
-        error_category execution_tier detected_challenge metadata_error
-      ].freeze
+      # Allowlisted ScrapeDiagnostics keys nested under diagnostics.
+      DIAGNOSTICS_KEYS = %w[request_id attempts strategy_used render_ms execution_tier challenge].freeze
+      CHALLENGE_KEYS = %w[blocked detected marker].freeze
 
       # Remaining seconds at or below which Botasaurus retries are disabled.
       TIGHT_BUDGET_SECONDS = 12
@@ -44,49 +42,28 @@ module Html2rss
       # Seconds reserved from remaining budget before setting wait_timeout_seconds.
       BUDGET_WAIT_RESERVE_SECONDS = 2
 
-      # Parsed Botasaurus ScrapeResponse wrapper.
-      class ParsedResponse
+      ##
+      # Parsed OpenAPI ScrapeSuccess envelope (HTTP 200).
+      class Success
         # Per-body size cap for captured XHR JSON (defense-in-depth vs upstream).
         MAX_XHR_BODY_BYTES = 500_000
         # Aggregate size cap across all captured XHR bodies.
         MAX_XHR_AGGREGATE_BYTES = 2_000_000
 
-        # @param payload [Hash{String => Object}] parsed ScrapeResponse object
-        # @param transport_status [Integer] HTTP status returned by Botasaurus
-        def initialize(payload:, transport_status:)
+        # @param payload [Hash{String => Object}] parsed ScrapeSuccess object
+        def initialize(payload:)
           @payload = payload
-          @transport_status = transport_status
+          html
+          diagnostics
         end
 
-        # @return [Boolean] true when upstream classified request as challenge blocked
-        def challenge_block? = error_category == 'challenge_block'
+        # @return [String] rendered HTML body
+        def html
+          value = payload['html']
+          raise BotasaurusServiceError, 'Botasaurus scrape success requires html' unless value.is_a?(String)
 
-        # @return [Boolean] true when the scrape envelope reports a timeout
-        def timeout?
-          transport_status == 504 || error_category == 'timeout'
+          value
         end
-
-        # @return [Boolean] true when scrape transport is not 200 or error is present
-        def upstream_failure?
-          transport_status != 200 || error_message?
-        end
-
-        # @return [String] normalized challenge error message
-        def challenge_message
-          error || 'Botasaurus challenge block detected.'
-        end
-
-        # @return [String] actionable upstream failure summary
-        def upstream_failure_message
-          details = ["status=#{status}"]
-          details << "error_category=#{error_category}" if error_category
-          details << "error=#{error}" if error
-          details << "request_id=#{request_id}" if request_id
-          "Botasaurus scrape failed (#{details.join(', ')})."
-        end
-
-        # @return [String] rendered HTML body (OpenAPI default is empty string)
-        def html = payload.fetch('html', '').to_s
 
         # @return [Hash{String => String}] normalized response headers (null → {})
         def headers
@@ -96,17 +73,21 @@ module Html2rss
           raw_headers.to_h { |key, value| [key.to_s, value.to_s] }
         end
 
-        # @return [Integer] resolved status code (payload status_code or transport status)
+        # @return [Integer, nil] document status_code when present
         def status
           status_code = payload['status_code']
-          status_code.is_a?(Integer) ? status_code : transport_status
+          status_code.is_a?(Integer) ? status_code : nil
         end
 
         # @return [String, nil] final URL reported by upstream
         def final_url = payload['final_url']
 
-        # @return [Hash{String => Object}] allowlisted upstream telemetry (frozen)
-        def transport_meta = payload.slice(*META_KEYS).compact.freeze
+        # @return [Hash{String => Object}] diagnostics plus success-only metadata_error (frozen)
+        def transport_meta
+          meta = diagnostics.dup
+          meta['metadata_error'] = metadata_error if metadata_error
+          meta.freeze
+        end
 
         # @return [Array<Hash{String => Object}>] size-capped XHR/fetch captures (absent → [])
         def xhr_responses
@@ -125,17 +106,13 @@ module Html2rss
 
         private
 
-        attr_reader :payload, :transport_status
+        attr_reader :payload
 
-        def error = payload['error']
+        def diagnostics = BotasaurusContract.diagnostics_from(payload)
 
-        def request_id = payload['request_id']
-
-        def error_category = payload['error_category']
-
-        def error_message?
-          value = error
-          value.is_a?(String) ? !value.empty? : !value.nil?
+        def metadata_error
+          value = payload['metadata_error']
+          value.is_a?(String) && !value.empty? ? value : nil
         end
 
         def normalize_xhr_entry(entry)
@@ -177,6 +154,91 @@ module Html2rss
       end
 
       ##
+      # Parsed OpenAPI ScrapeError envelope (HTTP 400/403/422/502/504).
+      class Error
+        # @param payload [Hash{String => Object}] parsed ScrapeError object
+        # @param transport_status [Integer] HTTP status returned by Botasaurus
+        def initialize(payload:, transport_status:)
+          @payload = payload
+          @transport_status = transport_status
+          error
+          error_category
+          diagnostics
+        end
+
+        # @return [Boolean] true when upstream classified request as challenge blocked
+        def challenge_block? = error_category == 'challenge_block'
+
+        # @return [Boolean] true when the scrape envelope reports a timeout
+        def timeout?
+          transport_status == 504 || error_category == 'timeout'
+        end
+
+        # @return [String] normalized challenge error message
+        def challenge_message
+          [error, challenge_marker].find { |value| value.is_a?(String) && !value.empty? } ||
+            'Botasaurus challenge block detected.'
+        end
+
+        # @return [String] actionable upstream failure summary
+        def failure_message
+          details = ["status=#{transport_status}", "error_category=#{error_category}", "error=#{error}"]
+          details << "request_id=#{request_id}" if request_id
+          "Botasaurus scrape failed (#{details.join(', ')})."
+        end
+
+        private
+
+        attr_reader :payload, :transport_status
+
+        def error
+          value = payload['error']
+          raise BotasaurusServiceError, 'Botasaurus scrape error requires error' unless value.is_a?(String)
+
+          value
+        end
+
+        def error_category
+          value = payload['error_category']
+          return value if ERROR_CATEGORIES.include?(value)
+
+          raise BotasaurusServiceError, 'Botasaurus scrape error requires error_category'
+        end
+
+        def diagnostics = BotasaurusContract.diagnostics_from(payload)
+
+        def request_id = diagnostics['request_id']
+
+        def challenge_marker
+          challenge = diagnostics['challenge']
+          challenge.is_a?(Hash) ? challenge['marker'] : nil
+        end
+      end
+
+      ##
+      # @param payload [Hash{String => Object}] scrape envelope
+      # @return [Hash{String => Object}] allowlisted diagnostics (frozen)
+      # @raise [BotasaurusServiceError] when diagnostics or request_id are missing
+      def self.diagnostics_from(payload)
+        raw = payload['diagnostics']
+        raise BotasaurusServiceError, 'Botasaurus scrape envelope requires diagnostics' unless raw.is_a?(Hash)
+        raise BotasaurusServiceError, 'Botasaurus diagnostics require request_id' if raw['request_id'].to_s.empty?
+
+        sliced = raw.slice(*DIAGNOSTICS_KEYS)
+        sliced['challenge'] = compact_challenge(sliced['challenge'])
+        sliced.compact.freeze
+      end
+
+      # @param challenge [Object] diagnostics.challenge value
+      # @return [Hash{String => Object}, nil]
+      def self.compact_challenge(challenge)
+        return unless challenge.is_a?(Hash)
+
+        challenge.slice(*CHALLENGE_KEYS).compact
+      end
+      private_class_method :compact_challenge
+
+      ##
       # @param url [Html2rss::Url] canonical URL to scrape
       # @param headers [Hash] request headers from context
       # @param options [Hash] validated request.botasaurus options
@@ -186,6 +248,7 @@ module Html2rss
       # @option options [Integer] :max_retries
       # @option options [String] :wait_for_selector
       # @option options [Integer] :wait_timeout_seconds
+      # @option options [Boolean] :scroll
       # @option options [Boolean] :block_images
       # @option options [Boolean] :block_images_and_css
       # @option options [Boolean] :block_trackers
@@ -193,7 +256,7 @@ module Html2rss
       # @option options [Boolean] :headless
       # @option options [String] :proxy
       # @option options [String] :user_agent
-      # @option options [Array<Integer>] :window_size
+      # @option options [Hash] :window_size
       # @option options [String] :lang
       # @option options [Hash] :cookies
       # @option options [Hash] :headers
@@ -213,20 +276,27 @@ module Html2rss
       end
 
       # @param transport_response [Faraday::Response] upstream HTTP response
-      # @return [ParsedResponse]
-      # @raise [BotasaurusServiceError] when payload is not a JSON object
+      # @return [Success, Error]
+      # @raise [BotasaurusServiceError] when payload is not a scrape envelope
       def parse_response(transport_response)
-        payload = JSON.parse(transport_response.body.to_s)
-        raise BotasaurusServiceError, 'Botasaurus response must be a JSON object' unless payload.is_a?(Hash)
+        payload = json_object(transport_response.body.to_s)
+        return Success.new(payload:) if transport_response.status == 200
 
-        ParsedResponse.new(payload:, transport_status: transport_response.status)
-      rescue JSON::ParserError => error
-        raise BotasaurusServiceError, "Botasaurus response JSON parse failed: #{error.message}"
+        Error.new(payload:, transport_status: transport_response.status)
       end
 
       private
 
       attr_reader :url, :headers, :options, :remaining_timeout_seconds
+
+      def json_object(body)
+        payload = JSON.parse(body)
+        return payload if payload.is_a?(Hash)
+
+        raise BotasaurusServiceError, 'Botasaurus response must be a JSON object'
+      rescue JSON::ParserError => error
+        raise BotasaurusServiceError, "Botasaurus response JSON parse failed: #{error.message}"
+      end
 
       def merged_headers
         explicit = options[:headers] || {}

--- a/lib/html2rss/request_service/botasaurus_contract.rb
+++ b/lib/html2rss/request_service/botasaurus_contract.rb
@@ -15,28 +15,6 @@ module Html2rss
         headless: false
       }.freeze
 
-      # Allowlisted request.botasaurus keys forwarded to upstream.
-      OPTION_KEYS = %i[
-        execution_mode
-        navigation_mode
-        max_retries
-        wait_for_selector
-        wait_timeout_seconds
-        scroll
-        scroll_to_bottom
-        block_images
-        block_images_and_css
-        block_trackers
-        wait_for_complete_page_load
-        headless
-        proxy
-        user_agent
-        window_size
-        lang
-        headers
-        cookies
-      ].freeze
-
       # Allowlisted upstream response keys exposed as Response#transport_meta.
       META_KEYS = %w[
         request_id strategy_used render_ms challenge_detected blocked_detected attempts error_category
@@ -51,6 +29,18 @@ module Html2rss
 
       # Botasaurus scrape API Field(..., le=DEFAULT_SCRAPE_TIMEOUT_SECONDS) ceiling.
       MAX_WAIT_TIMEOUT_SECONDS = 20
+
+      class << self
+        ##
+        # Validator-owned request.botasaurus keys, resolved lazily to avoid a load-time
+        # cycle with {Config::Validator::BotasaurusRequestConfig} (which references
+        # {MAX_WAIT_TIMEOUT_SECONDS}).
+        #
+        # @return [Array<Symbol>]
+        def option_keys
+          Config::Validator::BotasaurusRequestConfig.key_map.map { |schema_key| schema_key.name.to_sym }
+        end
+      end
 
       # Parsed Botasaurus response wrapper.
       class ParsedResponse # rubocop:disable Metrics/ClassLength -- payload accessors stay with 422 detail parse
@@ -268,7 +258,7 @@ module Html2rss
       end
 
       def filtered_options
-        OPTION_KEYS.each_with_object({}) do |key, normalized|
+        self.class.option_keys.each_with_object({}) do |key, normalized|
           normalized[key] = options[key] if options.key?(key)
         end
       end

--- a/lib/html2rss/request_service/botasaurus_strategy.rb
+++ b/lib/html2rss/request_service/botasaurus_strategy.rb
@@ -13,6 +13,7 @@ module Html2rss
       def fetch
         parsed_response = post_scrape_request
         raise_if_challenge_blocked!(parsed_response)
+        raise_if_timed_out!(parsed_response)
         raise_if_upstream_failed!(parsed_response)
         build_response(parsed_response)
       end
@@ -37,6 +38,13 @@ module Html2rss
         return unless parsed_response.challenge_block?
 
         raise BlockedSurfaceDetected, "Blocked surface detected: #{parsed_response.challenge_message}"
+      end
+
+      def raise_if_timed_out!(parsed_response)
+        return unless parsed_response.timeout?
+
+        log_timeout!(reason: 'botasaurus_upstream')
+        raise RequestTimedOut, parsed_response.upstream_failure_message
       end
 
       def raise_if_upstream_failed!(parsed_response)

--- a/lib/html2rss/request_service/botasaurus_strategy.rb
+++ b/lib/html2rss/request_service/botasaurus_strategy.rb
@@ -12,9 +12,8 @@ module Html2rss
 
       def fetch
         parsed_response = post_scrape_request
-        raise_if_challenge_blocked!(parsed_response)
-        raise_if_timed_out!(parsed_response)
-        raise_if_upstream_failed!(parsed_response)
+        raise_from_error!(parsed_response) if parsed_response.is_a?(BotasaurusContract::Error)
+
         build_response(parsed_response)
       end
 
@@ -34,23 +33,23 @@ module Html2rss
         )
       end
 
-      def raise_if_challenge_blocked!(parsed_response)
-        return unless parsed_response.challenge_block?
-
-        raise BlockedSurfaceDetected, "Blocked surface detected: #{parsed_response.challenge_message}"
+      def raise_from_error!(error)
+        raise_if_challenge_blocked!(error)
+        raise_if_timed_out!(error)
+        raise BotasaurusServiceError, error.failure_message
       end
 
-      def raise_if_timed_out!(parsed_response)
-        return unless parsed_response.timeout?
+      def raise_if_challenge_blocked!(error)
+        return unless error.challenge_block?
+
+        raise BlockedSurfaceDetected, "Blocked surface detected: #{error.challenge_message}"
+      end
+
+      def raise_if_timed_out!(error)
+        return unless error.timeout?
 
         log_timeout!(reason: 'botasaurus_upstream')
-        raise RequestTimedOut, parsed_response.upstream_failure_message
-      end
-
-      def raise_if_upstream_failed!(parsed_response)
-        return unless parsed_response.upstream_failure?
-
-        raise BotasaurusServiceError, parsed_response.upstream_failure_message
+        raise RequestTimedOut, error.failure_message
       end
 
       def response_url(final_url)

--- a/lib/html2rss/request_service/compressed_body.rb
+++ b/lib/html2rss/request_service/compressed_body.rb
@@ -10,6 +10,7 @@ module Html2rss
     module CompressedBody
       # Gzip stream magic (RFC 1952).
       GZIP_MAGIC = "\x1F\x8B".b.freeze
+      # HTML prefix for unlabeled brotli trial decode. Same object as {Response::HTML_BODY_SNIFF}.
       HTML_BODY_SNIFF = Response::HTML_BODY_SNIFF
 
       module_function

--- a/lib/html2rss/request_service/compressed_body.rb
+++ b/lib/html2rss/request_service/compressed_body.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'brotli'
+require 'stringio'
+require 'zlib'
+
+module Html2rss
+  class RequestService
+    # Decodes gzip/brotli bodies when Content-Encoding is missing or the type is octet-stream.
+    module CompressedBody
+      # Gzip stream magic (RFC 1952).
+      GZIP_MAGIC = "\x1F\x8B".b.freeze
+      # HTML prefix used to accept a brotli trial decode (keep in lockstep with {Response::HTML_BODY_SNIFF}).
+      HTML_BODY_SNIFF = /\A\s*(?:<!DOCTYPE\s+html|<html)/i
+
+      module_function
+
+      # @param body [String, nil] raw response body
+      # @param headers [Hash] response headers (Content-Encoding / Content-Type)
+      # @return [String, nil] decoded body when compressed; otherwise the original body
+      def decode(body, headers: {})
+        return body if body.nil? || body.empty?
+
+        raw = body.to_s.b
+        decode_labeled(raw, headers) || decode_unlabeled(raw, headers) || body
+      end
+
+      def decode_labeled(raw, headers)
+        encodings = content_encodings(headers)
+        return if encodings.empty?
+
+        encodings.reverse.reduce(raw) { |buffer, encoding| inflate(buffer, encoding) || buffer }
+      end
+      module_function :decode_labeled
+      private_class_method :decode_labeled
+
+      def decode_unlabeled(raw, headers)
+        return uncompress_gzip(raw) if raw.start_with?(GZIP_MAGIC)
+        return unless octet_stream?(headers)
+
+        try_brotli(raw)
+      end
+      module_function :decode_unlabeled
+      private_class_method :decode_unlabeled
+
+      def inflate(raw, encoding)
+        case encoding
+        when 'gzip' then uncompress_gzip(raw)
+        when 'deflate' then inflate_deflate(raw)
+        when 'br' then try_brotli(raw, require_html: false)
+        end
+      rescue Zlib::Error, Brotli::Error, ArgumentError
+        nil
+      end
+      module_function :inflate
+      private_class_method :inflate
+
+      def uncompress_gzip(raw)
+        Zlib::GzipReader.wrap(StringIO.new(raw), encoding: 'ASCII-8BIT', &:read)
+      end
+      module_function :uncompress_gzip
+      private_class_method :uncompress_gzip
+
+      def inflate_deflate(raw)
+        inflater = nil
+        Zlib::Inflate.inflate(raw)
+      rescue Zlib::DataError
+        inflater = Zlib::Inflate.new(-Zlib::MAX_WBITS)
+        inflater.inflate(raw)
+      ensure
+        inflater&.close
+      end
+      module_function :inflate_deflate
+      private_class_method :inflate_deflate
+
+      def try_brotli(raw, require_html: true)
+        inflated = Brotli.inflate(raw)
+        return inflated unless require_html
+        return inflated if inflated.b.match?(HTML_BODY_SNIFF)
+
+        nil
+      rescue Brotli::Error, ArgumentError
+        nil
+      end
+      module_function :try_brotli
+      private_class_method :try_brotli
+
+      def content_encodings(headers)
+        header(headers, 'content-encoding').to_s.split(',').map { |value| value.strip.downcase }.reject(&:empty?)
+      end
+      module_function :content_encodings
+      private_class_method :content_encodings
+
+      def octet_stream?(headers)
+        header(headers, 'content-type').to_s.downcase.include?('application/octet-stream')
+      end
+      module_function :octet_stream?
+      private_class_method :octet_stream?
+
+      def header(headers, name)
+        headers.fetch(name) do
+          headers.find { |key, _value| key.to_s.casecmp?(name) }&.last
+        end
+      end
+      module_function :header
+      private_class_method :header
+    end
+  end
+end

--- a/lib/html2rss/request_service/compressed_body.rb
+++ b/lib/html2rss/request_service/compressed_body.rb
@@ -10,8 +10,7 @@ module Html2rss
     module CompressedBody
       # Gzip stream magic (RFC 1952).
       GZIP_MAGIC = "\x1F\x8B".b.freeze
-      # HTML prefix used to accept a brotli trial decode (keep in lockstep with {Response::HTML_BODY_SNIFF}).
-      HTML_BODY_SNIFF = /\A\s*(?:<!DOCTYPE\s+html|<html)/i
+      HTML_BODY_SNIFF = Response::HTML_BODY_SNIFF
 
       module_function
 

--- a/lib/html2rss/request_service/faraday_strategy.rb
+++ b/lib/html2rss/request_service/faraday_strategy.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'brotli'
 require 'faraday'
 require 'faraday/follow_redirects'
 require 'faraday/gzip'
@@ -89,7 +90,8 @@ module Html2rss
       end
 
       def build_response(response)
-        Response.new(body: response.body, headers: response.headers, url: response_url(response),
+        Response.new(body: CompressedBody.decode(response.body, headers: response.headers),
+                     headers: response.headers, url: response_url(response),
                      status: response.status)
       end
 

--- a/lib/html2rss/request_service/policy.rb
+++ b/lib/html2rss/request_service/policy.rb
@@ -115,7 +115,7 @@ module Html2rss
       # @raise [UnsupportedUrlScheme] if the redirect downgrades from HTTPS to HTTP
       def validate_redirect!(from_url:, to_url:, origin_url:, relation:)
         if from_url.scheme == 'https' && to_url.scheme == 'http'
-          raise UnsupportedUrlScheme, 'Redirect downgraded from https to http'
+          raise UnsupportedUrlScheme, "Redirect downgraded from #{from_url} to #{to_url}"
         end
 
         validate_request!(url: to_url, origin_url:, relation:)

--- a/lib/html2rss/request_service/response.rb
+++ b/lib/html2rss/request_service/response.rb
@@ -72,14 +72,16 @@ module Html2rss
       # @return [Boolean] whether response content is JSON
       def json_response? = content_type.include?('application/json')
 
-      # @return [Boolean] whether response content is HTML
-      def html_response? = content_type.include?('text/html')
+      # @return [Boolean] whether response content is HTML (header or sniffed body, never JSON)
+      def html_response?
+        content_type.include?('text/html') || (!json_response? && html_looking_body?)
+      end
 
       ##
       # @return [Nokogiri::HTML::Document, Hash] the parsed body of the response, frozen object
       # @raise [UnsupportedResponseContentType] if the content type is not supported
       def parsed_body
-        @parsed_body ||= if html_document?
+        @parsed_body ||= if html_response?
                            parse_html_document
                          elsif json_response?
                            JSON.parse(body, symbolize_names: true).freeze
@@ -136,10 +138,6 @@ module Html2rss
 
       def meta_charset(bytes)
         bytes.byteslice(0, META_CHARSET_BYTES).to_s[CHARSET_PARAMETER, 1]
-      end
-
-      def html_document?
-        html_response? || (!json_response? && html_looking_body?)
       end
 
       def html_looking_body?

--- a/lib/html2rss/request_service/response.rb
+++ b/lib/html2rss/request_service/response.rb
@@ -12,6 +12,9 @@ module Html2rss
       # Default when a strategy does not capture sub-resource responses.
       EMPTY_CAPTURED_RESPONSES = [].freeze
 
+      # Bodies that look like HTML even when Content-Type is missing, empty, or wrong.
+      HTML_BODY_SNIFF = /\A\s*(?:<!DOCTYPE\s+html|<html)/i
+
       ##
       # @param body [String] the body of the response
       # @param url [Html2rss::Url] the final request URL
@@ -71,11 +74,8 @@ module Html2rss
       # @return [Nokogiri::HTML::Document, Hash] the parsed body of the response, frozen object
       # @raise [UnsupportedResponseContentType] if the content type is not supported
       def parsed_body
-        @parsed_body ||= if html_response?
-                           Nokogiri::HTML(body).tap do |doc|
-                             # Remove comments from the document to avoid processing irrelevant content
-                             doc.xpath('//comment()').each(&:remove)
-                           end.freeze
+        @parsed_body ||= if html_document?
+                           parse_html_document
                          elsif json_response?
                            JSON.parse(body, symbolize_names: true).freeze
                          else
@@ -91,6 +91,20 @@ module Html2rss
         headers.fetch(name) do
           headers.find { |key, _value| key.casecmp?(name) }&.last
         end
+      end
+
+      def parse_html_document
+        Nokogiri::HTML(body).tap do |doc|
+          doc.xpath('//comment()').each(&:remove)
+        end.freeze
+      end
+
+      def html_document?
+        html_response? || (!json_response? && html_looking_body?)
+      end
+
+      def html_looking_body?
+        body.to_s.match?(HTML_BODY_SNIFF)
       end
     end
   end

--- a/lib/html2rss/request_service/response.rb
+++ b/lib/html2rss/request_service/response.rb
@@ -14,6 +14,11 @@ module Html2rss
 
       # Bodies that look like HTML even when Content-Type is missing, empty, or wrong.
       HTML_BODY_SNIFF = /\A\s*(?:<!DOCTYPE\s+html|<html)/i
+      # Charset from Content-Type or a leading <meta charset>.
+      CHARSET_PARAMETER = /charset\s*=\s*["']?([\w.:-]+)/i
+      # Bytes scanned for a meta charset hint (HTML spec looks at the first 1024).
+      META_CHARSET_BYTES = 2048
+      private_constant :CHARSET_PARAMETER, :META_CHARSET_BYTES
 
       ##
       # @param body [String] the body of the response
@@ -94,9 +99,43 @@ module Html2rss
       end
 
       def parse_html_document
-        Nokogiri::HTML(body).tap do |doc|
+        Nokogiri::HTML(decoded_html_body).tap do |doc|
           doc.xpath('//comment()').each(&:remove)
         end.freeze
+      end
+
+      def decoded_html_body
+        bytes = body.to_s.b
+        transcode_html(bytes, header_charset || meta_charset(bytes))
+      end
+
+      def transcode_html(bytes, charset)
+        encoding = html_encoding_for(charset)
+        return utf8_scrub(bytes) unless encoding
+
+        bytes.dup.force_encoding(encoding).encode(Encoding::UTF_8)
+      rescue Encoding::UndefinedConversionError, Encoding::InvalidByteSequenceError
+        utf8_scrub(bytes)
+      end
+
+      def html_encoding_for(charset)
+        return if charset.nil? || utf8_charset?(charset)
+
+        Encoding.find(charset)
+      rescue ArgumentError
+        nil
+      end
+
+      def utf8_charset?(charset) = charset.to_s.downcase.gsub(/[\s_-]/, '') == 'utf8'
+
+      def utf8_scrub(bytes) = bytes.dup.force_encoding(Encoding::UTF_8).scrub
+
+      def header_charset
+        content_type[CHARSET_PARAMETER, 1]
+      end
+
+      def meta_charset(bytes)
+        bytes.byteslice(0, META_CHARSET_BYTES).to_s[CHARSET_PARAMETER, 1]
       end
 
       def html_document?
@@ -104,7 +143,7 @@ module Html2rss
       end
 
       def html_looking_body?
-        body.to_s.match?(HTML_BODY_SNIFF)
+        body.to_s.b.match?(HTML_BODY_SNIFF)
       end
     end
   end

--- a/lib/html2rss/url.rb
+++ b/lib/html2rss/url.rb
@@ -2,6 +2,7 @@
 
 require 'addressable/uri'
 require 'cgi'
+require 'ipaddr'
 require 'nokogiri'
 
 module Html2rss
@@ -152,6 +153,16 @@ module Html2rss
     # @return [String, nil] URI host component
     def host = @uri.host
 
+    # Registrable domain (eTLD+1). Same-site hosts like www.wp.pl and wiadomosci.wp.pl
+    # share `wp.pl`. IP literals stay the host so 1.2.3.4 is not treated as `3.4`.
+    #
+    # @return [String, nil]
+    def domain
+      return host if ip_address_host?
+
+      @uri.domain || host
+    end
+
     # @return [Integer, nil] URI port component
     def port = @uri.port
 
@@ -281,6 +292,15 @@ module Html2rss
     #
     # @return [String] the debug representation
     def inspect = "#<#{self.class}:#{object_id} @uri=#{@uri.inspect}>"
+
+    private
+
+    def ip_address_host?
+      IPAddr.new(host.to_s)
+      true
+    rescue IPAddr::Error
+      false
+    end
   end
   # rubocop:enable Metrics/ClassLength
 end

--- a/schema/html2rss-config.schema.json
+++ b/schema/html2rss-config.schema.json
@@ -693,12 +693,6 @@
                 "type": "null"
               }
             },
-            "scroll_to_bottom": {
-              "type": "boolean",
-              "not": {
-                "type": "null"
-              }
-            },
             "block_images": {
               "type": "boolean",
               "not": {
@@ -738,13 +732,27 @@
               "minLength": 1
             },
             "window_size": {
-              "type": "array",
-              "items": {
-                "minLength": 2,
-                "maxLength": 2,
-                "type": "integer",
-                "exclusiveMinimum": 0
-              }
+              "type": "object",
+              "properties": {
+                "width": {
+                  "type": "integer",
+                  "not": {
+                    "type": "null"
+                  },
+                  "exclusiveMinimum": 0
+                },
+                "height": {
+                  "type": "integer",
+                  "not": {
+                    "type": "null"
+                  },
+                  "exclusiveMinimum": 0
+                }
+              },
+              "required": [
+                "width",
+                "height"
+              ]
             },
             "lang": {
               "type": "string",
@@ -757,7 +765,8 @@
               "type": "object"
             }
           },
-          "required": []
+          "required": [],
+          "additionalProperties": false
         },
         "local_file_path": {
           "type": "string",

--- a/schema/html2rss-config.schema.json
+++ b/schema/html2rss-config.schema.json
@@ -684,7 +684,8 @@
               "not": {
                 "type": "null"
               },
-              "exclusiveMinimum": 0
+              "exclusiveMinimum": 0,
+              "maximum": 20
             },
             "scroll": {
               "type": "boolean",

--- a/schema/html2rss-config.schema.json
+++ b/schema/html2rss-config.schema.json
@@ -684,7 +684,7 @@
               "not": {
                 "type": "null"
               },
-              "exclusiveMinimum": 0,
+              "minimum": 1,
               "maximum": 20
             },
             "scroll": {

--- a/schema/html2rss-config.schema.json
+++ b/schema/html2rss-config.schema.json
@@ -752,7 +752,8 @@
               "required": [
                 "width",
                 "height"
-              ]
+              ],
+              "additionalProperties": false
             },
             "lang": {
               "type": "string",

--- a/spec/lib/html2rss/auto_source/cleanup_spec.rb
+++ b/spec/lib/html2rss/auto_source/cleanup_spec.rb
@@ -115,6 +115,31 @@ RSpec.describe Html2rss::AutoSource::Cleanup do
       end
     end
 
+    context 'when article hosts share a registrable domain' do
+      let(:url) { Html2rss::Url.from_absolute('https://www.wp.pl/') }
+      let(:articles) do
+        [
+          instance_double(Html2rss::Article,
+                          valid?: true,
+                          url: Html2rss::Url.from_absolute('https://wiadomosci.wp.pl/story-one'),
+                          title: 'Wiadomosci Portal Story Title Words'),
+          instance_double(Html2rss::Article,
+                          valid?: true,
+                          url: Html2rss::Url.from_absolute('https://film.wp.pl/story-two'),
+                          title: 'Film Portal Story Title Words'),
+          instance_double(Html2rss::Article,
+                          valid?: true,
+                          url: Html2rss::Url.from_absolute('https://otherdomain.com/story-three'),
+                          title: 'Offsite Portal Story Title Words')
+        ]
+      end
+
+      it 'keeps same-site portal hosts and still drops true off-site', :aggregate_failures do
+        expect(cleaned.map { |article| article.url.host }).to contain_exactly('wiadomosci.wp.pl', 'film.wp.pl')
+        expect(result.drop_tallies['different_domain']).to eq(1)
+      end
+    end
+
     it 'rejects titles with fewer than three words' do
       expect(cleaned).not_to include(articles[5])
     end
@@ -198,6 +223,8 @@ RSpec.describe Html2rss::AutoSource::Cleanup do
         { title: 'Hello {{article_title}} world token', reason: :template },
         { title: 'Jobs in Berlin', reason: nil },
         { title: '5 Wahrheiten über die deutsche Leichtathletik', reason: nil },
+        { title: '{text: "Poland election results surprise analysts"}', reason: :json_blob },
+        { title: '{"text":"Onet widget headline extra words"}', reason: :json_blob },
         # First-match pin: agency-only credit beats slug shape for hyphenated CMS ids.
         { title: 'AFP', reason: :credit }
       ].each_with_index do |example, index|

--- a/spec/lib/html2rss/auto_source_spec.rb
+++ b/spec/lib/html2rss/auto_source_spec.rb
@@ -415,6 +415,35 @@ RSpec.describe Html2rss::AutoSource do
         expect(article.scraper).to eq(Html2rss::AutoSource::Scraper::Microdata)
       end
     end
+
+    context 'when the listing is wrapping a.card links (ISS Africa shape)' do
+      let(:url) { Html2rss::Url.from_absolute('https://issafrica.org/iss-today') }
+      let(:body) do
+        cards = [
+          ['/iss-today/sahel-conflict-needs-more-attention', 'Sahel conflict needs more attention today'],
+          ['/iss-today/west-africa-coup-watch-briefing', 'West Africa coup watch briefing today'],
+          ['/iss-today/sudan-peace-talks-stall-again', 'Sudan peace talks stall again this week']
+        ]
+        items = cards.map do |href, title|
+          <<~CARD
+            <a class="card" href="#{href}">
+              <div class="card__image"><img src="/img/#{href.split('/').last}.jpg" alt=""></div>
+              <div class="card__content">
+                <h3>#{title}</h3>
+                <p>Teaser line for the ISS Today briefing.</p>
+              </div>
+            </a>
+          CARD
+        end.join
+        "<!DOCTYPE html><html><body>#{items}</body></html>"
+      end
+
+      it 'admits at least one article from the wrapping cards', :aggregate_failures do
+        expect(articles.size).to be >= 1
+        expect(articles.map { |article| article.url.to_s }).to all(include('/iss-today/'))
+        expect(articles.map(&:title)).to all(match(/\A\S+(?:\s+\S+){2,}/))
+      end
+    end
   end
 end
 # rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/lib/html2rss/capture_spec.rb
+++ b/spec/lib/html2rss/capture_spec.rb
@@ -5,11 +5,11 @@ require 'spec_helper'
 RSpec.describe Html2rss::Capture do
   let(:url) { 'https://example.com/blog' }
 
-  def html_response(body, page_url: url)
+  def html_response(body, page_url: url, content_type: 'text/html')
     Html2rss::RequestService::Response.new(
       body:,
       url: Html2rss::Url.from_absolute(page_url),
-      headers: { 'content-type' => 'text/html' }
+      headers: { 'content-type' => content_type }
     )
   end
 
@@ -44,6 +44,21 @@ RSpec.describe Html2rss::Capture do
         )
         expect(result.config[:channel]).to include(url:, title: a_string_matching(/\S/), time_zone: 'UTC')
         expect(result.channel_title).to eq(result.config.dig(:channel, :title))
+      end
+    end
+
+    context 'when HTML is labeled octet-stream' do
+      subject(:result) do
+        response = html_response(File.read('spec/fixtures/local_feed_test.html'),
+                                 content_type: 'application/octet-stream')
+        articles = Html2rss::AutoSource.new(response, Html2rss::AutoSource::DEFAULT_CONFIG).articles
+        stub_outcome(response, articles:)
+        described_class.new(url).build
+      end
+
+      it 'derives selectors from sniffed HTML', :aggregate_failures do
+        expect(result.has_selectors).to be true
+        expect(result.config[:selectors]).to eq(items: { selector: 'div.item', enhance: true })
       end
     end
 

--- a/spec/lib/html2rss/capture_spec.rb
+++ b/spec/lib/html2rss/capture_spec.rb
@@ -94,6 +94,50 @@ RSpec.describe Html2rss::Capture do
       # rubocop:enable RSpec/ExampleLength
     end
 
+    it 'lifts heading-link item roots to the research card', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      html = <<~HTML
+        <html><body>
+          <article class="research-card">
+            <h3><a href="/pub/1">Title of the first publication about research</a></h3>
+            <p>Sibling teaser about the first research paper with extra words.</p>
+          </article>
+          <article class="research-card">
+            <h3><a href="/pub/2">Title of the second publication about research</a></h3>
+            <p>Sibling teaser about the second research paper with extra words.</p>
+          </article>
+        </body></html>
+      HTML
+      response = html_response(html)
+      articles = Html2rss::AutoSource.new(response, Html2rss::AutoSource::DEFAULT_CONFIG).articles
+      stub_outcome(response, articles:)
+
+      items = described_class.new(url).build.config.dig(:selectors, :items)
+      expect(items[:enhance]).to be true
+      expect(items[:selector]).to eq('article.research-card')
+    end
+
+    it 'keeps Equinor-style wrapping anchors as the item root', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      html = <<~HTML
+        <html><body>
+          <a href="/news/one">
+            <h2>Equinor starts first offshore wind project</h2>
+            <p>The project will add capacity to the North Sea grid this decade.</p>
+          </a>
+          <a href="/news/two">
+            <h2>Equinor starts second offshore wind project</h2>
+            <p>The project will add capacity to the North Sea grid this decade.</p>
+          </a>
+        </body></html>
+      HTML
+      response = html_response(html)
+      articles = Html2rss::AutoSource.new(response, Html2rss::AutoSource::DEFAULT_CONFIG).articles
+      stub_outcome(response, articles:)
+
+      items = described_class.new(url).build.config.dig(:selectors, :items)
+      expect(items[:enhance]).to be true
+      expect(items[:selector]).to eq('a')
+    end
+
     context 'when selector derivation raises ArgumentError' do
       subject(:result) { described_class.new(url).build }
 

--- a/spec/lib/html2rss/capture_spec.rb
+++ b/spec/lib/html2rss/capture_spec.rb
@@ -116,6 +116,37 @@ RSpec.describe Html2rss::Capture do
       expect(items[:selector]).to eq('article.research-card')
     end
 
+    it 'lifts list-strategy heading roots to the enclosing research card', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      html = <<~HTML
+        <html><body>
+          <article class="research-card">
+            <h3><a href="/pub/1">Title of the first publication about research</a></h3>
+            <p>Sibling teaser about the first research paper with extra words.</p>
+          </article>
+          <article class="research-card">
+            <h3><a href="/pub/2">Title of the second publication about research</a></h3>
+            <p>Sibling teaser about the second research paper with extra words.</p>
+          </article>
+        </body></html>
+      HTML
+      response = html_response(html)
+      articles = Html2rss::AutoSource.new(response, Html2rss::AutoSource::DEFAULT_CONFIG).articles
+      stub_outcome(response, articles:)
+
+      allow(Html2rss::AutoSource::Segmenter).to receive(:call) do |sst, strategy:, **|
+        next [] unless strategy == :list
+
+        sst.index.each_node.select { |node| node.name.to_s == 'h3' }.map do |heading|
+          anchor = heading.children.find { |child| child.name.to_s == 'a' }
+          instance_double(Html2rss::AutoSource::Segment, primary_link: anchor, root_node: heading)
+        end
+      end
+
+      items = described_class.new(url).build.config.dig(:selectors, :items)
+      expect(items[:enhance]).to be true
+      expect(items[:selector]).to eq('article.research-card')
+    end
+
     it 'keeps Equinor-style wrapping anchors as the item root', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
       html = <<~HTML
         <html><body>

--- a/spec/lib/html2rss/config/schema_spec.rb
+++ b/spec/lib/html2rss/config/schema_spec.rb
@@ -139,10 +139,9 @@ RSpec.describe Html2rss::Config::Schema do
     end
 
     it 'exposes botasaurus request options and constraints', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-      botasaurus = json_schema.dig('properties', 'request', 'properties', 'botasaurus', 'properties')
+      botasaurus_schema = json_schema.dig('properties', 'request', 'properties', 'botasaurus')
+      botasaurus = botasaurus_schema.fetch('properties')
       window_size = botasaurus.fetch('window_size')
-      min_window_size = window_size['minItems'] || window_size.dig('items', 'minLength')
-      max_window_size = window_size['maxItems'] || window_size.dig('items', 'maxLength')
 
       expect(botasaurus.fetch('execution_mode').fetch('enum'))
         .to contain_exactly('auto', 'request', 'browser')
@@ -153,12 +152,14 @@ RSpec.describe Html2rss::Config::Schema do
       expect(botasaurus.dig('wait_timeout_seconds', 'minimum')).to eq(1)
       expect(botasaurus.dig('wait_timeout_seconds', 'maximum')).to eq(20)
       expect(botasaurus).to have_key('scroll')
-      expect(botasaurus).to have_key('scroll_to_bottom')
+      expect(botasaurus).not_to have_key('scroll_to_bottom')
       expect(botasaurus).to have_key('block_trackers')
       expect(botasaurus).to have_key('cookies')
       expect(botasaurus).to have_key('headers')
-      expect(min_window_size).to eq(2)
-      expect(max_window_size).to eq(2)
+      expect(window_size.fetch('type')).to eq('object')
+      expect(window_size.dig('properties', 'width')).to include('exclusiveMinimum' => 0)
+      expect(window_size.dig('properties', 'height')).to include('exclusiveMinimum' => 0)
+      expect(botasaurus_schema.fetch('additionalProperties')).to be false
     end
   end
 

--- a/spec/lib/html2rss/config/schema_spec.rb
+++ b/spec/lib/html2rss/config/schema_spec.rb
@@ -157,6 +157,7 @@ RSpec.describe Html2rss::Config::Schema do
       expect(botasaurus).to have_key('cookies')
       expect(botasaurus).to have_key('headers')
       expect(window_size.fetch('type')).to eq('object')
+      expect(window_size.fetch('additionalProperties')).to be false
       expect(window_size.dig('properties', 'width')).to include('exclusiveMinimum' => 0)
       expect(window_size.dig('properties', 'height')).to include('exclusiveMinimum' => 0)
       expect(botasaurus_schema.fetch('additionalProperties')).to be false

--- a/spec/lib/html2rss/config/schema_spec.rb
+++ b/spec/lib/html2rss/config/schema_spec.rb
@@ -151,6 +151,7 @@ RSpec.describe Html2rss::Config::Schema do
       expect(botasaurus.dig('max_retries', 'minimum')).to eq(0)
       expect(botasaurus.dig('max_retries', 'maximum')).to eq(3)
       expect(botasaurus.dig('wait_timeout_seconds', 'exclusiveMinimum')).to eq(0)
+      expect(botasaurus.dig('wait_timeout_seconds', 'maximum')).to eq(20)
       expect(botasaurus).to have_key('scroll')
       expect(botasaurus).to have_key('scroll_to_bottom')
       expect(botasaurus).to have_key('block_trackers')

--- a/spec/lib/html2rss/config/schema_spec.rb
+++ b/spec/lib/html2rss/config/schema_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Html2rss::Config::Schema do
         .to contain_exactly('auto', 'get', 'google_get', 'google_get_bypass', 'organic_get')
       expect(botasaurus.dig('max_retries', 'minimum')).to eq(0)
       expect(botasaurus.dig('max_retries', 'maximum')).to eq(3)
-      expect(botasaurus.dig('wait_timeout_seconds', 'exclusiveMinimum')).to eq(0)
+      expect(botasaurus.dig('wait_timeout_seconds', 'minimum')).to eq(1)
       expect(botasaurus.dig('wait_timeout_seconds', 'maximum')).to eq(20)
       expect(botasaurus).to have_key('scroll')
       expect(botasaurus).to have_key('scroll_to_bottom')

--- a/spec/lib/html2rss/config_spec.rb
+++ b/spec/lib/html2rss/config_spec.rb
@@ -420,7 +420,7 @@ RSpec.describe Html2rss::Config do
               headless: false,
               proxy: 'http://user:pass@proxy:8080',
               user_agent: 'Mozilla/5.0',
-              window_size: [1920, 1080],
+              window_size: { width: 1920, height: 1080 },
               lang: 'en-US'
             }
           }
@@ -471,20 +471,56 @@ RSpec.describe Html2rss::Config do
       end
     end
 
-    context 'when botasaurus window_size length is not exactly two items' do
+    context 'when botasaurus window_size is not a width/height object' do
       let(:config) do
         {
           channel: { url: 'http://example.com' },
           selectors: { items: { selector: '.item' }, title: { selector: 'h2' } },
           request: {
             botasaurus: {
-              window_size: [1920]
+              window_size: [1920, 1080]
             }
           }
         }
       end
 
       it 'rejects the botasaurus config' do
+        expect(described_class.validate(config)).to be_failure
+      end
+    end
+
+    context 'when botasaurus window_size omits height' do
+      let(:config) do
+        {
+          channel: { url: 'http://example.com' },
+          selectors: { items: { selector: '.item' }, title: { selector: 'h2' } },
+          request: {
+            botasaurus: {
+              window_size: { width: 1920 }
+            }
+          }
+        }
+      end
+
+      it 'rejects the botasaurus config' do
+        expect(described_class.validate(config)).to be_failure
+      end
+    end
+
+    context 'when botasaurus includes removed scroll_to_bottom' do
+      let(:config) do
+        {
+          channel: { url: 'http://example.com' },
+          selectors: { items: { selector: '.item' }, title: { selector: 'h2' } },
+          request: {
+            botasaurus: {
+              scroll_to_bottom: true
+            }
+          }
+        }
+      end
+
+      it 'rejects the unknown key' do
         expect(described_class.validate(config)).to be_failure
       end
     end

--- a/spec/lib/html2rss/config_spec.rb
+++ b/spec/lib/html2rss/config_spec.rb
@@ -435,6 +435,22 @@ RSpec.describe Html2rss::Config do
       end
     end
 
+    context 'when botasaurus wait_timeout_seconds exceeds the API maximum' do
+      let(:config) do
+        {
+          channel: { url: 'http://example.com' },
+          selectors: { items: { selector: '.item' }, title: { selector: 'h2' } },
+          request: {
+            botasaurus: { wait_timeout_seconds: 45 }
+          }
+        }
+      end
+
+      it 'rejects an explicit wait above the Botasaurus API cap' do
+        expect(described_class.validate(config)).to be_failure
+      end
+    end
+
     context 'when request includes invalid botasaurus options' do
       let(:config) do
         {
@@ -644,6 +660,20 @@ RSpec.describe Html2rss::Config do
 
       it 'raises an ArgumentError' do
         expect { instance }.to raise_error(described_class::InvalidConfig, /Invalid configuration:/)
+      end
+    end
+
+    context 'when botasaurus wait_timeout_seconds exceeds the API maximum' do
+      let(:config) do
+        {
+          channel: { url: 'http://example.com' },
+          selectors: { items: { selector: '.item' }, title: { selector: 'h2' } },
+          request: { botasaurus: { wait_timeout_seconds: 45 } }
+        }
+      end
+
+      it 'raises InvalidConfig naming wait_timeout_seconds' do
+        expect { instance }.to raise_error(described_class::InvalidConfig, /wait_timeout_seconds/)
       end
     end
   end

--- a/spec/lib/html2rss/config_spec.rb
+++ b/spec/lib/html2rss/config_spec.rb
@@ -489,6 +489,24 @@ RSpec.describe Html2rss::Config do
       end
     end
 
+    context 'when botasaurus window_size includes an unknown property' do
+      let(:config) do
+        {
+          channel: { url: 'http://example.com' },
+          selectors: { items: { selector: '.item' }, title: { selector: 'h2' } },
+          request: {
+            botasaurus: {
+              window_size: { width: 1920, height: 1080, extra: 1 }
+            }
+          }
+        }
+      end
+
+      it 'rejects the botasaurus config' do
+        expect(described_class.validate(config)).to be_failure
+      end
+    end
+
     context 'when botasaurus window_size omits height' do
       let(:config) do
         {

--- a/spec/lib/html2rss/feed_pipeline/auto_fallback_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline/auto_fallback_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Html2rss::FeedPipeline::AutoFallback do
+  describe '::NON_FALLBACK_ERRORS' do
+    it 'does not abort auto when Faraday reports an unsupported content type' do
+      expect(described_class::NON_FALLBACK_ERRORS)
+        .not_to include(Html2rss::RequestService::UnsupportedResponseContentType)
+    end
+  end
+end

--- a/spec/lib/html2rss/feed_pipeline_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline_spec.rb
@@ -4,11 +4,11 @@ require 'spec_helper'
 
 RSpec.describe Html2rss::FeedPipeline do
   let(:build_response) do
-    lambda do |body:, url: 'https://example.com/news'|
+    lambda do |body:, url: 'https://example.com/news', headers: { 'content-type' => 'text/html' }|
       Html2rss::RequestService::Response.new(
         body:,
         url: Html2rss::Url.from_absolute(url),
-        headers: { 'content-type' => 'text/html' },
+        headers:,
         status: 200
       )
     end
@@ -242,6 +242,64 @@ RSpec.describe Html2rss::FeedPipeline do
             expect(error.surface_category).to eq(:app_shell)
             expect(error.message).to include('app-shell surface detected')
           end
+        end
+      end
+
+      context 'when Faraday raises UnsupportedResponseContentType' do # rubocop:disable RSpec/NestedGroups, RSpec/MultipleMemoizedHelpers
+        let(:strategy_results) do
+          {
+            faraday: Html2rss::RequestService::UnsupportedResponseContentType.new(
+              'Unsupported content type: application/octet-stream'
+            ),
+            botasaurus: item_response
+          }
+        end
+
+        it 'falls back to Botasaurus instead of aborting auto', :aggregate_failures do
+          rss = pipeline.to_result.to_rss
+
+          expect(rss.items.map(&:title)).to eq(['bota'])
+          expect(Html2rss::RequestService).to have_received(:execute).with(anything, strategy: :faraday).once
+          expect(Html2rss::RequestService).to have_received(:execute).with(anything, strategy: :botasaurus).once
+        end
+      end
+
+      context 'when Faraday returns HTML labeled as octet-stream' do # rubocop:disable RSpec/NestedGroups, RSpec/MultipleMemoizedHelpers
+        let(:strategy_results) do
+          {
+            faraday: build_response.call(
+              body: '<html><body><article><h1>seznam</h1></article></body></html>',
+              headers: { 'content-type' => 'application/octet-stream' }
+            ),
+            botasaurus: item_response
+          }
+        end
+
+        it 'extracts Faraday HTML without calling Botasaurus', :aggregate_failures do
+          rss = pipeline.to_result.to_rss
+
+          expect(rss.items.map(&:title)).to eq(['seznam'])
+          expect(Html2rss::RequestService).to have_received(:execute).with(anything, strategy: :faraday).once
+          expect(Html2rss::RequestService).not_to have_received(:execute).with(anything, strategy: :botasaurus)
+        end
+      end
+
+      context 'when Faraday returns non-HTML octet-stream' do # rubocop:disable RSpec/NestedGroups, RSpec/MultipleMemoizedHelpers
+        let(:strategy_results) do
+          {
+            faraday: build_response.call(
+              body: "PK\x03\x04not-html",
+              headers: { 'content-type' => 'application/octet-stream' }
+            ),
+            botasaurus: item_response
+          }
+        end
+
+        it 'records the Faraday error and uses Botasaurus', :aggregate_failures do
+          rss = pipeline.to_result.to_rss
+
+          expect(rss.items.map(&:title)).to eq(['bota'])
+          expect(Html2rss::RequestService).to have_received(:execute).with(anything, strategy: :botasaurus).once
         end
       end
 

--- a/spec/lib/html2rss/html/article_rules/description_spec.rb
+++ b/spec/lib/html2rss/html/article_rules/description_spec.rb
@@ -36,5 +36,30 @@ RSpec.describe Html2rss::Html::ArticleRules::Description do
       expect(described_class.date_shaped?("a#{' ' * 10_000}")).to be(false)
       expect(described_class.date_shaped?("a - #{'  ' * 5_000}")).to be(false)
     end
+
+    it 'accepts a Nokia-shaped pipe date with spaced comma and clock zone' do
+      expect(described_class.date_shaped?('August 06 , 2026 | 13:00 PM Europe/Amsterdam')).to be(true)
+    end
+
+    it 'accepts a Telenor-shaped leading type-chip with juli' do
+      expect(described_class.date_shaped?('Press release • 16 juli, 2026')).to be(true)
+    end
+  end
+
+  describe '.date_core Nokia/Telenor fragments' do
+    it 'keeps the calendar day from a pipe clock line' do
+      expect(described_class.date_core('August 06 , 2026 | 13:00 PM Europe/Amsterdam'))
+        .to match(/August 06\s*,?\s*2026/)
+    end
+  end
+
+  describe '.keep?' do
+    it 'drops a Telenor-shaped type-chip date line' do
+      expect(described_class.keep?('Press release • 16 juli, 2026')).to be(false)
+    end
+
+    it 'keeps a longer read-more sentence' do
+      expect(described_class.keep?('Read more about the trial')).to be(true)
+    end
   end
 end

--- a/spec/lib/html2rss/html/article_rules/description_spec.rb
+++ b/spec/lib/html2rss/html/article_rules/description_spec.rb
@@ -41,6 +41,13 @@ RSpec.describe Html2rss::Html::ArticleRules::Description do
       expect(described_class.date_shaped?('August 06 , 2026 | 13:00 PM Europe/Amsterdam')).to be(true)
     end
 
+    it 'rejects a clock plus teaser after a date separator', :aggregate_failures do
+      expect(described_class.date_shaped?('12 March 2024 - 10:00 Team announces a new reactor design'))
+        .to be(false)
+      expect(described_class.date_shaped?('12 March 2024 | 10:00 Team announces a new reactor design'))
+        .to be(false)
+    end
+
     it 'accepts a Telenor-shaped leading type-chip with juli' do
       expect(described_class.date_shaped?('Press release • 16 juli, 2026')).to be(true)
     end
@@ -60,6 +67,15 @@ RSpec.describe Html2rss::Html::ArticleRules::Description do
 
     it 'keeps a longer read-more sentence' do
       expect(described_class.keep?('Read more about the trial')).to be(true)
+    end
+
+    it 'keeps a teaser that follows a clock, not the whole line as date chrome', :aggregate_failures do
+      expect(described_class.keep?('12 March 2024 - 10:00 Team announces a new reactor design')).to be(true)
+      expect(described_class.keep?('12 March 2024 | 10:00 Team announces a new reactor design')).to be(true)
+    end
+
+    it 'still drops a Nokia-shaped pipe clock line as description chrome' do
+      expect(described_class.keep?('August 06 , 2026 | 13:00 PM Europe/Amsterdam')).to be(false)
     end
   end
 end

--- a/spec/lib/html2rss/html/card_walk_spec.rb
+++ b/spec/lib/html2rss/html/card_walk_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Html2rss::Html::CardWalk do
+  describe '.miss?' do
+    it 'climbs only heading/anchor items that lack leftover description and date', :aggregate_failures do
+      expect(described_class.miss?(heading_or_anchor_item: true, published_at: nil, description: nil)).to be true
+      expect(described_class.miss?(heading_or_anchor_item: true, published_at: nil,
+                                   description: 'A real teaser.')).to be false
+      expect(described_class.miss?(heading_or_anchor_item: false, published_at: nil, description: nil)).to be false
+    end
+  end
+
+  describe '.thin_wrapper?' do
+    let(:item) { Object.new }
+
+    it 'is thin when the only child is the item itself' do
+      expect(described_class.thin_wrapper?(children: [item], item:, descendant_of: ->(*) { false })).to be true
+    end
+
+    it 'is thin when the only child wraps the item' do
+      inner = Object.new
+      descendant_of = ->(candidate, child) { candidate.equal?(item) && child.equal?(inner) }
+      expect(described_class.thin_wrapper?(children: [inner], item:, descendant_of:)).to be true
+    end
+
+    it 'is not thin when a sibling sits beside the item' do
+      sibling = Object.new
+      expect(
+        described_class.thin_wrapper?(children: [item, sibling], item:, descendant_of: ->(*) { false })
+      ).to be false
+    end
+  end
+
+  describe '.crowded?' do
+    it 'aborts when a parent has two headings or two distinct main hrefs', :aggregate_failures do
+      expect(described_class.crowded?(heading_count: 2, distinct_main_hrefs: 1)).to be true
+      expect(described_class.crowded?(heading_count: 1, distinct_main_hrefs: 2)).to be true
+      expect(described_class.crowded?(heading_count: 1, distinct_main_hrefs: 1)).to be false
+    end
+  end
+end

--- a/spec/lib/html2rss/html/sst_article_extractor_spec.rb
+++ b/spec/lib/html2rss/html/sst_article_extractor_spec.rb
@@ -14,15 +14,16 @@ RSpec.describe Html2rss::Html::SstArticleExtractor do
       lambda do |html, item_selector: 'article'|
         wrapped = html.match?(/<html/i) ? html : "<html><body>#{html}</body></html>"
         doc = Html2rss::SST::Normalizer.call(wrapped)
-        name = item_selector.to_sym
-        root = doc.root.find { |n| n.name == name }
-        link = root.find(&:link?)
+        root = item_selector.split.reduce(doc.root) do |node, tag|
+          node&.find { |candidate| candidate.name == tag.to_sym }
+        end
+        link = root.name == :a ? root : root.find(&:link?)
         segment = Html2rss::AutoSource::Segment.build(
           root_node: root, primary_link: link, strategy: :semantic, position: 0
         )
         article = described_class.call(segment, base_url: 'https://example.com', time_zone: extractor_time_zone)
         { title: article&.title, description: article&.description, published_at: article&.published_at,
-          categories: article&.categories || [] }
+          categories: article&.categories || [], url: article&.url }
       end
     end
 

--- a/spec/lib/html2rss/mcp/inspect_spec.rb
+++ b/spec/lib/html2rss/mcp/inspect_spec.rb
@@ -28,6 +28,25 @@ RSpec.describe Html2rss::MCP::Inspect do
     expect(result[:sst]).to include(:node_count, :segment_stats)
   end
 
+  context 'when Content-Type is octet-stream but the body is HTML' do
+    let(:response) do
+      Html2rss::RequestService::Response.new(
+        body: response_body,
+        url: response_url,
+        headers: { 'content-type' => 'application/octet-stream' },
+        status: response_status
+      )
+    end
+
+    it 'still reports html_response and runs SST', :aggregate_failures do
+      result = described_class.call(url: 'https://example.com/blog', strategy: :auto)
+
+      expect(result[:content_type]).to eq('application/octet-stream')
+      expect(result[:html_response]).to be(true)
+      expect(result[:sst]).to include(:node_count, :segment_stats)
+    end
+  end
+
   context 'when the fetch downgrades https to http' do
     let(:response_url) { Html2rss::Url.from_absolute('http://example.com/blog') }
     let(:response_status) { 301 }

--- a/spec/lib/html2rss/request_service/botasaurus_contract_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_contract_spec.rb
@@ -70,6 +70,27 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
       expect(parsed).to be_a(described_class::ParsedResponse)
     end
 
+    context 'when scrape envelope returns 422 naming window_size' do
+      let(:status) { 422 }
+      let(:body) do
+        JSON.generate(
+          {
+            'url' => 'https://example.com/',
+            'html' => '',
+            'error' => 'window_size: List should have at least 2 items',
+            'error_category' => 'navigation_error',
+            'request_id' => 'req-422'
+          }
+        )
+      end
+
+      it 'is an upstream failure that names the field', :aggregate_failures do
+        expect(parsed).to be_upstream_failure
+        expect(parsed.upstream_failure_message).to include('window_size')
+        expect(parsed.upstream_failure_message).to include('req-422')
+      end
+    end
+
     context 'when FastAPI returns a 422 validation detail' do
       let(:status) { 422 }
       let(:body) do
@@ -91,6 +112,30 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
         expect(parsed).to be_upstream_failure
         expect(parsed.upstream_failure_message).to include('wait_timeout_seconds')
         expect(parsed.upstream_failure_message).to include('20')
+      end
+    end
+
+    # main-image compat: :latest still 422s schema errors as FastAPI `detail` until envelope 422 ships.
+    context 'when FastAPI returns 422 detail (main-image compat)' do
+      let(:status) { 422 }
+      let(:body) do
+        JSON.generate(
+          {
+            'detail' => [
+              {
+                'loc' => %w[body window_size],
+                'msg' => 'Input should be a valid list',
+                'type' => 'list_type',
+                'input' => [1920]
+              }
+            ]
+          }
+        )
+      end
+
+      it 'appends the field name from detail', :aggregate_failures do
+        expect(parsed).to be_upstream_failure
+        expect(parsed.upstream_failure_message).to include('window_size')
       end
     end
   end

--- a/spec/lib/html2rss/request_service/botasaurus_contract_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_contract_spec.rb
@@ -2,21 +2,55 @@
 
 require 'spec_helper'
 require 'json'
+require 'yaml'
 
 RSpec.describe Html2rss::RequestService::BotasaurusContract do
   let(:url) { Html2rss::Url.from_absolute('https://example.com') }
 
-  describe '::MAX_WAIT_TIMEOUT_SECONDS' do
-    it 'matches the Botasaurus scrape API wait ceiling' do
-      expect(described_class::MAX_WAIT_TIMEOUT_SECONDS).to eq(20)
+  describe 'OpenAPI scrape contract' do
+    # rubocop:disable RSpec/ExampleLength -- one sibling OpenAPI snapshot assertion
+    it 'matches the sibling ScrapeRequest / ScrapeResponse schemas', :aggregate_failures do
+      repo_root = File.expand_path('../../../..', __dir__)
+      openapi_path = File.expand_path('../botasaurus-scrape-api/openapi.yaml', repo_root)
+      skip "sibling OpenAPI not found at #{openapi_path}" unless File.exist?(openapi_path)
+
+      openapi = YAML.load_file(openapi_path)
+      schemas = openapi.fetch('components').fetch('schemas')
+      scrape_request = schemas.fetch('ScrapeRequest').fetch('properties')
+      scrape_response = schemas.fetch('ScrapeResponse').fetch('properties')
+      wait = scrape_request.fetch('wait_timeout_seconds')
+      retries = scrape_request.fetch('max_retries')
+      category = scrape_response.fetch('error_category')
+      scrape_responses = openapi.dig('paths', '/scrape', 'post', 'responses')
+      clamp_range = "[#{described_class::MIN_WAIT_TIMEOUT_SECONDS}, #{described_class::MAX_WAIT_TIMEOUT_SECONDS}]"
+
+      expect(described_class::REQUEST_OPTION_KEYS.map(&:to_s)).to match_array(scrape_request.keys - %w[url])
+      expect(described_class::EXECUTION_MODES).to eq(scrape_request.fetch('execution_mode').fetch('enum'))
+      expect(described_class::NAVIGATION_MODES).to eq(scrape_request.fetch('navigation_mode').fetch('enum'))
+      expect(described_class::DEFAULT_WAIT_TIMEOUT_SECONDS).to eq(wait.fetch('default'))
+      expect(wait.fetch('description')).to include(clamp_range)
+      expect(wait).not_to have_key('minimum')
+      expect(wait).not_to have_key('maximum')
+      expect(described_class::MAX_RETRIES).to eq(retries.fetch('maximum').to_i)
+      expect(described_class::ERROR_CATEGORIES).to eq(category.fetch('anyOf').find { _1['enum'] }.fetch('enum'))
+      expect(scrape_response.keys).to include(*described_class::META_KEYS)
+      expect(scrape_responses.keys).to include('200', '400', '403', '422', '502', '504')
+      expect(scrape_responses.except('200').values).to all(
+        include('content' => a_hash_including(
+          'application/json' => a_hash_including(
+            'schema' => { '$ref' => '#/components/schemas/ScrapeResponse' }
+          )
+        ))
+      )
     end
+    # rubocop:enable RSpec/ExampleLength
   end
 
-  describe '.option_keys' do
+  describe '::REQUEST_OPTION_KEYS' do
     it 'matches the validator BotasaurusRequestConfig key names' do
       validator_keys = Html2rss::Config::Validator::BotasaurusRequestConfig.key_map.map { |key| key.name.to_sym }
 
-      expect(described_class.option_keys).to match_array(validator_keys)
+      expect(described_class::REQUEST_OPTION_KEYS).to match_array(validator_keys)
     end
   end
 
@@ -28,16 +62,26 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
     end
     let(:remaining_timeout_seconds) { 30 }
 
-    it 'caps auto-computed remaining-2 wait at the API maximum', :aggregate_failures do
-      expect(payload.fetch(:wait_timeout_seconds)).to be <= described_class::MAX_WAIT_TIMEOUT_SECONDS
-      expect(payload.fetch(:wait_timeout_seconds)).to eq(20)
+    it 'sends only the URL so OpenAPI defaults apply', :aggregate_failures do
+      expect(payload).to eq(url: 'https://example.com/')
+      expect(payload).not_to have_key(:wait_timeout_seconds)
+      expect(payload).not_to have_key(:max_retries)
     end
 
-    context 'when remaining budget minus reserve still exceeds the API max' do
+    context 'when remaining budget minus reserve still exceeds the OpenAPI wait default' do
       let(:remaining_timeout_seconds) { 25 }
 
-      it 'mins remaining-2 with MAX_WAIT_TIMEOUT_SECONDS' do
-        expect(payload.fetch(:wait_timeout_seconds)).to eq(20)
+      it 'does not inflate wait_timeout_seconds above the published default' do
+        expect(payload).not_to have_key(:wait_timeout_seconds)
+      end
+    end
+
+    context 'when remaining budget cannot cover the published wait default' do
+      let(:remaining_timeout_seconds) { 12 }
+
+      it 'clamps wait down and disables retries', :aggregate_failures do
+        expect(payload.fetch(:wait_timeout_seconds)).to eq(10)
+        expect(payload.fetch(:max_retries)).to eq(0)
       end
     end
 
@@ -52,7 +96,7 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
     context 'when options include an unknown key' do
       let(:contract) { described_class.new(url:, options: { not_a_botasaurus_option: true, lang: 'de' }) }
 
-      it 'drops the unknown key and keeps validator keys', :aggregate_failures do
+      it 'drops the unknown key and keeps OpenAPI keys', :aggregate_failures do
         expect(payload).not_to have_key(:not_a_botasaurus_option)
         expect(payload[:lang]).to eq('de')
       end
@@ -91,7 +135,7 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
       end
     end
 
-    context 'when FastAPI returns a 422 validation detail' do
+    context 'when the body is FastAPI HTTPValidationError detail' do
       let(:status) { 422 }
       let(:body) do
         JSON.generate(
@@ -100,7 +144,6 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
               {
                 'loc' => %w[body wait_timeout_seconds],
                 'msg' => 'Input should be less than or equal to 20',
-                'type' => 'less_than_equal',
                 'input' => 28
               }
             ]
@@ -108,34 +151,10 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
         )
       end
 
-      it 'names wait_timeout_seconds and the API cap on BotasaurusServiceError', :aggregate_failures do
+      it 'does not treat FastAPI detail as the scrape envelope', :aggregate_failures do
         expect(parsed).to be_upstream_failure
-        expect(parsed.upstream_failure_message).to include('wait_timeout_seconds')
-        expect(parsed.upstream_failure_message).to include('20')
-      end
-    end
-
-    # main-image compat: :latest still 422s schema errors as FastAPI `detail` until envelope 422 ships.
-    context 'when FastAPI returns 422 detail (main-image compat)' do
-      let(:status) { 422 }
-      let(:body) do
-        JSON.generate(
-          {
-            'detail' => [
-              {
-                'loc' => %w[body window_size],
-                'msg' => 'Input should be a valid list',
-                'type' => 'list_type',
-                'input' => [1920]
-              }
-            ]
-          }
-        )
-      end
-
-      it 'appends the field name from detail', :aggregate_failures do
-        expect(parsed).to be_upstream_failure
-        expect(parsed.upstream_failure_message).to include('window_size')
+        expect(parsed.upstream_failure_message).not_to include('wait_timeout_seconds')
+        expect(parsed.upstream_failure_message).not_to include('detail=')
       end
     end
   end
@@ -193,6 +212,33 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
 
       it { is_expected.to be_upstream_failure }
     end
+
+    context 'when html is omitted on a successful envelope' do
+      let(:payload) { { 'url' => 'https://example.com/', 'request_id' => 'req-1', 'error' => nil } }
+
+      it 'uses the OpenAPI empty-string default', :aggregate_failures do
+        expect(parsed).not_to be_upstream_failure
+        expect(parsed.html).to eq('')
+      end
+    end
+  end
+
+  describe 'ParsedResponse#timeout?' do
+    subject(:parsed) { described_class::ParsedResponse.new(payload:, transport_status:) }
+
+    let(:payload) { { 'error' => 'Scrape timed out after 20 seconds', 'error_category' => 'timeout' } }
+
+    context 'when transport is 504' do
+      let(:transport_status) { 504 }
+
+      it { is_expected.to be_timeout }
+    end
+
+    context 'when error_category is timeout on 502' do
+      let(:transport_status) { 502 }
+
+      it { is_expected.to be_timeout }
+    end
   end
 
   describe 'ParsedResponse#challenge_block?' do
@@ -207,5 +253,26 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
     end
 
     it { is_expected.to be_challenge_block }
+  end
+
+  describe 'ParsedResponse#transport_meta' do
+    subject(:parsed) { described_class::ParsedResponse.new(payload:, transport_status: 200) }
+
+    let(:payload) do
+      {
+        'html' => '<html>ok</html>',
+        'error' => nil,
+        'metadata_error' => 'driver.requests.get failed',
+        'request_id' => 'req-meta'
+      }
+    end
+
+    it 'keeps metadata_error as telemetry without treating it as scrape failure', :aggregate_failures do
+      expect(parsed).not_to be_upstream_failure
+      expect(parsed.transport_meta).to include(
+        'metadata_error' => 'driver.requests.get failed',
+        'request_id' => 'req-meta'
+      )
+    end
   end
 end

--- a/spec/lib/html2rss/request_service/botasaurus_contract_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_contract_spec.rb
@@ -94,4 +94,73 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
       end
     end
   end
+
+  describe 'ParsedResponse#upstream_failure?' do
+    subject(:parsed) { described_class::ParsedResponse.new(payload:, transport_status:) }
+
+    let(:transport_status) { 200 }
+    let(:payload) do
+      {
+        'html' => '<html>ok</html>',
+        'status_code' => 200,
+        'error' => nil
+      }
+    end
+
+    [204, 301].each do |document_status|
+      context "when transport is 200, error is null, and status_code is #{document_status}" do
+        let(:payload) do
+          {
+            'html' => '<html>ok</html>',
+            'status_code' => document_status,
+            'error' => nil
+          }
+        end
+
+        it 'is not an upstream failure and keeps the document status', :aggregate_failures do
+          expect(parsed).not_to be_upstream_failure
+          expect(parsed.status).to eq(document_status)
+        end
+      end
+    end
+
+    context 'when transport is 502' do
+      let(:transport_status) { 502 }
+      let(:payload) do
+        {
+          'html' => '<html>error</html>',
+          'status_code' => 502,
+          'error' => 'navigation failed'
+        }
+      end
+
+      it { is_expected.to be_upstream_failure }
+    end
+
+    context 'when error is present' do
+      let(:payload) do
+        {
+          'html' => '<html>error</html>',
+          'status_code' => 200,
+          'error' => 'metadata collection failed'
+        }
+      end
+
+      it { is_expected.to be_upstream_failure }
+    end
+  end
+
+  describe 'ParsedResponse#challenge_block?' do
+    subject(:parsed) { described_class::ParsedResponse.new(payload:, transport_status: 502) }
+
+    let(:payload) do
+      {
+        'html' => '<html>challenge</html>',
+        'error' => 'Challenge block detected',
+        'error_category' => 'challenge_block'
+      }
+    end
+
+    it { is_expected.to be_challenge_block }
+  end
 end

--- a/spec/lib/html2rss/request_service/botasaurus_contract_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_contract_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
 
   describe 'OpenAPI scrape contract' do
     # rubocop:disable RSpec/ExampleLength -- one sibling OpenAPI snapshot assertion
-    it 'matches the sibling ScrapeRequest / ScrapeResponse schemas', :aggregate_failures do
+    it 'matches the sibling ScrapeRequest / ScrapeSuccess / ScrapeError schemas', :aggregate_failures do
       repo_root = File.expand_path('../../../..', __dir__)
       openapi_path = File.expand_path('../botasaurus-scrape-api/openapi.yaml', repo_root)
       skip "sibling OpenAPI not found at #{openapi_path}" unless File.exist?(openapi_path)
@@ -17,28 +17,38 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
       openapi = YAML.load_file(openapi_path)
       schemas = openapi.fetch('components').fetch('schemas')
       scrape_request = schemas.fetch('ScrapeRequest').fetch('properties')
-      scrape_response = schemas.fetch('ScrapeResponse').fetch('properties')
+      scrape_success = schemas.fetch('ScrapeSuccess').fetch('properties')
+      scrape_error = schemas.fetch('ScrapeError').fetch('properties')
       wait = scrape_request.fetch('wait_timeout_seconds')
       retries = scrape_request.fetch('max_retries')
-      category = scrape_response.fetch('error_category')
+      diagnostics = schemas.fetch('ScrapeDiagnostics').fetch('properties')
+      window_size = schemas.fetch('WindowSize')
       scrape_responses = openapi.dig('paths', '/scrape', 'post', 'responses')
       clamp_range = "[#{described_class::MIN_WAIT_TIMEOUT_SECONDS}, #{described_class::MAX_WAIT_TIMEOUT_SECONDS}]"
 
+      expect(schemas.keys).not_to include('ScrapeResponse')
+      expect(scrape_request.keys).not_to include('scroll_to_bottom')
       expect(described_class::REQUEST_OPTION_KEYS.map(&:to_s)).to match_array(scrape_request.keys - %w[url])
-      expect(described_class::EXECUTION_MODES).to eq(scrape_request.fetch('execution_mode').fetch('enum'))
-      expect(described_class::NAVIGATION_MODES).to eq(scrape_request.fetch('navigation_mode').fetch('enum'))
+      expect(described_class::EXECUTION_MODES).to eq(schemas.fetch('ExecutionMode').fetch('enum'))
+      expect(described_class::NAVIGATION_MODES).to eq(schemas.fetch('NavigationMode').fetch('enum'))
+      expect(described_class::ERROR_CATEGORIES).to eq(schemas.fetch('ErrorCategory').fetch('enum'))
+      expect(described_class::WINDOW_SIZE_PROPERTIES.map(&:to_s)).to match_array(window_size.fetch('required'))
       expect(described_class::DEFAULT_WAIT_TIMEOUT_SECONDS).to eq(wait.fetch('default'))
       expect(wait.fetch('description')).to include(clamp_range)
       expect(wait).not_to have_key('minimum')
       expect(wait).not_to have_key('maximum')
       expect(described_class::MAX_RETRIES).to eq(retries.fetch('maximum').to_i)
-      expect(described_class::ERROR_CATEGORIES).to eq(category.fetch('anyOf').find { _1['enum'] }.fetch('enum'))
-      expect(scrape_response.keys).to include(*described_class::META_KEYS)
-      expect(scrape_responses.keys).to include('200', '400', '403', '422', '502', '504')
+      expect(described_class::DIAGNOSTICS_KEYS).to match_array(diagnostics.keys)
+      expect(scrape_success.keys).to include('html', 'diagnostics', 'metadata_error', 'xhr_responses')
+      expect(scrape_error.keys).to include('error', 'error_category', 'diagnostics')
+      expect(scrape_error.keys).not_to include('html')
+      expect(scrape_responses.dig('200', 'content', 'application/json', 'schema')).to eq(
+        { '$ref' => '#/components/schemas/ScrapeSuccess' }
+      )
       expect(scrape_responses.except('200').values).to all(
         include('content' => a_hash_including(
           'application/json' => a_hash_including(
-            'schema' => { '$ref' => '#/components/schemas/ScrapeResponse' }
+            'schema' => { '$ref' => '#/components/schemas/ScrapeError' }
           )
         ))
       )
@@ -66,6 +76,7 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
       expect(payload).to eq(url: 'https://example.com/')
       expect(payload).not_to have_key(:wait_timeout_seconds)
       expect(payload).not_to have_key(:max_retries)
+      expect(payload).not_to have_key(:headless)
     end
 
     context 'when remaining budget minus reserve still exceeds the OpenAPI wait default' do
@@ -93,11 +104,21 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
       end
     end
 
+    context 'when options include window_size' do
+      let(:contract) { described_class.new(url:, options: { window_size: { width: 1920, height: 1080 } }) }
+
+      it 'forwards the OpenAPI object shape' do
+        expect(payload[:window_size]).to eq(width: 1920, height: 1080)
+      end
+    end
+
     context 'when options include an unknown key' do
-      let(:contract) { described_class.new(url:, options: { not_a_botasaurus_option: true, lang: 'de' }) }
+      let(:contract) do
+        described_class.new(url:, options: { scroll_to_bottom: true, lang: 'de' })
+      end
 
       it 'drops the unknown key and keeps OpenAPI keys', :aggregate_failures do
-        expect(payload).not_to have_key(:not_a_botasaurus_option)
+        expect(payload).not_to have_key(:scroll_to_bottom)
         expect(payload[:lang]).to eq('de')
       end
     end
@@ -108,10 +129,19 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
 
     let(:transport_response) { instance_double(Faraday::Response, status:, body:) }
     let(:status) { 200 }
-    let(:body) { JSON.generate({ 'html' => '<html></html>', 'status_code' => 200 }) }
+    let(:body) do
+      JSON.generate(
+        {
+          'url' => 'https://example.com/',
+          'html' => '<html></html>',
+          'status_code' => 200,
+          'diagnostics' => { 'request_id' => 'req-ok' }
+        }
+      )
+    end
 
-    it 'returns a ParsedResponse for a scrape envelope' do
-      expect(parsed).to be_a(described_class::ParsedResponse)
+    it 'returns Success for a scrape success envelope' do
+      expect(parsed).to be_a(described_class::Success)
     end
 
     context 'when scrape envelope returns 422 naming window_size' do
@@ -120,22 +150,22 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
         JSON.generate(
           {
             'url' => 'https://example.com/',
-            'html' => '',
-            'error' => 'window_size: List should have at least 2 items',
-            'error_category' => 'navigation_error',
-            'request_id' => 'req-422'
+            'error' => 'window_size.width: Field required',
+            'error_category' => 'validation',
+            'diagnostics' => { 'request_id' => 'req-422' }
           }
         )
       end
 
-      it 'is an upstream failure that names the field', :aggregate_failures do
-        expect(parsed).to be_upstream_failure
-        expect(parsed.upstream_failure_message).to include('window_size')
-        expect(parsed.upstream_failure_message).to include('req-422')
+      it 'returns Error naming the field', :aggregate_failures do
+        expect(parsed).to be_a(described_class::Error)
+        expect(parsed.failure_message).to include('window_size.width')
+        expect(parsed.failure_message).to include('req-422')
+        expect(parsed.failure_message).to include('error_category=validation')
       end
     end
 
-    context 'when the body is FastAPI HTTPValidationError detail' do
+    context 'when the body is not a scrape envelope' do
       let(:status) { 422 }
       let(:body) do
         JSON.generate(
@@ -151,82 +181,97 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
         )
       end
 
-      it 'does not treat FastAPI detail as the scrape envelope', :aggregate_failures do
-        expect(parsed).to be_upstream_failure
-        expect(parsed.upstream_failure_message).not_to include('wait_timeout_seconds')
-        expect(parsed.upstream_failure_message).not_to include('detail=')
+      it 'fails loud instead of reading a non-envelope body' do
+        expect { parsed }.to raise_error(
+          Html2rss::RequestService::BotasaurusServiceError,
+          /requires (error|diagnostics|error_category)/
+        )
+      end
+    end
+
+    context 'when success omits html' do
+      let(:body) { JSON.generate({ 'url' => 'https://example.com/', 'diagnostics' => { 'request_id' => 'req-1' } }) }
+
+      it 'fails loud because html is required' do
+        expect { parsed }.to raise_error(
+          Html2rss::RequestService::BotasaurusServiceError,
+          /requires html/
+        )
       end
     end
   end
 
-  describe 'ParsedResponse#upstream_failure?' do
-    subject(:parsed) { described_class::ParsedResponse.new(payload:, transport_status:) }
+  describe 'Success#status' do
+    subject(:parsed) { described_class::Success.new(payload:) }
 
-    let(:transport_status) { 200 }
     let(:payload) do
       {
         'html' => '<html>ok</html>',
         'status_code' => 200,
-        'error' => nil
+        'diagnostics' => { 'request_id' => 'req-1' }
       }
     end
 
     [204, 301].each do |document_status|
-      context "when transport is 200, error is null, and status_code is #{document_status}" do
+      context "when status_code is #{document_status}" do
         let(:payload) do
           {
             'html' => '<html>ok</html>',
             'status_code' => document_status,
-            'error' => nil
+            'diagnostics' => { 'request_id' => 'req-1' }
           }
         end
 
-        it 'is not an upstream failure and keeps the document status', :aggregate_failures do
-          expect(parsed).not_to be_upstream_failure
+        it 'keeps the document status' do
           expect(parsed.status).to eq(document_status)
         end
       end
     end
 
-    context 'when transport is 502' do
-      let(:transport_status) { 502 }
+    context 'when status_code is null' do
       let(:payload) do
         {
-          'html' => '<html>error</html>',
-          'status_code' => 502,
-          'error' => 'navigation failed'
+          'html' => '<html>ok</html>',
+          'status_code' => nil,
+          'diagnostics' => { 'request_id' => 'req-1' }
         }
       end
 
-      it { is_expected.to be_upstream_failure }
-    end
-
-    context 'when error is present' do
-      let(:payload) do
-        {
-          'html' => '<html>error</html>',
-          'status_code' => 200,
-          'error' => 'metadata collection failed'
-        }
-      end
-
-      it { is_expected.to be_upstream_failure }
-    end
-
-    context 'when html is omitted on a successful envelope' do
-      let(:payload) { { 'url' => 'https://example.com/', 'request_id' => 'req-1', 'error' => nil } }
-
-      it 'uses the OpenAPI empty-string default', :aggregate_failures do
-        expect(parsed).not_to be_upstream_failure
-        expect(parsed.html).to eq('')
+      it 'does not invent a document status' do
+        expect(parsed.status).to be_nil
       end
     end
   end
 
-  describe 'ParsedResponse#timeout?' do
-    subject(:parsed) { described_class::ParsedResponse.new(payload:, transport_status:) }
+  describe 'Error' do
+    subject(:parsed) { described_class::Error.new(payload:, transport_status:) }
 
-    let(:payload) { { 'error' => 'Scrape timed out after 20 seconds', 'error_category' => 'timeout' } }
+    let(:transport_status) { 502 }
+    let(:payload) do
+      {
+        'url' => 'https://example.com/',
+        'error' => 'navigation failed',
+        'error_category' => 'navigation_error',
+        'diagnostics' => { 'request_id' => 'req-502' }
+      }
+    end
+
+    it 'is not a timeout or challenge block', :aggregate_failures do
+      expect(parsed).not_to be_timeout
+      expect(parsed).not_to be_challenge_block
+    end
+  end
+
+  describe 'Error#timeout?' do
+    subject(:parsed) { described_class::Error.new(payload:, transport_status:) }
+
+    let(:payload) do
+      {
+        'error' => 'Scrape timed out after 20 seconds',
+        'error_category' => 'timeout',
+        'diagnostics' => { 'request_id' => 'req-timeout' }
+      }
+    end
 
     context 'when transport is 504' do
       let(:transport_status) { 504 }
@@ -241,37 +286,48 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
     end
   end
 
-  describe 'ParsedResponse#challenge_block?' do
-    subject(:parsed) { described_class::ParsedResponse.new(payload:, transport_status: 502) }
+  describe 'Error#challenge_block?' do
+    subject(:parsed) { described_class::Error.new(payload:, transport_status: 502) }
 
     let(:payload) do
       {
-        'html' => '<html>challenge</html>',
         'error' => 'Challenge block detected',
-        'error_category' => 'challenge_block'
+        'error_category' => 'challenge_block',
+        'diagnostics' => {
+          'request_id' => 'req-challenge',
+          'challenge' => { 'blocked' => true, 'detected' => true, 'marker' => 'Just a moment...' }
+        }
       }
     end
 
     it { is_expected.to be_challenge_block }
   end
 
-  describe 'ParsedResponse#transport_meta' do
-    subject(:parsed) { described_class::ParsedResponse.new(payload:, transport_status: 200) }
+  describe 'Success#transport_meta' do
+    subject(:parsed) { described_class::Success.new(payload:) }
 
     let(:payload) do
       {
         'html' => '<html>ok</html>',
-        'error' => nil,
         'metadata_error' => 'driver.requests.get failed',
-        'request_id' => 'req-meta'
+        'diagnostics' => {
+          'request_id' => 'req-meta',
+          'attempts' => 1,
+          'strategy_used' => nil,
+          'render_ms' => 154,
+          'execution_tier' => 'http_request',
+          'challenge' => { 'blocked' => false, 'detected' => false, 'marker' => nil }
+        }
       }
     end
 
-    it 'keeps metadata_error as telemetry without treating it as scrape failure', :aggregate_failures do
-      expect(parsed).not_to be_upstream_failure
+    it 'keeps metadata_error as telemetry without treating it as scrape failure', :aggregate_failures do # rubocop:disable RSpec/ExampleLength -- html plus nested diagnostics
+      expect(parsed.html).to eq('<html>ok</html>')
       expect(parsed.transport_meta).to include(
         'metadata_error' => 'driver.requests.get failed',
-        'request_id' => 'req-meta'
+        'request_id' => 'req-meta',
+        'execution_tier' => 'http_request',
+        'challenge' => { 'blocked' => false, 'detected' => false }
       )
     end
   end

--- a/spec/lib/html2rss/request_service/botasaurus_contract_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_contract_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
     end
   end
 
+  describe '.option_keys' do
+    it 'matches the validator BotasaurusRequestConfig key names' do
+      validator_keys = Html2rss::Config::Validator::BotasaurusRequestConfig.key_map.map { |key| key.name.to_sym }
+
+      expect(described_class.option_keys).to match_array(validator_keys)
+    end
+  end
+
   describe '#request_payload' do
     subject(:payload) { contract.request_payload }
 
@@ -30,6 +38,23 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
 
       it 'mins remaining-2 with MAX_WAIT_TIMEOUT_SECONDS' do
         expect(payload.fetch(:wait_timeout_seconds)).to eq(20)
+      end
+    end
+
+    context 'when options include a validator-legal key' do
+      let(:contract) { described_class.new(url:, options: { scroll: true }) }
+
+      it 'forwards the key that the validator already accepted' do
+        expect(payload[:scroll]).to be true
+      end
+    end
+
+    context 'when options include an unknown key' do
+      let(:contract) { described_class.new(url:, options: { not_a_botasaurus_option: true, lang: 'de' }) }
+
+      it 'drops the unknown key and keeps validator keys', :aggregate_failures do
+        expect(payload).not_to have_key(:not_a_botasaurus_option)
+        expect(payload[:lang]).to eq('de')
       end
     end
   end

--- a/spec/lib/html2rss/request_service/botasaurus_contract_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_contract_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
           {
             'detail' => [
               {
-                'loc' => ['body', 'wait_timeout_seconds'],
+                'loc' => %w[body wait_timeout_seconds],
                 'msg' => 'Input should be less than or equal to 20',
                 'type' => 'less_than_equal',
                 'input' => 28
@@ -64,8 +64,8 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
 
       it 'names wait_timeout_seconds and the API cap on BotasaurusServiceError', :aggregate_failures do
         expect(parsed).to be_upstream_failure
-        expect(parsed.upstream_failure_message).to match(/wait_timeout_seconds/)
-        expect(parsed.upstream_failure_message).to match(/20/)
+        expect(parsed.upstream_failure_message).to include('wait_timeout_seconds')
+        expect(parsed.upstream_failure_message).to include('20')
       end
     end
   end

--- a/spec/lib/html2rss/request_service/botasaurus_contract_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_contract_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+
+RSpec.describe Html2rss::RequestService::BotasaurusContract do
+  let(:url) { Html2rss::Url.from_absolute('https://example.com') }
+
+  describe '::MAX_WAIT_TIMEOUT_SECONDS' do
+    it 'matches the Botasaurus scrape API wait ceiling' do
+      expect(described_class::MAX_WAIT_TIMEOUT_SECONDS).to eq(20)
+    end
+  end
+
+  describe '#request_payload' do
+    subject(:payload) { contract.request_payload }
+
+    let(:contract) do
+      described_class.new(url:, remaining_timeout_seconds:)
+    end
+    let(:remaining_timeout_seconds) { 30 }
+
+    it 'caps auto-computed remaining-2 wait at the API maximum', :aggregate_failures do
+      expect(payload.fetch(:wait_timeout_seconds)).to be <= described_class::MAX_WAIT_TIMEOUT_SECONDS
+      expect(payload.fetch(:wait_timeout_seconds)).to eq(20)
+    end
+
+    context 'when remaining budget minus reserve still exceeds the API max' do
+      let(:remaining_timeout_seconds) { 25 }
+
+      it 'mins remaining-2 with MAX_WAIT_TIMEOUT_SECONDS' do
+        expect(payload.fetch(:wait_timeout_seconds)).to eq(20)
+      end
+    end
+  end
+
+  describe '#parse_response' do
+    subject(:parsed) { described_class.new(url:).parse_response(transport_response) }
+
+    let(:transport_response) { instance_double(Faraday::Response, status:, body:) }
+    let(:status) { 200 }
+    let(:body) { JSON.generate({ 'html' => '<html></html>', 'status_code' => 200 }) }
+
+    it 'returns a ParsedResponse for a scrape envelope' do
+      expect(parsed).to be_a(described_class::ParsedResponse)
+    end
+
+    context 'when FastAPI returns a 422 validation detail' do
+      let(:status) { 422 }
+      let(:body) do
+        JSON.generate(
+          {
+            'detail' => [
+              {
+                'loc' => ['body', 'wait_timeout_seconds'],
+                'msg' => 'Input should be less than or equal to 20',
+                'type' => 'less_than_equal',
+                'input' => 28
+              }
+            ]
+          }
+        )
+      end
+
+      it 'names wait_timeout_seconds and the API cap on BotasaurusServiceError', :aggregate_failures do
+        expect(parsed).to be_upstream_failure
+        expect(parsed.upstream_failure_message).to match(/wait_timeout_seconds/)
+        expect(parsed.upstream_failure_message).to match(/20/)
+      end
+    end
+  end
+end

--- a/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
         'navigation_mode' => 'auto',
         'max_retries' => 1,
         'headless' => false,
-        'wait_timeout_seconds' => 28
+        'wait_timeout_seconds' => 20
       )
     end
 
@@ -177,7 +177,8 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
       [
         { remaining: 12, max_retries: 0, wait_timeout_seconds: 10 },
         { remaining: 10.5, max_retries: 0, wait_timeout_seconds: 8 },
-        { remaining: 20, max_retries: 1, wait_timeout_seconds: 18 }
+        { remaining: 20, max_retries: 1, wait_timeout_seconds: 18 },
+        { remaining: 25, max_retries: 1, wait_timeout_seconds: 20 }
       ].each do |example|
         context "with remaining=#{example[:remaining]}" do
           before do
@@ -344,6 +345,30 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
   end
 
   describe 'failure handling' do
+    context 'when FastAPI returns 422 detail for wait_timeout_seconds' do
+      let(:response_status) { 422 }
+      let(:response_payload) do
+        {
+          detail: [
+            {
+              loc: ['body', 'wait_timeout_seconds'],
+              msg: 'Input should be less than or equal to 20',
+              type: 'less_than_equal',
+              input: 28
+            }
+          ]
+        }
+      end
+
+      it 'raises BotasaurusServiceError naming wait_timeout_seconds' do
+        expect { execute }
+          .to raise_error(
+            Html2rss::RequestService::BotasaurusServiceError,
+            /wait_timeout_seconds/
+          )
+      end
+    end
+
     context 'when upstream returns non-200 status with error details' do
       let(:response_status) { 502 }
       let(:response_payload) do

--- a/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
   end
 
   describe 'request contract' do
-    it 'posts defaults and validates request policy', :aggregate_failures do
+    it 'posts the target URL and validates request policy', :aggregate_failures do
       execute
 
       expect(budget).to have_received(:consume!)
@@ -94,14 +94,7 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
       path, body, headers = captured_post_args.first
       expect(path).to eq('/scrape')
       expect(headers).to eq('Content-Type' => 'application/json')
-      expect(JSON.parse(body)).to eq(
-        'url' => 'https://example.com/',
-        'execution_mode' => 'auto',
-        'navigation_mode' => 'auto',
-        'max_retries' => 1,
-        'headless' => false,
-        'wait_timeout_seconds' => 20
-      )
+      expect(JSON.parse(body)).to eq('url' => 'https://example.com/')
     end
 
     context 'when request includes optional botasaurus fields and headers' do
@@ -177,8 +170,8 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
       [
         { remaining: 12, max_retries: 0, wait_timeout_seconds: 10 },
         { remaining: 10.5, max_retries: 0, wait_timeout_seconds: 8 },
-        { remaining: 20, max_retries: 1, wait_timeout_seconds: 18 },
-        { remaining: 25, max_retries: 1, wait_timeout_seconds: 20 }
+        { remaining: 20, max_retries: nil, wait_timeout_seconds: nil },
+        { remaining: 25, max_retries: nil, wait_timeout_seconds: nil }
       ].each do |example|
         context "with remaining=#{example[:remaining]}" do
           before do
@@ -322,12 +315,12 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
         }
       end
 
-      it 'falls back to transport status, source url, and default headers', :aggregate_failures do
+      it 'falls back to transport status, source url, and empty headers', :aggregate_failures do
         result = execute
 
         expect(result.status).to eq(200)
         expect(result.url.to_s).to eq('https://example.com/')
-        expect(result.headers).to eq('content-type' => 'text/html')
+        expect(result.headers).to eq({})
         expect(result.captured_responses).to eq([])
       end
     end
@@ -379,26 +372,22 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
       end
     end
 
-    context 'when FastAPI returns 422 detail for wait_timeout_seconds' do
-      let(:response_status) { 422 }
+    context 'when scrape envelope returns 504 timeout' do
+      let(:response_status) { 504 }
       let(:response_payload) do
         {
-          detail: [
-            {
-              loc: %w[body wait_timeout_seconds],
-              msg: 'Input should be less than or equal to 20',
-              type: 'less_than_equal',
-              input: 28
-            }
-          ]
+          html: '',
+          error: 'Scrape timed out after 20 seconds',
+          error_category: 'timeout',
+          request_id: 'req-504'
         }
       end
 
-      it 'raises BotasaurusServiceError naming wait_timeout_seconds' do
+      it 'raises RequestTimedOut with envelope diagnostics' do
         expect { execute }
           .to raise_error(
-            Html2rss::RequestService::BotasaurusServiceError,
-            /wait_timeout_seconds/
+            Html2rss::RequestService::RequestTimedOut,
+            /error_category=timeout.*req-504/
           )
       end
     end
@@ -453,7 +442,7 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
       end
     end
 
-    context "when upstream payload omits required 'html'" do
+    context 'when the scrape envelope omits html on success' do
       let(:response_payload) do
         {
           final_url: 'https://redacted.example/path/',
@@ -463,9 +452,8 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
         }
       end
 
-      it 'raises BotasaurusServiceError' do
-        expect { execute }
-          .to raise_error(Html2rss::RequestService::BotasaurusServiceError, /missing required 'html'/)
+      it 'maps the OpenAPI empty-string default' do
+        expect(execute.body).to eq('')
       end
     end
 

--- a/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
@@ -358,6 +358,27 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
   end
 
   describe 'failure handling' do
+    context 'when scrape envelope returns 422 naming window_size' do
+      let(:response_status) { 422 }
+      let(:response_payload) do
+        {
+          url: 'https://example.com/',
+          html: '',
+          error: 'window_size: List should have at least 2 items',
+          error_category: 'navigation_error',
+          request_id: 'req-422'
+        }
+      end
+
+      it 'raises BotasaurusServiceError naming window_size' do
+        expect { execute }
+          .to raise_error(
+            Html2rss::RequestService::BotasaurusServiceError,
+            /window_size/
+          )
+      end
+    end
+
     context 'when FastAPI returns 422 detail for wait_timeout_seconds' do
       let(:response_status) { 422 }
       let(:response_payload) do

--- a/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
@@ -297,6 +297,19 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
       end
     end
 
+    [204, 301].each do |document_status|
+      context "when scrape envelope succeeds with document status_code #{document_status}" do
+        let(:response_payload) { base_payload.merge(status_code: document_status, error: nil) }
+
+        it 'does not raise and maps Response#status from the document code', :aggregate_failures do
+          result = execute
+
+          expect(result.status).to eq(document_status)
+          expect(result.body).to include('ok')
+        end
+      end
+    end
+
     context 'when response omits headers and url metadata' do
       let(:response_payload) do
         {

--- a/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
@@ -351,7 +351,7 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
         {
           detail: [
             {
-              loc: ['body', 'wait_timeout_seconds'],
+              loc: %w[body wait_timeout_seconds],
               msg: 'Input should be less than or equal to 20',
               type: 'less_than_equal',
               input: 28

--- a/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
@@ -38,15 +38,16 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
       status_code: 200,
       headers: { 'content-type' => 'text/html' },
       html: '<html><body>ok</body></html>',
-      error: nil,
       metadata_error: nil,
-      request_id: 'request-id',
-      attempts: 2,
-      strategy_used: 'google_get_bypass',
-      render_ms: 5000,
-      blocked_detected: false,
-      challenge_detected: false,
-      error_category: nil
+      xhr_responses: [],
+      diagnostics: {
+        request_id: 'request-id',
+        attempts: 2,
+        strategy_used: 'google_get_bypass',
+        render_ms: 5000,
+        execution_tier: 'browser_driver',
+        challenge: { blocked: false, detected: false, marker: nil }
+      }
     }
   end
   let(:sanitized_sample_payload) do
@@ -56,15 +57,16 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
       'status_code' => 200,
       'headers' => { 'content-type' => 'text/html' },
       'html' => '<html>redacted</html>',
-      'error' => nil,
       'metadata_error' => nil,
-      'request_id' => '8d78d630-280c-407f-9884-d71f3c092956',
-      'attempts' => 2,
-      'strategy_used' => 'google_get_bypass',
-      'render_ms' => 8074,
-      'blocked_detected' => false,
-      'challenge_detected' => false,
-      'error_category' => nil
+      'xhr_responses' => [],
+      'diagnostics' => {
+        'request_id' => '8d78d630-280c-407f-9884-d71f3c092956',
+        'attempts' => 2,
+        'strategy_used' => 'google_get_bypass',
+        'render_ms' => 8074,
+        'execution_tier' => 'browser_driver',
+        'challenge' => { 'blocked' => false, 'detected' => false, 'marker' => nil }
+      }
     }
   end
 
@@ -116,7 +118,6 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
             wait_for_selector: 'h1',
             wait_timeout_seconds: 15,
             scroll: true,
-            scroll_to_bottom: false,
             block_images: true,
             block_images_and_css: false,
             block_trackers: true,
@@ -124,7 +125,7 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
             headless: true,
             proxy: 'http://proxy.local:8080',
             user_agent: 'Agent/1.0',
-            window_size: [1920, 1080],
+            window_size: { width: 1920, height: 1080 },
             lang: 'en-US',
             cookies: { 'session' => 'test-session-token' },
             headers: { 'X-Override' => 'Overridden' },
@@ -144,7 +145,6 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
           'wait_for_selector' => 'h1',
           'wait_timeout_seconds' => 15,
           'scroll' => true,
-          'scroll_to_bottom' => false,
           'block_images' => true,
           'block_images_and_css' => false,
           'block_trackers' => true,
@@ -152,7 +152,7 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
           'headless' => true,
           'proxy' => 'http://proxy.local:8080',
           'user_agent' => 'Agent/1.0',
-          'window_size' => [1920, 1080],
+          'window_size' => { 'width' => 1920, 'height' => 1080 },
           'lang' => 'en-US',
           'cookies' => { 'session' => 'test-session-token' },
           'headers' => {
@@ -217,9 +217,9 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
         'request_id' => 'request-id',
         'strategy_used' => 'google_get_bypass',
         'render_ms' => 5000,
-        'blocked_detected' => false,
-        'challenge_detected' => false,
-        'attempts' => 2
+        'attempts' => 2,
+        'execution_tier' => 'browser_driver',
+        'challenge' => { 'blocked' => false, 'detected' => false }
       )
       expect(result.transport_meta).to be_frozen
     end
@@ -252,7 +252,7 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
     end
 
     context 'when xhr_responses exceed the aggregate size cap' do
-      let(:chunk) { 'y' * Html2rss::RequestService::BotasaurusContract::ParsedResponse::MAX_XHR_BODY_BYTES }
+      let(:chunk) { 'y' * Html2rss::RequestService::BotasaurusContract::Success::MAX_XHR_BODY_BYTES }
       let(:response_payload) do
         base_payload.merge(
           'xhr_responses' => Array.new(5) do |index|
@@ -272,7 +272,7 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
     end
 
     context 'when an individual xhr body exceeds the per-body size cap' do
-      let(:oversized_body) { 'x' * (Html2rss::RequestService::BotasaurusContract::ParsedResponse::MAX_XHR_BODY_BYTES + 1) }
+      let(:oversized_body) { 'x' * (Html2rss::RequestService::BotasaurusContract::Success::MAX_XHR_BODY_BYTES + 1) }
       let(:response_payload) do
         base_payload.merge(
           'xhr_responses' => [
@@ -292,7 +292,7 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
 
     [204, 301].each do |document_status|
       context "when scrape envelope succeeds with document status_code #{document_status}" do
-        let(:response_payload) { base_payload.merge(status_code: document_status, error: nil) }
+        let(:response_payload) { base_payload.merge(status_code: document_status) }
 
         it 'does not raise and maps Response#status from the document code', :aggregate_failures do
           result = execute
@@ -306,22 +306,23 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
     context 'when response omits headers and url metadata' do
       let(:response_payload) do
         {
+          url: 'https://example.com/',
           final_url: nil,
           status_code: nil,
           headers: nil,
           html: '<html>fallback</html>',
-          error: nil,
-          error_category: nil
+          diagnostics: { request_id: 'req-fallback' }
         }
       end
 
-      it 'falls back to transport status, source url, and empty headers', :aggregate_failures do
+      it 'keeps a nil document status, source url, and empty headers', :aggregate_failures do
         result = execute
 
-        expect(result.status).to eq(200)
+        expect(result.status).to be_nil
         expect(result.url.to_s).to eq('https://example.com/')
         expect(result.headers).to eq({})
         expect(result.captured_responses).to eq([])
+        expect(result.transport_meta).to include('request_id' => 'req-fallback')
       end
     end
 
@@ -335,13 +336,12 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
 
         expect(sanitized_sample_payload).to include(
           'status_code' => 200,
-          'error' => nil,
-          'metadata_error' => nil,
+          'metadata_error' => nil
+        )
+        expect(sanitized_sample_payload.fetch('diagnostics')).to include(
           'attempts' => 2,
           'strategy_used' => 'google_get_bypass',
-          'blocked_detected' => false,
-          'challenge_detected' => false,
-          'error_category' => nil
+          'challenge' => { 'blocked' => false, 'detected' => false, 'marker' => nil }
         )
         expect(result.url.to_s).to eq('https://redacted.example/technology/')
         expect(result.headers.fetch('content-type')).to include('text/html')
@@ -356,10 +356,9 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
       let(:response_payload) do
         {
           url: 'https://example.com/',
-          html: '',
-          error: 'window_size: List should have at least 2 items',
-          error_category: 'navigation_error',
-          request_id: 'req-422'
+          error: 'window_size.width: Field required',
+          error_category: 'validation',
+          diagnostics: { request_id: 'req-422' }
         }
       end
 
@@ -376,10 +375,10 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
       let(:response_status) { 504 }
       let(:response_payload) do
         {
-          html: '',
+          url: 'https://example.com/',
           error: 'Scrape timed out after 20 seconds',
           error_category: 'timeout',
-          request_id: 'req-504'
+          diagnostics: { request_id: 'req-504' }
         }
       end
 
@@ -396,11 +395,10 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
       let(:response_status) { 502 }
       let(:response_payload) do
         {
-          html: '<html>error</html>',
-          status_code: 502,
+          url: 'https://example.com/',
           error: 'navigation failed',
           error_category: 'navigation_error',
-          request_id: 'trace-123'
+          diagnostics: { request_id: 'trace-123' }
         }
       end
 
@@ -413,23 +411,16 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
       end
     end
 
-    context 'when upstream returns 200 with error payload' do
+    context 'when success includes metadata_error' do
       let(:response_payload) do
-        {
-          html: '<html>error</html>',
-          status_code: 200,
-          error: 'metadata collection failed',
-          error_category: 'metadata_error',
-          request_id: 'trace-456'
-        }
+        base_payload.merge(metadata_error: 'metadata collection failed')
       end
 
-      it 'raises BotasaurusServiceError' do
-        expect { execute }
-          .to raise_error(
-            Html2rss::RequestService::BotasaurusServiceError,
-            /status=200, error_category=metadata_error, error=metadata collection failed, request_id=trace-456/
-          )
+      it 'keeps HTML success and records metadata_error as telemetry', :aggregate_failures do
+        result = execute
+
+        expect(result.body).to include('ok')
+        expect(result.transport_meta).to include('metadata_error' => 'metadata collection failed')
       end
     end
 
@@ -445,24 +436,30 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
     context 'when the scrape envelope omits html on success' do
       let(:response_payload) do
         {
+          url: 'https://example.com/',
           final_url: 'https://redacted.example/path/',
           status_code: 200,
-          error: nil,
-          error_category: nil
+          diagnostics: { request_id: 'req-missing-html' }
         }
       end
 
-      it 'maps the OpenAPI empty-string default' do
-        expect(execute.body).to eq('')
+      it 'raises because html is required' do
+        expect { execute }
+          .to raise_error(Html2rss::RequestService::BotasaurusServiceError, /requires html/)
       end
     end
 
     context 'when upstream reports challenge_block' do
+      let(:response_status) { 502 }
       let(:response_payload) do
         {
-          html: '<html>challenge</html>',
+          url: 'https://example.com/',
           error: 'Challenge block detected',
-          error_category: 'challenge_block'
+          error_category: 'challenge_block',
+          diagnostics: {
+            request_id: 'req-challenge',
+            challenge: { blocked: true, detected: true, marker: 'Just a moment...' }
+          }
         }
       end
 

--- a/spec/lib/html2rss/request_service/compressed_body_spec.rb
+++ b/spec/lib/html2rss/request_service/compressed_body_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe Html2rss::RequestService::CompressedBody do
   let(:html) { '<!DOCTYPE html><html><body><div>decoded stream</div></body></html>' }
   let(:headers) { {} }
 
+  it 'reuses Response::HTML_BODY_SNIFF instead of a lockstep copy' do
+    expect(described_class::HTML_BODY_SNIFF).to equal(Html2rss::RequestService::Response::HTML_BODY_SNIFF)
+  end
+
   context 'when the body is empty' do
     let(:body) { '' }
 

--- a/spec/lib/html2rss/request_service/compressed_body_spec.rb
+++ b/spec/lib/html2rss/request_service/compressed_body_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'brotli'
+require 'stringio'
+require 'zlib'
+
+RSpec.describe Html2rss::RequestService::CompressedBody do
+  subject(:decoded) { described_class.decode(body, headers:) }
+
+  let(:html) { '<!DOCTYPE html><html><body><div>decoded stream</div></body></html>' }
+  let(:headers) { {} }
+
+  context 'when the body is empty' do
+    let(:body) { '' }
+
+    it 'returns the original body' do
+      expect(decoded).to eq('')
+    end
+  end
+
+  context 'when Content-Encoding is gzip' do
+    let(:headers) { { 'Content-Encoding' => 'gzip' } }
+    let(:body) do
+      StringIO.new.tap { |io| Zlib::GzipWriter.wrap(io) { |gzip| gzip.write(html) } }.string
+    end
+
+    it 'inflates the labeled gzip body' do
+      expect(decoded).to eq(html)
+    end
+  end
+
+  context 'when Content-Encoding is zlib deflate' do
+    let(:headers) { { 'content-encoding' => 'deflate' } }
+    let(:body) { Zlib::Deflate.deflate(html) }
+
+    it 'inflates the labeled deflate body' do
+      expect(decoded).to eq(html)
+    end
+  end
+
+  context 'when Content-Encoding is raw deflate' do
+    let(:headers) { { 'content-encoding' => 'deflate' } }
+    let(:body) do
+      inflater = Zlib::Deflate.new(Zlib::BEST_COMPRESSION, -Zlib::MAX_WBITS)
+      inflater.deflate(html, Zlib::FINISH)
+    ensure
+      inflater.close
+    end
+
+    it 'inflates the Microsoft-style raw deflate body' do
+      expect(decoded).to eq(html)
+    end
+  end
+
+  context 'when Content-Encoding is br' do
+    let(:headers) { { 'content-encoding' => 'br' } }
+    let(:body) { Brotli.deflate(html) }
+
+    it 'inflates the labeled brotli body' do
+      expect(decoded).to eq(html)
+    end
+  end
+
+  context 'when Content-Encoding is gzip but the body is not gzip' do
+    let(:headers) { { 'content-encoding' => 'gzip', 'content-type' => 'application/octet-stream' } }
+    let(:body) { 'not-gzip' }
+
+    it 'returns the original body' do
+      expect(decoded).to eq('not-gzip')
+    end
+  end
+
+  context 'when unlabeled octet-stream brotli is not HTML' do
+    let(:headers) { { 'content-type' => 'application/octet-stream' } }
+    let(:body) { Brotli.deflate('plain text payload') }
+
+    it 'leaves the body unchanged' do
+      expect(decoded).to eq(body)
+    end
+  end
+
+  context 'when unlabeled octet-stream is not brotli' do
+    let(:headers) { { 'content-type' => 'application/octet-stream' } }
+    let(:body) { 'PK not a brotli stream' }
+
+    it 'leaves the body unchanged' do
+      expect(decoded).to eq(body)
+    end
+  end
+end

--- a/spec/lib/html2rss/request_service/faraday_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/faraday_strategy_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'brotli'
 require 'stringio'
 require 'zlib'
 
@@ -174,6 +175,36 @@ RSpec.describe Html2rss::RequestService::FaradayStrategy do # rubocop:disable RS
 
     expect { execute }
       .to raise_error(Html2rss::RequestService::BlockedSurfaceDetected, /Blocked surface detected/)
+  end
+
+  [
+    {
+      label: 'gzip',
+      encode: lambda { |html|
+        StringIO.new.tap { |io| Zlib::GzipWriter.wrap(io) { |gzip| gzip.write(html) } }.string
+      }
+    },
+    {
+      label: 'brotli',
+      encode: ->(html) { Brotli.deflate(html) }
+    }
+  ].each do |codec|
+    context "when #{codec[:label]} HTML is labeled application/octet-stream" do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      let(:html) { '<!DOCTYPE html><html><body><div>decoded stream</div></body></html>' }
+      let(:response) do
+        instance_double(
+          Faraday::Response,
+          body: codec[:encode].call(html),
+          headers: { 'content-type' => 'application/octet-stream' },
+          env: response_env,
+          status: 200
+        )
+      end
+
+      it 'decodes the HTML document before parse' do
+        expect(execute.parsed_body.at_css('div').text).to eq('decoded stream')
+      end
+    end
   end
 
   describe 'RedirectLimitReached terminal URL retry' do # rubocop:disable RSpec/MultipleMemoizedHelpers

--- a/spec/lib/html2rss/request_service/policy_spec.rb
+++ b/spec/lib/html2rss/request_service/policy_spec.rb
@@ -210,9 +210,11 @@ RSpec.describe Html2rss::RequestService::Policy do
     context 'when the redirect downgrades the scheme' do # rubocop:disable RSpec/MultipleMemoizedHelpers
       let(:to_url) { Html2rss::Url.from_absolute('http://example.com/feed') }
 
-      it 'rejects the redirect' do
-        expect { validate_redirect! }.to raise_error(Html2rss::RequestService::UnsupportedUrlScheme,
-                                                     'Redirect downgraded from https to http')
+      it 'rejects the redirect and names the hop', :aggregate_failures do
+        expect { validate_redirect! }.to raise_error(
+          Html2rss::RequestService::UnsupportedUrlScheme,
+          'Redirect downgraded from https://example.com/feed to http://example.com/feed'
+        )
       end
     end
 

--- a/spec/lib/html2rss/request_service/response_spec.rb
+++ b/spec/lib/html2rss/request_service/response_spec.rb
@@ -75,6 +75,32 @@ RSpec.describe Html2rss::RequestService::Response do
                            'Unsupported content type: text/plain')
       end
     end
+
+    [
+      { content_type: 'application/octet-stream', label: 'octet-stream' },
+      { content_type: '', label: 'empty' },
+      { content_type: 'text/plain', label: 'wrong' }
+    ].each do |example|
+      context "when Content-Type is #{example[:label]} but the body looks like HTML" do
+        let(:body) { "<!DOCTYPE html><html><body><div>#{example[:label]}</div></body></html>" }
+        let(:headers) { example[:content_type].empty? ? {} : { 'content-type' => example[:content_type] } }
+
+        it 'parses the HTML document' do
+          expect(parsed_body.at_css('div').text).to eq(example[:label])
+        end
+      end
+    end
+
+    context 'when Content-Type is octet-stream and the body is not HTML' do
+      let(:body) { "PK\x03\x04not-html" }
+      let(:headers) { { 'content-type' => 'application/octet-stream' } }
+
+      it 'raises UnsupportedResponseContentType' do
+        expect { parsed_body }
+          .to raise_error(Html2rss::RequestService::UnsupportedResponseContentType,
+                          'Unsupported content type: application/octet-stream')
+      end
+    end
   end
 
   describe '#url' do

--- a/spec/lib/html2rss/request_service/response_spec.rb
+++ b/spec/lib/html2rss/request_service/response_spec.rb
@@ -29,6 +29,39 @@ RSpec.describe Html2rss::RequestService::Response do
     end
   end
 
+  describe '#html_response?' do
+    [
+      { content_type: 'application/octet-stream', label: 'octet-stream' },
+      { content_type: '', label: 'empty' },
+      { content_type: 'text/plain', label: 'wrong' }
+    ].each do |example|
+      context "when Content-Type is #{example[:label]} but the body looks like HTML" do
+        let(:body) { "<!DOCTYPE html><html><body><div>#{example[:label]}</div></body></html>" }
+        let(:headers) { example[:content_type].empty? ? {} : { 'content-type' => example[:content_type] } }
+
+        it 'treats sniffed HTML as an HTML response so Capture and Inspect do not skip SST' do
+          expect(instance.html_response?).to be true
+        end
+      end
+    end
+
+    context 'when the response is JSON' do
+      let(:body) { '{"html":"<html></html>"}' }
+      let(:headers) { { 'content-type' => 'application/json' } }
+
+      it 'does not treat JSON as HTML even when the payload mentions markup' do
+        expect(instance.html_response?).to be false
+      end
+    end
+
+    context 'when Content-Type is octet-stream and the body is not HTML' do
+      let(:body) { "PK\x03\x04not-html" }
+      let(:headers) { { 'content-type' => 'application/octet-stream' } }
+
+      it { expect(instance.html_response?).to be false }
+    end
+  end
+
   describe '#parsed_body' do
     subject(:parsed_body) { instance.parsed_body }
 

--- a/spec/lib/html2rss/request_service/response_spec.rb
+++ b/spec/lib/html2rss/request_service/response_spec.rb
@@ -101,6 +101,29 @@ RSpec.describe Html2rss::RequestService::Response do
                           'Unsupported content type: application/octet-stream')
       end
     end
+
+    [
+      {
+        label: 'Content-Type charset',
+        headers: { 'content-type' => 'text/html; charset=windows-1252' },
+        html: '<!DOCTYPE html><html><body><h1>Caffè</h1></body></html>'
+      },
+      {
+        label: 'meta charset',
+        headers: { 'content-type' => 'text/html' },
+        html: '<!DOCTYPE html><html><head><meta charset="windows-1252"></head>' \
+              '<body><h1>Caffè</h1></body></html>'
+      }
+    ].each do |example|
+      context "when windows-1252 HTML uses #{example[:label]}" do
+        let(:body) { example[:html].encode('Windows-1252').force_encoding(Encoding::UTF_8) }
+        let(:headers) { example[:headers] }
+
+        it 'decodes Caffè instead of mojibake' do
+          expect(parsed_body.at_css('h1').text).to eq('Caffè')
+        end
+      end
+    end
   end
 
   describe '#url' do

--- a/spec/lib/html2rss/url_spec.rb
+++ b/spec/lib/html2rss/url_spec.rb
@@ -180,6 +180,14 @@ RSpec.describe Html2rss::Url do
       expect(url.host).to eq('example.com')
     end
 
+    it 'returns the registrable domain (eTLD+1)' do
+      expect(described_class.from_absolute('https://www.wp.pl/').domain).to eq('wp.pl')
+    end
+
+    it 'uses the host for IP addresses instead of a public-suffix suffix' do
+      expect(described_class.from_absolute('https://1.2.3.4/story').domain).to eq('1.2.3.4')
+    end
+
     it 'delegates path method' do
       expect(url.path).to eq('/path')
     end

--- a/spec/lib/html2rss_spec.rb
+++ b/spec/lib/html2rss_spec.rb
@@ -450,8 +450,8 @@ RSpec.describe Html2rss do
       expect(feed_return).to be_a(RSS::Rss)
       expect(feed_return.channel.title).to eq 'WELT - Aktuelle Nachrichten, News, Hintergründe & Videos'
       expect(feed_return.channel.link).to eq 'https://www.welt.de/'
-      # Admission hard-exclude + no Html padding: fewer clean items beats a padded homepage.
-      expect(feed_return.items.size).to eq(75)
+      # eTLD+1 keeps same-site portal hosts (go.welt.de, asbs.welt.de) with www.welt.de.
+      expect(feed_return.items.size).to eq(86)
     end
 
     it_behaves_like 'auto source option forwarding', method: :auto_source
@@ -469,7 +469,7 @@ RSpec.describe Html2rss do
     end
 
     it 'returns items', :slow do
-      expect(feed_return[:items].size).to eq(75)
+      expect(feed_return[:items].size).to eq(86)
     end
 
     it_behaves_like 'auto source option forwarding', method: :auto_json_feed

--- a/spec/support/shared_examples/article_extractor_leftover.rb
+++ b/spec/support/shared_examples/article_extractor_leftover.rb
@@ -191,6 +191,27 @@ RSpec.shared_examples 'article extractor leftover hygiene' do
     end
   end
 
+  describe 'crowded parent with two distinct content hrefs' do
+    let(:html) do
+      <<~HTML
+        <div class="card">
+          <h3><a href="/news/one">Title One About The First Story</a></h3>
+          <p>Shared teaser that must not attach to one crowded heading.</p>
+          <h3><a href="/news/two">Title Two About The Second Story</a></h3>
+        </div>
+      HTML
+    end
+
+    it 'aborts the parent walk instead of taking the shared teaser', :aggregate_failures do
+      fields = leftover_fields.call(html, item_selector: 'h3')
+
+      expect(fields[:title]).to eq('Title One About The First Story')
+      expect(fields[:description]).to be_nil
+      expect(fields[:description].to_s).not_to include('Shared teaser')
+      expect(fields[:description].to_s).not_to include('Title Two')
+    end
+  end
+
   describe 'heading wrapped in a header landmark' do
     let(:html) do
       <<~HTML

--- a/spec/support/shared_examples/article_extractor_leftover.rb
+++ b/spec/support/shared_examples/article_extractor_leftover.rb
@@ -304,7 +304,7 @@ RSpec.shared_examples 'article extractor leftover hygiene' do
       HTML
     end
 
-    it 'does not treat title plus CTA as two articles', :aggregate_failures do
+    it 'does not treat title plus CTA as two articles', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
       fields = leftover_fields.call(html, item_selector: 'h3 a')
 
       expect(fields[:title]).to eq('Heading title about the story')

--- a/spec/support/shared_examples/article_extractor_leftover.rb
+++ b/spec/support/shared_examples/article_extractor_leftover.rb
@@ -315,6 +315,24 @@ RSpec.shared_examples 'article extractor leftover hygiene' do
     end
   end
 
+  describe 'clock plus teaser is not date chrome' do
+    let(:html) do
+      <<~HTML
+        <article>
+          <h2><a href="/news/story">Headline about the reactor design</a></h2>
+          <p>12 March 2024 - 10:00 Team announces a new reactor design</p>
+        </article>
+      HTML
+    end
+
+    it 'keeps the teaser line in the description', :aggregate_failures do
+      fields = leftover_fields.call(html)
+
+      expect(fields[:description]).to eq('12 March 2024 - 10:00 Team announces a new reactor design')
+      expect(fields[:description]).to include('Team announces a new reactor design')
+    end
+  end
+
   describe 'Nokia-shaped wrapping anchor with pipe date' do
     let(:html) do
       <<~HTML

--- a/spec/support/shared_examples/article_extractor_leftover.rb
+++ b/spec/support/shared_examples/article_extractor_leftover.rb
@@ -270,4 +270,87 @@ RSpec.shared_examples 'article extractor leftover hygiene' do
       expect(fields[:published_at].to_date).to eq(Date.new(2024, 3, 12))
     end
   end
+
+  describe 'DIIS-shaped heading-link item' do
+    let(:html) do
+      <<~HTML
+        <article class="research-card">
+          <h3><a href="/research/publication-one">Title of the publication about research</a></h3>
+          <p>Sibling teaser that lives beside the heading link.</p>
+          <time datetime="2024-03-12T09:00:00Z">12 March 2024</time>
+        </article>
+      HTML
+    end
+
+    it 'walks from h3 a to the card for teaser, date, and url', :aggregate_failures do
+      fields = leftover_fields.call(html, item_selector: 'h3 a')
+
+      expect(fields[:title]).to eq('Title of the publication about research')
+      expect(fields[:description]).to eq('Sibling teaser that lives beside the heading link.')
+      expect(fields[:published_at]).to be_a(DateTime)
+      expect(fields[:url].to_s).to include('/research/publication-one')
+    end
+  end
+
+  describe 'heading-link plus same-href Read more' do
+    let(:html) do
+      <<~HTML
+        <div class="card">
+          <h3><a href="/news/story">Heading title about the story</a></h3>
+          <p>Sibling teaser that lives beside the heading.</p>
+          <a href="/news/story">Read more</a>
+          <time datetime="2024-03-12T09:00:00Z">12 March 2024</time>
+        </div>
+      HTML
+    end
+
+    it 'does not treat title plus CTA as two articles', :aggregate_failures do
+      fields = leftover_fields.call(html, item_selector: 'h3 a')
+
+      expect(fields[:title]).to eq('Heading title about the story')
+      expect(fields[:description]).to eq('Sibling teaser that lives beside the heading.')
+      expect(fields[:description].to_s).not_to eq('Read more')
+      expect(fields[:published_at]).to be_a(DateTime)
+      expect(fields[:url].to_s).to include('/news/story')
+    end
+  end
+
+  describe 'Nokia-shaped wrapping anchor with pipe date' do
+    let(:html) do
+      <<~HTML
+        <a href="/news/story">
+          <h2>Nokia headline about the product launch</h2>
+          <span>August 06 , 2026 | 13:00 PM Europe/Amsterdam</span>
+        </a>
+      HTML
+    end
+
+    it 'parses the calendar day and drops the pipe clock line', :aggregate_failures do
+      fields = leftover_fields.call(html, item_selector: 'a')
+
+      expect(fields[:title]).to eq('Nokia headline about the product launch')
+      expect(fields[:published_at]).to be_a(DateTime)
+      expect(fields[:published_at].to_date).to eq(Date.new(2026, 8, 6))
+      expect(fields[:description]).to be_nil
+    end
+  end
+
+  describe 'Telenor-shaped wrapping anchor with bullet juli date' do
+    let(:html) do
+      <<~HTML
+        <a href="/news/story">
+          <h2>Telenor headline about the network upgrade</h2>
+          <span>Press release • 16 juli, 2026</span>
+        </a>
+      HTML
+    end
+
+    it 'drops the type-chip date line from description', :aggregate_failures do
+      fields = leftover_fields.call(html, item_selector: 'a')
+
+      expect(fields[:title]).to eq('Telenor headline about the network upgrade')
+      expect(fields[:description]).to be_nil
+      expect(fields[:description].to_s).not_to include('juli')
+    end
+  end
 end


### PR DESCRIPTION
## What changed

- Botasaurus client matches scrape-api OpenAPI **2.0.0**: `POST /scrape` maps `ScrapeSuccess` (HTTP 200) vs `ScrapeError` (400/403/422/502/504). Nested `diagnostics` (+ success `metadata_error`) become `Response#transport_meta`. No `ScrapeResponse` alias, no FastAPI `detail` parse, no `scroll_to_bottom`. `window_size` is `{width, height}`.
- YAML `request.botasaurus` unknown keys fail admission (including removed `scroll_to_bottom`). Packaged JSON Schema sets `additionalProperties: false` on the botasaurus object and on `window_size`.
- Faraday HTML sniff treats `<!DOCTYPE html` / `<html` as HTML when Content-Type is missing, empty, `text/plain`, or `application/octet-stream`. `Response#html_response?` is the one HTML-ness predicate. AutoFallback records Faraday `UnsupportedResponseContentType` and hops to Botasaurus.
- Faraday decodes gzip/brotli (`CompressedBody`) before sniff/parse, then transcodes HTML charset. Inflate stays Faraday-only.
- Leftover heading-link walk starts parent-card fill for any item anchor. Walk policy lives in `Html::CardWalk`. Capture lifts heading roots to usable cards as a second job.
- Cleanup admits same-site portal hosts by eTLD+1 and drops JSON-blob titles.

## Why

The Botasaurus scrape API stabilized on OpenAPI 2.0 (split success/error envelopes, nested diagnostics, object viewport). The 1.x client would mis-parse 2.0 bodies and still accept `scroll_to_bottom` / array `window_size`. Auto feeds were also failing on leftover chrome, mislabeled/compressed Faraday bodies, heading-link Capture selectors, and same-host portal admission.

## Risk

- **Breaking:** this gem must run against scrape-api **2.0.0**. Pointing `BOTASAURUS_SCRAPER_URL` at 1.x fails loud (missing `diagnostics` / Error envelope). YAML with array `window_size` or `scroll_to_bottom` is rejected.
- AutoFallback now continues after Faraday `UnsupportedResponseContentType`; Botasaurus may run where Faraday used to abort.
- `html_response?` is true for sniffed non-JSON HTML; Capture, Channel, and Inspect SST-parse those bodies.
- eTLD+1 admission keeps more same-site hosts (welt fixture 75 → 86).
- Owned residual: unlabeled gzip/brotli inflate can allocate before a decompressed-size guard. Sibling OpenAPI snapshot is skipped in gem CI when `../botasaurus-scrape-api` is absent.

## Review map

1. `spec/lib/html2rss/request_service/botasaurus_contract_spec.rb` — OpenAPI 2.0 lock (Success/Error, no `ScrapeResponse`, object `window_size`).
2. `lib/html2rss/request_service/botasaurus_contract.rb` — request payload + envelope parse; `Success` vs `Error`.
3. `lib/html2rss/request_service/botasaurus_strategy.rb` — Faraday `POST /scrape` error mapping only.
4. `lib/html2rss/config/validator.rb` + `schema/html2rss-config.schema.json` — YAML admission and published schema.
5. `lib/html2rss/html/card_walk.rb` — leftover parent-card walk policy.
6. `lib/html2rss/request_service/response.rb` + `compressed_body.rb` — HTML-ness sniff and Faraday-only inflate.

## Validation

- `make quick` — exit 0
- `make ready` — exit 0 (1615 examples, 0 failures)
- Assure — production readiness Conditional; no Critical/Important on the OpenAPI 2.0 commits. Ship only with scrape-api 2.0.0.