### PR TITLE
fix(gem): align botasaurus client timeouts with scrape-api work budget

### DIFF
--- a/lib/html2rss/request_service/botasaurus_contract.rb
+++ b/lib/html2rss/request_service/botasaurus_contract.rb
@@ -7,7 +7,7 @@ module Html2rss
     ##
     # Maps html2rss request/response handling to botasaurus-scrape-api OpenAPI 2.0
     # +ScrapeRequest+ / +ScrapeSuccess+ / +ScrapeError+ (sibling +openapi.yaml+).
-    class BotasaurusContract # rubocop:disable Metrics/ClassLength -- Success/Error envelopes stay with the owner
+    class BotasaurusContract
       # Closed set from OpenAPI ExecutionMode.
       EXECUTION_MODES = %w[auto request browser].freeze
       # Closed set from OpenAPI NavigationMode.
@@ -25,12 +25,19 @@ module Html2rss
       # OpenAPI WindowSize required keys (positive integers).
       WINDOW_SIZE_PROPERTIES = %i[width height].freeze
 
-      # Published wait clamp floor (`[1, 20]` in OpenAPI description).
+      # Faraday POST /scrape cap mirroring botasaurus-scrape-api total scrape wall (`SCRAPE_TIMEOUT_SECONDS`).
+      SCRAPE_TIMEOUT_SECONDS = Integer(ENV.fetch('BOTASAURUS_SCRAPE_TIMEOUT_SECONDS', 45))
+      # Post-boot navigate/wait budget mirrored from scrape-api (`SCRAPE_WORK_TIMEOUT_SECONDS`).
+      SCRAPE_WORK_TIMEOUT_SECONDS = Integer(ENV.fetch('BOTASAURUS_SCRAPE_WORK_TIMEOUT_SECONDS', 30))
+      # Seconds added to the scrape total for client transport overhead.
+      TRANSPORT_BUFFER_SECONDS = 2
+
+      # Published wait clamp floor (`[1, SCRAPE_WORK_TIMEOUT_SECONDS]` in OpenAPI description).
       MIN_WAIT_TIMEOUT_SECONDS = 1
       # Published wait clamp ceiling; YAML values above this are rejected.
-      MAX_WAIT_TIMEOUT_SECONDS = 20
+      MAX_WAIT_TIMEOUT_SECONDS = SCRAPE_WORK_TIMEOUT_SECONDS
       # OpenAPI wait_timeout_seconds default (omitted from the client payload).
-      DEFAULT_WAIT_TIMEOUT_SECONDS = 15
+      DEFAULT_WAIT_TIMEOUT_SECONDS = [15, SCRAPE_WORK_TIMEOUT_SECONDS].min
 
       # OpenAPI max_retries maximum (default 2 is applied upstream when omitted).
       MAX_RETRIES = 3
@@ -39,12 +46,6 @@ module Html2rss
       DIAGNOSTICS_KEYS = %w[request_id attempts strategy_used render_ms execution_tier challenge].freeze
       # Allowlisted ChallengeSignal keys nested under diagnostics.challenge.
       CHALLENGE_KEYS = %w[blocked detected marker].freeze
-
-      # Remaining seconds at or below which Botasaurus retries are disabled.
-      TIGHT_BUDGET_SECONDS = 12
-
-      # Seconds reserved from remaining budget before setting wait_timeout_seconds.
-      BUDGET_WAIT_RESERVE_SECONDS = 2
 
       ##
       # Parsed OpenAPI ScrapeSuccess envelope (HTTP 200).
@@ -246,7 +247,6 @@ module Html2rss
       # @param url [Html2rss::Url] canonical URL to scrape
       # @param headers [Hash] request headers from context
       # @param options [Hash] validated request.botasaurus options
-      # @param remaining_timeout_seconds [Numeric, nil] shared request budget remainder for clamps
       # @option options [String] :execution_mode
       # @option options [String] :navigation_mode
       # @option options [Integer] :max_retries
