### PR TITLE
feat(schema): require directory.title for catalog configs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,7 @@ Produce RSS 2.0 feeds from websites by scraping HTML or JSON. Adapt your strateg
 - Use `make quick` during implementation for the fast local feedback loop. It should stay focused on changed-file linting and targeted specs.
 - Treat `make ready` as the implementation quality gate before handoff or a potential PR merge. It must cover the repo's required merge checks.
 - When adding or modifying configuration options in `lib/html2rss/selectors/config.rb` or `lib/html2rss/config/validator.rb`, update `lib/html2rss/config/schema.rb` (`Html2rss::Config::Schema`) so the property is exported to the JSON schema, then run `make schema` to sync `schema/html2rss-config.schema.json`.
+- Catalog metadata on `directory` (`title`, `summary`, `topics`) is validated in `DirectoryConfig`. When changing those rules, regenerate the schema and coordinate `html2rss-configs` validation plus `Html2rss::Configs::Catalog`.
 - Treat YARD linting as a contract-integrity check for contributor-facing APIs and documentation syntax correctness. Keep validator scope high-signal; avoid baseline/todo suppression files as a long-term mechanism.
 - Run Ruby, Bundler, Rake, RuboCop, Reek, YARD, and RSpec commands through `mise exec -- ...` directly or via Make targets.
 - Treat `docs/` as generated YARD HTML only (`make docs` / `make clean`). Never commit source markdown there.

--- a/lib/html2rss/config/validator.rb
+++ b/lib/html2rss/config/validator.rb
@@ -35,6 +35,8 @@ module Html2rss
 
       # Contract for catalog-only `directory` metadata (topics for feed directories).
       DirectoryConfig = Dry::Schema.Params do
+        required(:title).filled(:string)
+        optional(:summary).maybe(:string, max_size?: 160)
         optional(:topics).value(:array, min_size?: 1).each(:string, included_in?: DIRECTORY_TOPICS)
       end
 

--- a/schema/html2rss-config.schema.json
+++ b/schema/html2rss-config.schema.json
@@ -66,6 +66,17 @@
     "directory": {
       "type": "object",
       "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "summary": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "maxLength": 160
+        },
         "topics": {
           "type": "array",
           "items": {
@@ -92,7 +103,9 @@
           "minItems": 1
         }
       },
-      "required": []
+      "required": [
+        "title"
+      ]
     },
     "headers": {
       "type": "object",

--- a/spec/lib/html2rss/config_spec.rb
+++ b/spec/lib/html2rss/config_spec.rb
@@ -322,7 +322,30 @@ RSpec.describe Html2rss::Config do
       expect(described_class.validate(config_with_unknown_strategy)).to be_failure
     end
 
-    context 'when directory includes valid topics' do
+    context 'when directory includes valid metadata' do
+      let(:config) do
+        {
+          directory: {
+            title: 'Example — News',
+            summary: 'Latest headlines from Example.',
+            topics: %w[sports news]
+          },
+          channel: { url: 'http://example.com' },
+          selectors: { items: { selector: '.item' }, title: { selector: 'h2' } }
+        }
+      end
+
+      it 'accepts the directory metadata contract', :aggregate_failures do
+        result = described_class.validate(config)
+
+        expect(result).to be_success
+        expect(result.to_h.dig(:directory, :title)).to eq('Example — News')
+        expect(result.to_h.dig(:directory, :summary)).to eq('Latest headlines from Example.')
+        expect(result.to_h.dig(:directory, :topics)).to eq(%w[sports news])
+      end
+    end
+
+    context 'when directory title is missing' do
       let(:config) do
         {
           directory: { topics: %w[sports news] },
@@ -331,18 +354,33 @@ RSpec.describe Html2rss::Config do
         }
       end
 
-      it 'accepts the directory topics contract', :aggregate_failures do
-        result = described_class.validate(config)
+      it 'rejects directory without title' do
+        expect(described_class.validate(config)).to be_failure
+      end
+    end
 
-        expect(result).to be_success
-        expect(result.to_h.dig(:directory, :topics)).to eq(%w[sports news])
+    context 'when directory summary exceeds 160 characters' do
+      let(:config) do
+        {
+          directory: {
+            title: 'Example — News',
+            summary: 'x' * 161,
+            topics: %w[news]
+          },
+          channel: { url: 'http://example.com' },
+          selectors: { items: { selector: '.item' }, title: { selector: 'h2' } }
+        }
+      end
+
+      it 'rejects an oversized summary' do
+        expect(described_class.validate(config)).to be_failure
       end
     end
 
     context 'when directory topics are empty' do
       let(:config) do
         {
-          directory: { topics: [] },
+          directory: { title: 'Example — News', topics: [] },
           channel: { url: 'http://example.com' },
           selectors: { items: { selector: '.item' }, title: { selector: 'h2' } }
         }
@@ -356,7 +394,7 @@ RSpec.describe Html2rss::Config do
     context 'when directory topics include an unknown value' do
       let(:config) do
         {
-          directory: { topics: %w[sports unknown-topic] },
+          directory: { title: 'Example — News', topics: %w[sports unknown-topic] },
           channel: { url: 'http://example.com' },
           selectors: { items: { selector: '.item' }, title: { selector: 'h2' } }
         }


### PR DESCRIPTION
## Summary
- Add required `directory.title` and optional `directory.summary` (max 160 chars) to the config JSON schema and `DirectoryConfig` validator.
- Regenerate `schema/html2rss-config.schema.json` and extend validator specs.

## Test plan
- [x] `make ready` (RSpec, RuboCop, schema sync)