@@ -264,19 +264,19 @@ module Html2rss
       # @option options [String] :lang
       # @option options [Hash] :cookies
       # @option options [Hash] :headers
-      def initialize(url:, headers: {}, options: {}, remaining_timeout_seconds: nil)
+      def initialize(url:, headers: {}, options: {})
         @url = url
         @headers = headers
         @options = options
-        @remaining_timeout_seconds = remaining_timeout_seconds
       end
 
-      # @return [Hash] payload for POST /scrape (explicit options plus budget clamp-downs)
+      # @return [Hash] payload for POST /scrape (explicit options plus wait cap)
       def request_payload
         payload = { url: url.to_s }.merge(filtered_options)
         forwarded_headers = merged_headers
         payload[:headers] = forwarded_headers if forwarded_headers&.any?
-        clamp_for_budget(payload)
+        cap_wait_timeout!(payload)
+        payload
       end
 
       # @param transport_response [Faraday::Response] upstream HTTP response
@@ -291,7 +291,7 @@ module Html2rss
 
       private
 
-      attr_reader :url, :headers, :options, :remaining_timeout_seconds
+      attr_reader :url, :headers, :options
 
       def json_object(body)
         payload = JSON.parse(body)
@@ -313,36 +313,6 @@ module Html2rss
         REQUEST_OPTION_KEYS.each_with_object({}) do |key, normalized|
           normalized[key] = options[key] if options.key?(key)
         end
-      end
-
-      def clamp_for_budget(payload)
-        remaining = remaining_timeout_seconds
-        clamped = payload.dup
-        unless remaining.nil?
-          apply_tight_retries!(clamped, remaining)
-          apply_budget_wait!(clamped, remaining)
-        end
-        cap_wait_timeout!(clamped)
-        clamped
-      end
-
-      def apply_tight_retries!(payload, remaining)
-        payload[:max_retries] = 0 if remaining <= TIGHT_BUDGET_SECONDS
-      end
-
-      def apply_budget_wait!(payload, remaining)
-        budget_wait = budget_wait_seconds(remaining)
-        configured = payload[:wait_timeout_seconds]
-        if configured
-          payload[:wait_timeout_seconds] = [configured, budget_wait].min
-        elsif budget_wait < DEFAULT_WAIT_TIMEOUT_SECONDS
-          payload[:wait_timeout_seconds] = budget_wait
-        end
-      end
-
-      def budget_wait_seconds(remaining)
-        reserved = [MIN_WAIT_TIMEOUT_SECONDS, (remaining - BUDGET_WAIT_RESERVE_SECONDS).floor].max
-        [reserved, MAX_WAIT_TIMEOUT_SECONDS].min
       end
 
       def cap_wait_timeout!(payload)

--- a/lib/html2rss/request_service/botasaurus_strategy.rb
+++ b/lib/html2rss/request_service/botasaurus_strategy.rb
@@ -74,8 +74,7 @@ module Html2rss
         @contract ||= BotasaurusContract.new(
           url: ctx.url,
           headers: ctx.headers,
-          options: ctx.request.fetch(:botasaurus, {}),
-          remaining_timeout_seconds: attempt_timeout_seconds
+          options: ctx.request.fetch(:botasaurus, {})
         )
       end
 
@@ -104,9 +103,10 @@ module Html2rss
       end
 
       def attempt_timeout_seconds
-        @attempt_timeout_seconds ||= ctx.budget.effective_timeout_seconds(
-          fallback: ctx.policy.total_timeout_seconds
-        )
+        @attempt_timeout_seconds ||= begin
+          budget = ctx.budget.effective_timeout_seconds(fallback: ctx.policy.total_timeout_seconds)
+          [budget, BotasaurusContract::SCRAPE_TIMEOUT_SECONDS + BotasaurusContract::TRANSPORT_BUFFER_SECONDS].min
+        end
       end
 
       def scraper_base_url

--- a/schema/html2rss-config.schema.json
+++ b/schema/html2rss-config.schema.json
@@ -698,7 +698,7 @@
                 "type": "null"
               },
               "minimum": 1,
-              "maximum": 20
+              "maximum": 30
             },
             "scroll": {
               "type": "boolean",

--- a/spec/fixtures/botasaurus/openapi.yaml
+++ b/spec/fixtures/botasaurus/openapi.yaml
@@ -10,7 +10,7 @@ info:
     - `POST /scrape` — scrape a public `http`/`https` URL
 
 
-    `wait_timeout_seconds` values outside `[1, 20]`
+    `wait_timeout_seconds` values outside `[1, 30]`
 
     are **clamped** into that range so scrape still runs; they are not rejected
 
@@ -174,7 +174,7 @@ paths:
             application/json:
               example:
                 url: https://example.com
-                error: Scrape timed out after 20 seconds
+                error: Scrape timed out after 45 seconds
                 error_category: timeout
                 diagnostics:
                   request_id: b01ef2f8-f641-4e75-8ef2-0b73f7b4f372
@@ -411,7 +411,7 @@ components:
         wait_timeout_seconds:
           type: integer
           title: Wait Timeout Seconds
-          description: Selector wait timeout in seconds. Values outside [1, 20] are
+          description: Selector wait timeout in seconds. Values outside [1, 30] are
             clamped into that range so scrape still runs; they are not rejected with
             422.
           default: 15

--- a/spec/lib/html2rss/config/schema_spec.rb
+++ b/spec/lib/html2rss/config/schema_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Html2rss::Config::Schema do
       expect(botasaurus.dig('max_retries', 'minimum')).to eq(0)
       expect(botasaurus.dig('max_retries', 'maximum')).to eq(3)
       expect(botasaurus.dig('wait_timeout_seconds', 'minimum')).to eq(1)
-      expect(botasaurus.dig('wait_timeout_seconds', 'maximum')).to eq(20)
+      expect(botasaurus.dig('wait_timeout_seconds', 'maximum')).to eq(30)
       expect(botasaurus).to have_key('scroll')
       expect(botasaurus).not_to have_key('scroll_to_bottom')
       expect(botasaurus).to have_key('block_trackers')

--- a/spec/lib/html2rss/request_service/botasaurus_contract_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_contract_spec.rb
@@ -97,10 +97,7 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
   describe '#request_payload' do
     subject(:payload) { contract.request_payload }
 
-    let(:contract) do
-      described_class.new(url:, remaining_timeout_seconds:)
-    end
-    let(:remaining_timeout_seconds) { 30 }
+    let(:contract) { described_class.new(url:) }
 
     it 'sends only the URL so OpenAPI defaults apply', :aggregate_failures do
       expect(payload).to eq(url: 'https://example.com/')
@@ -109,20 +106,11 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
       expect(payload).not_to have_key(:headless)
     end
 
-    context 'when remaining budget minus reserve still exceeds the OpenAPI wait default' do
-      let(:remaining_timeout_seconds) { 25 }
+    context 'when configured wait_timeout_seconds exceeds the work budget cap' do
+      let(:contract) { described_class.new(url:, options: { wait_timeout_seconds: 35 }) }
 
-      it 'does not inflate wait_timeout_seconds above the published default' do
-        expect(payload).not_to have_key(:wait_timeout_seconds)
-      end
-    end
-
-    context 'when remaining budget cannot cover the published wait default' do
-      let(:remaining_timeout_seconds) { 12 }
-
-      it 'clamps wait down and disables retries', :aggregate_failures do
-        expect(payload.fetch(:wait_timeout_seconds)).to eq(10)
-        expect(payload.fetch(:max_retries)).to eq(0)
+      it 'caps wait_timeout_seconds at MAX_WAIT_TIMEOUT_SECONDS' do
+        expect(payload.fetch(:wait_timeout_seconds)).to eq(described_class::MAX_WAIT_TIMEOUT_SECONDS)
       end
     end
 
@@ -203,8 +191,8 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
             'detail' => [
               {
                 'loc' => %w[body wait_timeout_seconds],
-                'msg' => 'Input should be less than or equal to 20',
-                'input' => 28
+                'msg' => 'Input should be less than or equal to 30',
+                'input' => 35
               }
             ]
           }

--- a/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
@@ -175,42 +175,27 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
       end
     end
 
-    # rubocop:disable RSpec/NestedGroups -- budget clamp matrix stays with request contract
-    context 'when remaining budget is tight' do
-      [
-        { remaining: 12, max_retries: 0, wait_timeout_seconds: 10 },
-        { remaining: 10.5, max_retries: 0, wait_timeout_seconds: 8 },
-        { remaining: 20, max_retries: nil, wait_timeout_seconds: nil },
-        { remaining: 25, max_retries: nil, wait_timeout_seconds: nil }
-      ].each do |example|
-        context "with remaining=#{example[:remaining]}" do
-          before do
-            allow(budget).to receive(:effective_timeout_seconds).and_return(example[:remaining])
-          end
-
-          it 'clamps max_retries and wait_timeout_seconds', :aggregate_failures do
-            execute
-
-            payload = JSON.parse(captured_post_args.first.fetch(1))
-            expect(payload['max_retries']).to eq(example[:max_retries])
-            expect(payload['wait_timeout_seconds']).to eq(example[:wait_timeout_seconds])
-          end
-        end
+    context 'when feed budget exceeds the scrape-api transport cap' do
+      before do
+        allow(budget).to receive(:effective_timeout_seconds).and_return(60.0)
       end
 
-      context 'when configured wait_timeout_seconds is below the budget cap' do
-        let(:request_config) { { botasaurus: { wait_timeout_seconds: 5 } } }
+      it 'uses the scrape total plus transport buffer for Faraday timeout' do
+        execute
 
-        before { allow(budget).to receive(:effective_timeout_seconds).and_return(20) }
-
-        it 'keeps the lower configured wait timeout' do
-          execute
-
-          expect(JSON.parse(captured_post_args.first.fetch(1))['wait_timeout_seconds']).to eq(5)
-        end
+        cap = Html2rss::RequestService::BotasaurusContract::SCRAPE_TIMEOUT_SECONDS +
+              Html2rss::RequestService::BotasaurusContract::TRANSPORT_BUFFER_SECONDS
+        expect(Faraday).to have_received(:new).with(
+          url: 'http://localhost:4010/',
+          headers: {
+            'User-Agent' => Html2rss::Config::RequestHeaders::DEFAULT_USER_AGENT,
+            'Accept' => described_class::TRANSPORT_ACCEPT,
+            'Accept-Encoding' => described_class::TRANSPORT_ENCODING
+          },
+          request: { timeout: cap }
+        )
       end
     end
-    # rubocop:enable RSpec/NestedGroups
   end
 
   describe 'transport headers' do


### PR DESCRIPTION
## Summary

- Align gem Botasaurus client constants with scrape-api total (45s) and work (30s) budgets via env-driven `SCRAPE_TIMEOUT_SECONDS` / `SCRAPE_WORK_TIMEOUT_SECONDS`.
- Remove gem-side payload budget clamping (`clamp_for_budget`, tight-budget retries/wait); pass YAML options through and only cap `wait_timeout_seconds` to the work budget.
- Cap Faraday `/scrape` timeout at `min(feed budget, scrape total + 2s transport buffer)`; sync OpenAPI fixture and config schema max `wait_timeout_seconds` to 30.

Depends on html2rss/botasaurus-scrape-api#42

## Test plan

- [x] `make ready` (exit 0)
- [x] OpenAPI fixture copied from PR1 `openapi.yaml`
- [x] Budget-clamp matrix specs removed; transport cap spec added