### PR TITLE
feat(scraper): add NativeFeed scraper to discover/parse native RSS/Atom

### DIFF
--- a/lib/html2rss/auto_source.rb
+++ b/lib/html2rss/auto_source.rb
@@ -24,6 +24,9 @@ module Html2rss
     DEFAULT_CONFIG = {
       limit: DEFAULT_LIMIT,
       scraper: {
+        native_feed: {
+          enabled: true
+        },
         wordpress_api: {
           enabled: true
         },

--- a/lib/html2rss/auto_source/README.md
+++ b/lib/html2rss/auto_source/README.md
@@ -10,9 +10,10 @@ Entry: `FeedPipeline` → `AutoSource#articles` → `Scraper.build_instance` →
 
 ## Live flow
 
-1. **Request** — `RequestSession` returns a `Response` with `body` (String) and `parsed_body` (Nokogiri HTML).
+1. **Request** — `RequestSession` returns a `Response` with `body` (String) and `parsed_body` (Nokogiri HTML). Direct syndication responses skip HTML scrapers and parse via `Syndication::Parser`.
 2. **Scraper tiers** — Enabled scrapers that claim the page (shallow `articles?` or instance `extractable?`) run in `Scraper::SCRAPER_TIERS` order. Merge within a tier, then stop when enough articles survive Cleanup:
 
+   0. Native feed: NativeFeed (head alternates + path discovery → RSS/Atom parse)
    1. In-page structured: Schema, Microdata, Microformats2, JsonState, XhrArticles
    2. Follow-up IO: WordPress API, Sitemap, MetaOembed
    3. Heuristic: SemanticHtml

--- a/lib/html2rss/auto_source/scraper.rb
+++ b/lib/html2rss/auto_source/scraper.rb
@@ -23,7 +23,9 @@ module Html2rss
 
       # Extraction tiers: merge within a tier, then stop when AutoSource has enough articles.
       # Heuristic scrapers are separate tiers so SemanticHtml can satisfy before Html runs.
+      # NativeFeed is tier 0 so syndication wins before structured HTML scrapers.
       SCRAPER_TIERS = [
+        [NativeFeed].freeze,
         [Schema, Microdata, Microformats2, JsonState, XhrArticles].freeze,
         [WordpressApi, Sitemap, MetaOembed].freeze,
         [SemanticHtml].freeze,
@@ -36,7 +38,7 @@ module Html2rss
       # Heuristic scrapers that share one memoized SST::Document per page.
       HEURISTIC_SCRAPERS = [SemanticHtml, Html].freeze
       # Scrapers that accept a shared follow-up +request_session+.
-      REQUEST_SESSION_SCRAPERS = [WordpressApi, Sitemap, MetaOembed].freeze
+      REQUEST_SESSION_SCRAPERS = [NativeFeed, WordpressApi, Sitemap, MetaOembed].freeze
       # Scrapers that consume browser-captured XHR/fetch JSON bodies.
       CAPTURED_RESPONSE_SCRAPERS = [XhrArticles].freeze
 
@@ -83,6 +85,7 @@ module Html2rss
       # Returns an array of scraper classes that claim to find articles in the parsed body.
       # @param parsed_body [Nokogiri::HTML::Document] The parsed HTML document.
       # @param opts [Hash] The options hash.
+      # @option opts [Hash] :native_feed scraper toggle and configuration
       # @option opts [Hash] :wordpress_api scraper toggle and configuration
       # @option opts [Hash] :schema scraper toggle and configuration
       # @option opts [Hash] :microdata scraper toggle and configuration

--- a/lib/html2rss/auto_source/scraper/native_feed.rb
+++ b/lib/html2rss/auto_source/scraper/native_feed.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module Html2rss
+  class AutoSource
+    module Scraper
+      ##
+      # Promotes a page's native RSS/Atom feed via {Syndication::Discovery} + {Syndication::Parser}.
+      class NativeFeed
+        include Enumerable
+
+        # @return [Symbol] scraper config key
+        def self.options_key = :native_feed
+
+        ##
+        # @param _opts [Hash] unused options
+        # @return [Integer] follow-up request slots (discovery probes + feed fetch share the budget)
+        def self.request_slots(_opts = {})
+          1
+        end
+
+        ##
+        # Shallow claim: head advertises a syndication alternate, or body looks feed-capable
+        # enough that path discovery is worth a follow-up slot.
+        #
+        # @param parsed_body [Nokogiri::HTML::Document, nil]
+        # @return [Boolean]
+        def self.articles?(parsed_body)
+          return false unless parsed_body.is_a?(Nokogiri::HTML::Document)
+
+          return true if ::Html2rss::Html::FeedLink.from_document(parsed_body).any?
+
+          parsed_body.css('head link[rel~="alternate"][href]').any? do |node|
+            href = node['href'].to_s
+            type = node['type'].to_s.downcase
+            type.include?('rss') || type.include?('atom') || href.match?(/rss|atom|feed|\.xml/i)
+          end
+        end
+
+        ##
+        # @param parsed_body [Nokogiri::HTML::Document]
+        # @param url [String, Html2rss::Url]
+        # @param request_session [Html2rss::RequestSession, nil]
+        # @param _opts [Hash]
+        # @option _opts [Object] :_reserved reserved for future scraper-specific options
+        def initialize(parsed_body, url:, request_session: nil, **_opts)
+          @parsed_body = parsed_body
+          @url = Html2rss::Url.from_absolute(url)
+          @request_session = request_session
+        end
+
+        ##
+        # @yieldparam article [Hash{Symbol => Object}]
+        # @return [Enumerator, void]
+        def each(&)
+          return enum_for(:each) unless block_given?
+
+          articles = fetch_articles
+          if articles.empty?
+            Log.info("#{self.class}: host=#{url.host} item_count=0 fallback=true")
+            return
+          end
+
+          Log.info("#{self.class}: host=#{url.host} item_count=#{articles.size} fallback=false")
+          articles.each(&)
+        end
+
+        private
+
+        attr_reader :parsed_body, :url, :request_session
+
+        def fetch_articles # rubocop:disable Metrics/MethodLength -- discovery + parse path
+          return [] unless request_session
+
+          response = Syndication::Discovery.best_feed_response(
+            page_url: url,
+            request_session:,
+            parsed_body:,
+            max_probes: self.class.request_slots
+          )
+          return [] unless response
+
+          Syndication::Parser.parse_response(response)
+        rescue Html2rss::Error, ArgumentError => error
+          Log.warn("#{self.class}: host=#{url.host} failed (#{error.class}: #{error.message})")
+          []
+        end
+      end
+    end
+  end
+end

--- a/lib/html2rss/config/auto_source_contract.rb
+++ b/lib/html2rss/config/auto_source_contract.rb
@@ -9,6 +9,9 @@ module Html2rss
       optional(:limit).filled(:integer, gt?: 0)
 
       optional(:scraper).hash do # rubocop:disable Metrics/BlockLength
+        optional(:native_feed).hash do
+          optional(:enabled).filled(:bool)
+        end
         optional(:wordpress_api).hash do
           optional(:enabled).filled(:bool)
         end

--- a/lib/html2rss/feed_pipeline.rb
+++ b/lib/html2rss/feed_pipeline.rb
@@ -131,6 +131,7 @@ module Html2rss
     # rubocop:disable Metrics/MethodLength
     def selector_articles(config:, response:, request_session:)
       return [] unless (selectors = config.selectors)
+      return [] if response.feed_response?
 
       page_responses = request_session.page_responses(
         response,
@@ -151,9 +152,17 @@ module Html2rss
     # @return [Array(Array<Html2rss::Article>, Hash{String => Integer})]
     def auto_source_articles(config:, response:, request_session:)
       return [[], {}] unless (auto_source = config.auto_source)
+      return syndication_articles(response) if response.feed_response?
 
       source = AutoSource.new(response, auto_source, request_session:)
       [source.articles, source.admission_drops]
+    end
+
+    def syndication_articles(response)
+      articles = Syndication::Parser.parse_response(response).map do |hash|
+        Article.new(**hash, scraper: AutoSource::Scraper::NativeFeed)
+      end
+      [articles, {}]
     end
   end
 end

--- a/lib/html2rss/mcp/outcome.rb
+++ b/lib/html2rss/mcp/outcome.rb
@@ -24,7 +24,8 @@ module Html2rss
                        'scheme_downgrade, alternate_feeds).',
           validate_config: 'Call validate_config with payload.yaml or a config hash (XOR, not both).',
           apply_config: 'Call apply_config next. Confirm payload.item_count before shipping.',
-          scrape_url: 'Call scrape_url for articles now. strategy auto already runs Faraday then Botasaurus.',
+          scrape_url: 'Call scrape_url for articles now. strategy auto already runs Faraday then Botasaurus ' \
+                      'and promotes native RSS/Atom when present.',
           capture_config: 'Call capture_config for a reusable YAML draft, then follow next_step.',
           read_runtime: 'Read html2rss://runtime. Set BOTASAURUS_SCRAPER_URL on the MCP process ' \
                         'if botasaurus_configured is false.'
@@ -150,7 +151,8 @@ module Html2rss
         end
 
         def inspect_next_step(payload)
-          return NextStep.done if Array(payload[:alternate_feeds]).any?
+          # Runtime scrape_url now consumes native alternates (NativeFeed / direct feed parse).
+          return NextStep.scrape_url if Array(payload[:alternate_feeds]).any?
           return NextStep.capture_config if payload[:articles_count].to_i.positive?
 
           NextStep.scrape_url

--- a/lib/html2rss/request_service/response.rb
+++ b/lib/html2rss/request_service/response.rb
@@ -14,11 +14,15 @@ module Html2rss
 
       # Bodies that look like HTML even when Content-Type is missing, empty, or wrong.
       HTML_BODY_SNIFF = /\A\s*(?:<!DOCTYPE\s+html|<html)/i
+      # Content-Type markers for RSS/Atom syndication responses.
+      FEED_CT_MARKERS = %w[rss+xml atom+xml rss atom].freeze
+      # Body sniff for unlabeled syndication (first 800 bytes, downcased).
+      FEED_BODY_MARKERS = ['<rss', '<feed xmlns', '<feed '].freeze
       # Charset from Content-Type or a leading <meta charset>.
       CHARSET_PARAMETER = /charset\s*=\s*["']?([\w.:-]+)/i
       # Bytes scanned for a meta charset hint (HTML spec looks at the first 1024).
       META_CHARSET_BYTES = 2048
-      private_constant :CHARSET_PARAMETER, :META_CHARSET_BYTES
+      private_constant :CHARSET_PARAMETER, :META_CHARSET_BYTES, :FEED_CT_MARKERS, :FEED_BODY_MARKERS
 
       ##
       # @param body [String] the body of the response
@@ -74,7 +78,14 @@ module Html2rss
 
       # @return [Boolean] whether response content is HTML (header or sniffed body, never JSON)
       def html_response?
-        content_type.include?('text/html') || (!json_response? && html_looking_body?)
+        content_type.include?('text/html') || (!json_response? && !feed_response? && html_looking_body?)
+      end
+
+      # @return [Boolean] whether response content is RSS/Atom (header or sniffed body)
+      def feed_response?
+        return @feed_response if defined?(@feed_response)
+
+        @feed_response = feed_content_type? || (!json_response? && !html_looking_body? && feed_looking_body?)
       end
 
       ##
@@ -142,6 +153,19 @@ module Html2rss
 
       def html_looking_body?
         body.to_s.b.match?(HTML_BODY_SNIFF)
+      end
+
+      def feed_content_type?
+        ct = content_type.downcase
+        return false if ct.empty? || ct.include?('html') || ct.include?('json')
+
+        # Substring match against Content-Type (not Array#intersect? on a String).
+        FEED_CT_MARKERS.any? { |marker| ct.include?(marker) } # rubocop:disable Style/ArrayIntersect
+      end
+
+      def feed_looking_body?
+        snippet = body.to_s[0, 800].downcase
+        FEED_BODY_MARKERS.any? { |marker| snippet.include?(marker) } # rubocop:disable Style/ArrayIntersect
       end
     end
   end

--- a/lib/html2rss/syndication.rb
+++ b/lib/html2rss/syndication.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Html2rss
+  ##
+  # Native RSS/Atom discovery and parse (not HTML AutoSource ownership).
+  #
+  # {include:file:lib/html2rss/syndication/README.md}
+  module Syndication
+  end
+end

--- a/lib/html2rss/syndication/README.md
+++ b/lib/html2rss/syndication/README.md
@@ -1,0 +1,21 @@
+# Syndication
+
+Native RSS/Atom discovery and parse for auto-source promotion and direct feed URLs.
+
+## Ownership
+
+| Concern | Owner |
+| --- | --- |
+| Head `rel=alternate` + common path probes + status-gated feedish | `Syndication::Discovery` |
+| RSS 2.0 / Atom → article hashes | `Syndication::Parser` |
+| Strict head-only link parse (no path guessing) | `Html::FeedLink` |
+| Response Content-Type / body feed sniff | `RequestService::Response#feed_response?` (sole sniff owner; Discovery only adds HTTP status gate) |
+
+## Non-goals
+
+- Entry-URL tournament / listing resolution (`FeedResolution`)
+- Page recon / surface classification (`PageRecon`)
+- Feed channel metadata for output (`Channel` / `FeedBuilder`)
+- Ranking or quality scoring of competing feeds beyond first feedish hit
+
+Discovery stops at the first same-origin feedish URL (lazy probe). Path guessing mirrors the legacy configs `probe_rss` script; that script should eventually thin-wrap this module.

--- a/lib/html2rss/syndication/candidate_catalog.rb
+++ b/lib/html2rss/syndication/candidate_catalog.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Html2rss
+  module Syndication
+    ##
+    # Shared path lexicon for syndication discovery and entry-resolution candidates.
+    module CandidateCatalog
+      # Common feed path suffixes probed after head +rel=alternate+ hints.
+      FEED_PATHS = %w[
+        /feed
+        /feed.xml
+        /rss
+        /rss.xml
+        /atom.xml
+        /index.xml
+        /news/rss
+        /news/feed
+        /blog/feed
+        /blog/rss.xml
+      ].freeze
+
+      # HTML listing paths probed only by {FeedResolution::CandidateGenerator}.
+      LISTING_PATHS = %w[/news /blog /releases /changelog /updates].freeze
+    end
+  end
+end

--- a/lib/html2rss/syndication/discovery.rb
+++ b/lib/html2rss/syndication/discovery.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+module Html2rss
+  module Syndication
+    ##
+    # Finds a same-origin RSS/Atom URL for a page via head alternates and path guesses.
+    #
+    # Ports configs +probe_rss+ path/alternate logic onto {RequestSession#follow_up}.
+    module Discovery # rubocop:disable Metrics/ModuleLength -- discovery + path probes stay co-located
+      # Common feed path suffixes probed after head +rel=alternate+ hints.
+      DEFAULT_PATHS = CandidateCatalog::FEED_PATHS
+
+      LINK_TAG_RE = /<link\b[^>]*>/i
+      HREF_RE = /\bhref\s*=\s*["']([^"']+)["']/i
+      TYPE_RE = /\btype\s*=\s*["']([^"']+)["']/i
+      REL_RE = /\brel\s*=\s*["']([^"']+)["']/i
+      private_constant :LINK_TAG_RE, :HREF_RE, :TYPE_RE, :REL_RE
+
+      module_function
+
+      ##
+      # Probes candidates lazily and returns the first feedish URL.
+      #
+      # @param page_url [String, Html2rss::Url] page or origin URL
+      # @param request_session [Html2rss::RequestSession] shared session for follow-ups
+      # @param parsed_body [Nokogiri::HTML::Document, nil] parsed HTML when available
+      # @param html [String, nil] raw HTML when a document is unavailable
+      # @param extra_paths [Array<String>] additional path guesses
+      # @param max_probes [Integer, nil] max candidate GETs (nil = uncapped)
+      # @return [Html2rss::Url, nil]
+      # rubocop:disable Metrics/ParameterLists -- discovery kwargs stay co-located
+      def best_feed_url(page_url:, request_session:, parsed_body: nil, html: nil, extra_paths: [],
+                        max_probes: nil)
+        best_feed_response(
+          page_url:, request_session:, parsed_body:, html:, extra_paths:, max_probes:
+        )&.url
+      end
+      # rubocop:enable Metrics/ParameterLists
+
+      ##
+      # Like {#best_feed_url} but returns the validated syndication response for parsing.
+      #
+      # @param page_url [String, Html2rss::Url]
+      # @param request_session [Html2rss::RequestSession]
+      # @param parsed_body [Nokogiri::HTML::Document, nil]
+      # @param html [String, nil]
+      # @param extra_paths [Array<String>]
+      # @param max_probes [Integer, nil] max candidate GETs (nil = uncapped)
+      # @return [Html2rss::RequestService::Response, nil]
+      # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength -- discovery kwargs stay co-located
+      def best_feed_response(page_url:, request_session:, parsed_body: nil, html: nil, extra_paths: [],
+                             max_probes: nil)
+        page = Html2rss::Url.from_absolute(page_url)
+        candidates = candidate_urls(page_url: page, parsed_body:, html:, extra_paths:)
+        Log.debug(
+          "Syndication::Discovery: host=#{page.host} candidate_count=#{candidates.size}"
+        )
+
+        first_feedish_response(
+          candidates, request_session:, origin_url: page, max_probes:
+        ).tap do |response|
+          next unless response
+
+          Log.info("Syndication::Discovery: host=#{page.host} selected_feed_url=#{response.url}")
+        end
+      end
+      # rubocop:enable Metrics/ParameterLists, Metrics/MethodLength
+
+      ##
+      # Ordered candidate feed URLs (head alternates first, then path guesses).
+      #
+      # @param page_url [String, Html2rss::Url]
+      # @param parsed_body [Nokogiri::HTML::Document, nil]
+      # @param html [String, nil]
+      # @param extra_paths [Array<String>]
+      # @return [Array<Html2rss::Url>]
+      def candidate_urls(page_url:, parsed_body: nil, html: nil, extra_paths: [])
+        page = Html2rss::Url.from_absolute(page_url)
+        (alternate_feed_urls(page, parsed_body:, html:) +
+          path_guess_urls(page, extra_paths:)).uniq
+      end
+
+      ##
+      # @param response [Html2rss::RequestService::Response, nil]
+      # @return [Boolean]
+      def feedish?(response)
+        return false unless response
+        return false unless successful_status?(response)
+
+        response.feed_response?
+      end
+
+      def successful_status?(response)
+        status = response.status
+        status.nil? || status.between?(200, 299)
+      end
+      module_function :successful_status?
+      private_class_method :successful_status?
+
+      ##
+      # Directory-relative feed path guesses for a page URL.
+      #
+      # @param page_url [String, Html2rss::Url]
+      # @return [Array<String>] relative paths
+      def page_dir_paths(page_url)
+        path = Html2rss::Url.from_absolute(page_url).path
+        return [] if path.nil? || path.empty? || path == '/'
+
+        dir = path.sub(%r{/[^/]*$}, '/')
+        ["#{dir}feed", "#{dir}rss.xml", "#{dir}atom.xml"]
+      end
+
+      def first_feedish_response(urls, request_session:, origin_url:, max_probes: nil)
+        scoped = max_probes.nil? ? urls.lazy : urls.lazy.take(max_probes)
+        scoped.filter_map do |url|
+          response = probe(url, request_session:, origin_url:)
+          response if feedish?(response)
+        end.first
+      end
+      module_function :first_feedish_response
+      private_class_method :first_feedish_response
+
+      def first_feedish_url(urls, request_session:, origin_url:, max_probes: nil)
+        first_feedish_response(urls, request_session:, origin_url:, max_probes:)&.url
+      end
+      module_function :first_feedish_url
+      private_class_method :first_feedish_url
+
+      def probe(url, request_session:, origin_url:)
+        request_session.follow_up(url:, relation: :auto_source, origin_url:)
+      rescue Html2rss::Error => error
+        Log.debug(
+          "Syndication::Discovery: probe skipped host=#{origin_url.host} " \
+          "(#{error.class})"
+        )
+        nil
+      end
+      module_function :probe
+      private_class_method :probe
+
+      def alternate_feed_urls(page, parsed_body:, html:)
+        from_document = feed_links_from_document(parsed_body, page)
+        return from_document if from_document.any?
+
+        alternate_feed_hrefs(html.to_s, page)
+      end
+      module_function :alternate_feed_urls
+      private_class_method :alternate_feed_urls
+
+      def feed_links_from_document(parsed_body, page)
+        return [] unless parsed_body.is_a?(Nokogiri::HTML::Document)
+
+        Html::FeedLink.from_document(parsed_body).filter_map do |link|
+          absolute_url(page, link.href)
+        end
+      end
+      module_function :feed_links_from_document
+      private_class_method :feed_links_from_document
+
+      def path_guess_urls(page, extra_paths:)
+        paths = (page_dir_paths(page) + DEFAULT_PATHS + Array(extra_paths)).uniq
+        paths.filter_map { |path| absolute_url(page, path) }
+      end
+      module_function :path_guess_urls
+      private_class_method :path_guess_urls
+
+      def alternate_feed_hrefs(html, page)
+        return [] if html.nil? || html.empty?
+
+        html.scan(LINK_TAG_RE).filter_map { |tag| href_from_alternate_link(tag, page) }.uniq
+      end
+      module_function :alternate_feed_hrefs
+      private_class_method :alternate_feed_hrefs
+
+      def href_from_alternate_link(tag, page)
+        return unless alternate_rel?(tag)
+
+        href = tag[HREF_RE, 1]
+        return if href.nil? || href.empty?
+        return unless syndication_type?(tag[TYPE_RE, 1]) || feed_like_href?(href)
+
+        absolute_url(page, href.strip)
+      end
+      module_function :href_from_alternate_link
+      private_class_method :href_from_alternate_link
+
+      def alternate_rel?(tag)
+        tag[REL_RE, 1].to_s.downcase.split(/\s+/).include?('alternate')
+      end
+      module_function :alternate_rel?
+      private_class_method :alternate_rel?
+
+      def syndication_type?(type)
+        return false if type.nil? || type.empty?
+
+        t = type.downcase
+        t.include?('rss+xml') || t.include?('atom+xml') || t.include?('rss') || t.include?('atom')
+      end
+      module_function :syndication_type?
+      private_class_method :syndication_type?
+
+      def feed_like_href?(href)
+        href.match?(/rss|atom|feed|\.xml/i)
+      end
+      module_function :feed_like_href?
+      private_class_method :feed_like_href?
+
+      def absolute_url(base, path)
+        Html2rss::Url.from_relative(path, base)
+      rescue ArgumentError
+        nil
+      end
+      module_function :absolute_url
+      private_class_method :absolute_url
+    end
+  end
+end

--- a/lib/html2rss/syndication/parser.rb
+++ b/lib/html2rss/syndication/parser.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require 'rss'
+
+module Html2rss
+  module Syndication
+    ##
+    # Parses RSS 2.0 and Atom documents into AutoSource article hashes.
+    module Parser
+      module_function
+
+      ##
+      # @param response [Html2rss::RequestService::Response]
+      # @return [Array<Hash{Symbol => Object}>] article hashes (may be empty)
+      # @raise [ArgumentError] when the response is not a syndication feed
+      def parse_response(response)
+        raise ArgumentError, 'response is not a syndication feed' unless response.feed_response?
+
+        parse(response.body, base_url: response.url)
+      end
+
+      ##
+      # @param body [String] raw RSS/Atom document
+      # @param base_url [String, Html2rss::Url, nil] fallback base for relative item links
+      # @return [Array<Hash{Symbol => Object}>]
+      def parse(body, base_url: nil)
+        feed = RSS::Parser.parse(body.to_s, false)
+        return [] unless feed
+
+        items_from(feed, base_url:).filter_map { |item| article_hash(item, base_url:) }
+      rescue RSS::Error => error
+        Log.warn("Syndication::Parser: failed to parse feed (#{error.class}: #{error.message})")
+        []
+      end
+
+      def items_from(feed, base_url:) # rubocop:disable Lint/UnusedMethodArgument -- base reserved for callers
+        case feed
+        when RSS::Rss then Array(feed.items)
+        when RSS::Atom::Feed then Array(feed.entries)
+        else []
+        end
+      end
+      module_function :items_from
+      private_class_method :items_from
+
+      def article_hash(item, base_url:)
+        case item
+        when RSS::Rss::Channel::Item then rss_item_hash(item, base_url:)
+        when RSS::Atom::Entry, RSS::Atom::Feed::Entry then atom_entry_hash(item, base_url:)
+        end
+      end
+      module_function :article_hash
+      private_class_method :article_hash
+
+      def rss_item_hash(item, base_url:) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength -- RSS item mapping
+        url = absolute_url(item.link, base_url:)
+        return unless url
+
+        {
+          id: present(item.guid&.content) || url.to_s,
+          title: present(item.title),
+          description: present(item.description),
+          url:,
+          published_at: item.date || item.pubDate,
+          author: present(item.author),
+          categories: Array(item.categories).filter_map { |cat| present(cat.content) }
+        }.compact
+      end
+      module_function :rss_item_hash
+      private_class_method :rss_item_hash
+
+      def atom_entry_hash(entry, base_url:) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity -- Atom entry mapping
+        url = atom_link(entry, base_url:)
+        return unless url
+
+        {
+          id: present(entry.id&.content) || url.to_s,
+          title: present(atom_text(entry.title)),
+          description: present(atom_text(entry.content) || atom_text(entry.summary)),
+          url:,
+          published_at: entry.published&.content || entry.updated&.content,
+          author: present(atom_author(entry)),
+          categories: Array(entry.categories).filter_map { |cat| present(cat.term) }
+        }.compact
+      end
+      module_function :atom_entry_hash
+      private_class_method :atom_entry_hash
+
+      def atom_link(entry, base_url:)
+        links = Array(entry.links)
+        link = links.find { |node| node.rel.nil? || node.rel == 'alternate' } || links.first
+        absolute_url(link&.href, base_url:)
+      end
+      module_function :atom_link
+      private_class_method :atom_link
+
+      def atom_text(node)
+        return if node.nil?
+
+        node.respond_to?(:content) ? node.content : node.to_s
+      end
+      module_function :atom_text
+      private_class_method :atom_text
+
+      def atom_author(entry)
+        author = Array(entry.author).first
+        return unless author
+
+        present(author.name&.content) || present(author.email&.content)
+      end
+      module_function :atom_author
+      private_class_method :atom_author
+
+      def absolute_url(raw, base_url:)
+        value = present(raw)
+        return unless value
+
+        if base_url
+          Html2rss::Url.from_relative(value, base_url)
+        else
+          Html2rss::Url.from_absolute(value)
+        end
+      rescue ArgumentError
+        nil
+      end
+      module_function :absolute_url
+      private_class_method :absolute_url
+
+      def present(value)
+        text = value.to_s.strip
+        text unless text.empty?
+      end
+      module_function :present
+      private_class_method :present
+    end
+  end
+end

--- a/schema/html2rss-config.schema.json
+++ b/schema/html2rss-config.schema.json
@@ -160,6 +160,18 @@
         "scraper": {
           "type": "object",
           "properties": {
+            "native_feed": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "not": {
+                    "type": "null"
+                  }
+                }
+              },
+              "required": []
+            },
             "wordpress_api": {
               "type": "object",
               "properties": {
@@ -339,6 +351,9 @@
       "default": {
         "limit": 25,
         "scraper": {
+          "native_feed": {
+            "enabled": true
+          },
           "wordpress_api": {
             "enabled": true
           },

--- a/spec/lib/html2rss/auto_source/scraper/native_feed_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper/native_feed_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/ExampleLength
+
+require 'spec_helper'
+
+RSpec.describe Html2rss::AutoSource::Scraper::NativeFeed do
+  let(:page_url) { Html2rss::Url.from_absolute('https://example.com/blog/') }
+  let(:parsed_body) do
+    Nokogiri::HTML(<<~HTML)
+      <html><head>
+        <link rel="alternate" type="application/rss+xml" href="/feed.xml" title="Blog">
+      </head>
+      <body>
+        <article><h1><a href="/posts/1">Structured title</a></h1></article>
+      </body></html>
+    HTML
+  end
+
+  describe '.options_key' do
+    it { expect(described_class.options_key).to eq(:native_feed) }
+  end
+
+  describe '.request_slots' do
+    it 'reserves one follow-up slot for discovery/fetch' do
+      expect(described_class.request_slots({})).to eq(1)
+    end
+  end
+
+  describe '.articles?' do
+    it 'claims pages that advertise a syndication alternate' do
+      expect(described_class.articles?(parsed_body)).to be true
+    end
+
+    it 'claims href-shaped alternates that FeedLink mime filtering skips' do
+      doc = Nokogiri::HTML(<<~HTML)
+        <html><head>
+          <link rel="alternate" type="text/xml" href="/blog/feed.xml">
+        </head></html>
+      HTML
+
+      expect(described_class.articles?(doc)).to be true
+    end
+
+    it 'does not claim pages without feed hints' do
+      doc = Nokogiri::HTML('<html><body><p>No feeds</p></body></html>')
+      expect(described_class.articles?(doc)).to be false
+    end
+
+    it 'does not claim non-document bodies' do
+      expect(described_class.articles?(nil)).to be false
+    end
+  end
+
+  describe '#each' do
+    let(:session) { instance_double(Html2rss::RequestSession) }
+    let(:feed_body) do
+      <<~XML
+        <?xml version="1.0"?>
+        <rss version="2.0">
+          <channel>
+            <title>Blog</title>
+            <link>https://example.com/</link>
+            <description>d</description>
+            <item>
+              <title>From feed</title>
+              <link>https://example.com/posts/from-feed</link>
+              <description>Native item</description>
+            </item>
+          </channel>
+        </rss>
+      XML
+    end
+    let(:feed_response) do
+      Html2rss::RequestService::Response.new(
+        body: feed_body,
+        headers: { 'content-type' => 'application/rss+xml' },
+        url: Html2rss::Url.from_absolute('https://example.com/feed.xml'),
+        status: 200
+      )
+    end
+
+    it 'yields articles parsed from the discovered native feed', :aggregate_failures do
+      allow(session).to receive(:follow_up).and_return(feed_response)
+
+      articles = described_class.new(parsed_body, url: page_url, request_session: session).to_a
+
+      expect(articles.size).to eq(1)
+      expect(articles.first[:title]).to eq('From feed')
+      expect(articles.first[:url].to_s).to eq('https://example.com/posts/from-feed')
+    end
+
+    it 'returns an enumerator without a block' do
+      expect(described_class.new(parsed_body, url: page_url, request_session: session).each).to be_a(Enumerator)
+    end
+
+    it 'logs and yields nothing when discovery finds no feed', :aggregate_failures do
+      allow(Html2rss::Log).to receive(:info)
+      allow(Html2rss::Syndication::Discovery).to receive(:best_feed_response).and_return(nil)
+
+      articles = described_class.new(parsed_body, url: page_url, request_session: session).to_a
+
+      expect(articles).to eq([])
+      expect(Html2rss::Syndication::Discovery).to have_received(:best_feed_response).with(
+        hash_including(max_probes: described_class.request_slots)
+      )
+      expect(Html2rss::Log).to have_received(:info).with(
+        a_string_including('item_count=0', 'fallback=true')
+      )
+    end
+
+    it 'swallows discovery errors and yields nothing', :aggregate_failures do
+      allow(Html2rss::Log).to receive(:warn)
+      allow(Html2rss::Syndication::Discovery).to receive(:best_feed_response)
+        .and_raise(Html2rss::Error, 'Network error')
+
+      articles = described_class.new(parsed_body, url: page_url, request_session: session).to_a
+
+      expect(articles).to eq([])
+      expect(Html2rss::Log).to have_received(:warn).with(
+        a_string_including('failed (Html2rss::Error: Network error)')
+      )
+    end
+
+    it 'yields nothing without a request session' do
+      expect(described_class.new(parsed_body, url: page_url).to_a).to eq([])
+    end
+  end
+end
+
+# rubocop:enable RSpec/ExampleLength

--- a/spec/lib/html2rss/auto_source/scraper_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper_spec.rb
@@ -7,8 +7,14 @@ RSpec.describe Html2rss::AutoSource::Scraper do
   it { expect(described_class::SCRAPERS).to be_an(Array) }
 
   describe '::SCRAPER_TIERS' do
-    it 'starts with in-page structured scrapers' do
-      expect(described_class::SCRAPER_TIERS.first).to include(
+    it 'starts with NativeFeed before in-page structured scrapers' do
+      expect(described_class::SCRAPER_TIERS.first).to eq(
+        [Html2rss::AutoSource::Scraper::NativeFeed]
+      )
+    end
+
+    it 'places structured scrapers in the second tier' do
+      expect(described_class::SCRAPER_TIERS[1]).to include(
         Html2rss::AutoSource::Scraper::Schema,
         Html2rss::AutoSource::Scraper::JsonState
       )
@@ -22,6 +28,12 @@ RSpec.describe Html2rss::AutoSource::Scraper do
 
     it 'flattens tiers into SCRAPERS' do
       expect(described_class::SCRAPERS).to eq(described_class::SCRAPER_TIERS.flatten)
+    end
+
+    it 'registers NativeFeed for request sessions' do
+      expect(described_class::REQUEST_SESSION_SCRAPERS).to include(
+        Html2rss::AutoSource::Scraper::NativeFeed
+      )
     end
   end
 

--- a/spec/lib/html2rss/config_spec.rb
+++ b/spec/lib/html2rss/config_spec.rb
@@ -733,6 +733,7 @@ RSpec.describe Html2rss::Config do
             meta_oembed: { enabled: true },   # wasn't explicitly set -> default
             microdata: { enabled: true },     # wasn't explicitly set -> default
             microformats2: { enabled: true }, # wasn't explicitly set -> default
+            native_feed: { enabled: true },   # wasn't explicitly set -> default
             sitemap: { enabled: true, max_age_days: 30, min_priority: 0.3 }, # wasn't explicitly set -> default
             wordpress_api: { enabled: true } # wasn't explicitly set -> default
           },

--- a/spec/lib/html2rss/feed_pipeline/runtime_policy_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline/runtime_policy_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Html2rss::FeedPipeline::RuntimePolicy do
       let(:config) { Html2rss::Config.from_hash(raw_config) }
 
       it 'sizes HTTP request slots', :aggregate_failures do
-        expect(runtime_policy.max_requests).to eq(8)
+        expect(runtime_policy.max_requests).to eq(9)
         expect(runtime_policy.max_redirects).to eq(8)
       end
     end
@@ -47,7 +47,7 @@ RSpec.describe Html2rss::FeedPipeline::RuntimePolicy do
       it 'adds auto fallback retry budget to the runtime policy', :aggregate_failures do
         expected_retry_budget = Html2rss::FeedPipeline::AutoFallback::CHAIN.size - 1
 
-        expect(runtime_policy.max_requests).to eq(8 + expected_retry_budget)
+        expect(runtime_policy.max_requests).to eq(9 + expected_retry_budget)
         expect(runtime_policy.max_redirects).to eq(8)
       end
     end
@@ -56,7 +56,7 @@ RSpec.describe Html2rss::FeedPipeline::RuntimePolicy do
       let(:config) { Html2rss::Config.from_hash(raw_config.merge(strategy: :faraday)) }
 
       it 'keeps baseline request budget unchanged for non-auto strategies' do
-        expect(runtime_policy.max_requests).to eq(8)
+        expect(runtime_policy.max_requests).to eq(9)
       end
     end
 
@@ -73,7 +73,9 @@ RSpec.describe Html2rss::FeedPipeline::RuntimePolicy do
       end
 
       it 'reserves request budget using default max_pages of 5' do
-        expect(runtime_policy.max_requests).to eq(10) # 1 initial + (5-1) pagination + 1 wordpress_api + 4 sitemap
+        # Baseline is 11 (1 + 4 pagination + 1 native_feed + 1 wordpress_api + 4 sitemap)
+        # but Policy clamps at MAX_REQUESTS_CEILING (10).
+        expect(runtime_policy.max_requests).to eq(10)
       end
     end
 
@@ -104,7 +106,7 @@ RSpec.describe Html2rss::FeedPipeline::RuntimePolicy do
     it 'builds a Budget with request pools', :aggregate_failures do
       budget = described_class.budget_for(config)
 
-      expect(budget.remaining_requests).to eq(8)
+      expect(budget.remaining_requests).to eq(9)
     end
   end
 end

--- a/spec/lib/html2rss/feed_pipeline_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline_spec.rb
@@ -440,5 +440,42 @@ RSpec.describe Html2rss::FeedPipeline do
         expect(result.status.to_generator_comment).not_to include('botasaurus')
       end
     end
+
+    context 'when the entry URL is a direct syndication feed' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      let(:config) do
+        {
+          strategy: :faraday,
+          channel: { url: 'https://example.com/feed.xml', title: 'Feed' },
+          auto_source: {}
+        }
+      end
+      let(:pipeline) { described_class.new(config) }
+      let(:feed_response) do
+        build_response.call(
+          body: <<~XML,
+            <?xml version="1.0"?>
+            <rss version="2.0">
+              <channel>
+                <title>Feed</title>
+                <link>https://example.com/</link>
+                <description>d</description>
+                <item>
+                  <title>Direct item</title>
+                  <link>https://example.com/posts/1</link>
+                </item>
+              </channel>
+            </rss>
+          XML
+          url: 'https://example.com/feed.xml',
+          headers: { 'content-type' => 'application/rss+xml' }
+        )
+      end
+
+      before { stub_first_strategy_success.call(feed_response) }
+
+      it 'parses syndication items without HTML AutoSource' do
+        expect(pipeline.to_result.to_rss.items.map(&:title)).to eq(['Direct item'])
+      end
+    end
   end
 end

--- a/spec/lib/html2rss/mcp/outcome_spec.rb
+++ b/spec/lib/html2rss/mcp/outcome_spec.rb
@@ -67,10 +67,10 @@ RSpec.describe Html2rss::MCP::Outcome do
   end
 
   describe '.inspect' do
-    it 'points at done when recon found native alternate feeds' do
+    it 'points at scrape_url when recon found native alternate feeds (runtime consumes them)' do
       outcome = described_class.inspect(payload: { alternate_feeds: [{ href: 'https://example.com/feed.xml' }] })
 
-      expect(outcome).to have_attributes(ok: true, next_step: have_attributes(name: :done))
+      expect(outcome).to have_attributes(ok: true, next_step: have_attributes(name: :scrape_url))
     end
 
     it 'points at capture_config when recon found extractable articles' do

--- a/spec/lib/html2rss/request_service/response_spec.rb
+++ b/spec/lib/html2rss/request_service/response_spec.rb
@@ -60,6 +60,43 @@ RSpec.describe Html2rss::RequestService::Response do
 
       it { expect(instance.html_response?).to be false }
     end
+
+    context 'when the response is RSS' do
+      let(:body) { '<?xml version="1.0"?><rss version="2.0"><channel></channel></rss>' }
+      let(:headers) { { 'content-type' => 'application/rss+xml' } }
+
+      it { expect(instance.html_response?).to be false }
+    end
+  end
+
+  describe '#feed_response?' do
+    context 'when Content-Type advertises RSS' do
+      let(:body) { '<?xml version="1.0"?><rss version="2.0"></rss>' }
+      let(:headers) { { 'content-type' => 'application/rss+xml' } }
+
+      it { expect(instance.feed_response?).to be true }
+    end
+
+    context 'when Content-Type is wrong but the body sniffs as Atom' do
+      let(:body) { '<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"></feed>' }
+      let(:headers) { { 'content-type' => 'text/plain' } }
+
+      it { expect(instance.feed_response?).to be true }
+    end
+
+    context 'when the response is HTML' do
+      let(:body) { '<!DOCTYPE html><html><body>hi</body></html>' }
+      let(:headers) { { 'content-type' => 'text/html' } }
+
+      it { expect(instance.feed_response?).to be false }
+    end
+
+    context 'when Content-Type is image/svg+xml' do
+      let(:body) { '<svg xmlns="http://www.w3.org/2000/svg"></svg>' }
+      let(:headers) { { 'content-type' => 'image/svg+xml' } }
+
+      it { expect(instance.feed_response?).to be false }
+    end
   end
 
   describe '#parsed_body' do

--- a/spec/lib/html2rss/syndication/discovery_spec.rb
+++ b/spec/lib/html2rss/syndication/discovery_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/ExampleLength
+
+require 'spec_helper'
+
+RSpec.describe Html2rss::Syndication::Discovery do
+  describe '.page_dir_paths' do
+    it 'returns directory-relative feed guesses for nested pages' do
+      expect(described_class.page_dir_paths('https://example.com/news/index.html')).to eq(
+        %w[/news/feed /news/rss.xml /news/atom.xml]
+      )
+    end
+
+    it 'returns no directory guesses for the origin root' do
+      expect(described_class.page_dir_paths('https://example.com/')).to eq([])
+    end
+  end
+
+  describe '.candidate_urls' do
+    it 'prefers head alternate links from a parsed document before path guesses', :aggregate_failures do
+      doc = Nokogiri::HTML(<<~HTML)
+        <html><head>
+          <link rel="alternate" type="application/rss+xml" href="/custom.xml">
+        </head></html>
+      HTML
+
+      urls = described_class.candidate_urls(
+        page_url: 'https://example.com/blog/',
+        parsed_body: doc
+      )
+
+      expect(urls.first.to_s).to eq('https://example.com/custom.xml')
+      expect(urls.map(&:to_s)).to include('https://example.com/feed')
+    end
+
+    it 'falls back to string HTML alternate scanning when no document is given' do
+      html = '<link rel="alternate" type="application/atom+xml" href="/atom.xml">'
+      urls = described_class.candidate_urls(page_url: 'https://example.com/', html:)
+
+      expect(urls.first.to_s).to eq('https://example.com/atom.xml')
+    end
+  end
+
+  describe '.feedish?' do
+    def response(body:, content_type:, status: 200)
+      Html2rss::RequestService::Response.new(
+        body:,
+        headers: { 'content-type' => content_type },
+        url: Html2rss::Url.from_absolute('https://example.com/feed'),
+        status:
+      )
+    end
+
+    it 'accepts RSS content types' do
+      expect(described_class.feedish?(response(body: '<rss', content_type: 'application/rss+xml'))).to be true
+    end
+
+    it 'accepts body sniff when content type is plain' do
+      expect(
+        described_class.feedish?(response(body: '<?xml version="1.0"?><rss version="2.0">', content_type: 'text/plain'))
+      ).to be true
+    end
+
+    it 'rejects non-success status' do
+      expect(
+        described_class.feedish?(response(body: '<rss', content_type: 'application/rss+xml', status: 404))
+      ).to be false
+    end
+  end
+
+  describe '.best_feed_url' do
+    let(:page_url) { Html2rss::Url.from_absolute('https://example.com/news/') }
+    let(:session) { instance_double(Html2rss::RequestSession) }
+
+    it 'stops at the first feedish candidate without probing further', :aggregate_failures do
+      feed_response = Html2rss::RequestService::Response.new(
+        body: '<?xml version="1.0"?><rss version="2.0"><channel></channel></rss>',
+        headers: { 'content-type' => 'application/rss+xml' },
+        url: Html2rss::Url.from_absolute('https://example.com/news/feed'),
+        status: 200
+      )
+
+      allow(session).to receive(:follow_up).and_return(feed_response)
+
+      selected = described_class.best_feed_url(
+        page_url:,
+        request_session: session,
+        html: ''
+      )
+
+      expect(selected.to_s).to eq('https://example.com/news/feed')
+      expect(session).to have_received(:follow_up).once
+    end
+
+    it 'skips probe errors and continues to the next candidate' do
+      miss = Html2rss::RequestService::Response.new(
+        body: 'not a feed',
+        headers: { 'content-type' => 'text/html' },
+        url: Html2rss::Url.from_absolute('https://example.com/news/rss.xml'),
+        status: 200
+      )
+      hit = Html2rss::RequestService::Response.new(
+        body: '<rss version="2.0"></rss>',
+        headers: { 'content-type' => 'application/rss+xml' },
+        url: Html2rss::Url.from_absolute('https://example.com/news/atom.xml'),
+        status: 200
+      )
+
+      allow(session).to receive(:follow_up).and_invoke(
+        ->(**) { raise Html2rss::RequestService::CrossOriginFollowUpDenied, 'denied' },
+        ->(**) { miss },
+        ->(**) { hit }
+      )
+
+      selected = described_class.best_feed_url(page_url:, request_session: session, html: '')
+
+      # Candidates: /news/feed (error), /news/rss.xml (miss), /news/atom.xml (hit)
+      expect(selected.to_s).to eq('https://example.com/news/atom.xml')
+    end
+
+    it 'caps candidate probes at max_probes when no feed is found', :aggregate_failures do
+      miss = Html2rss::RequestService::Response.new(
+        body: 'not a feed',
+        headers: { 'content-type' => 'text/html' },
+        url: Html2rss::Url.from_absolute('https://example.com/news/feed'),
+        status: 200
+      )
+      allow(session).to receive(:follow_up).and_return(miss)
+
+      selected = described_class.best_feed_url(
+        page_url:,
+        request_session: session,
+        html: '',
+        max_probes: 1
+      )
+
+      expect(selected).to be_nil
+      expect(session).to have_received(:follow_up).once
+    end
+  end
+end
+
+# rubocop:enable RSpec/ExampleLength

--- a/spec/lib/html2rss/syndication/parser_spec.rb
+++ b/spec/lib/html2rss/syndication/parser_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/ExampleLength
+
+require 'spec_helper'
+
+RSpec.describe Html2rss::Syndication::Parser do
+  describe '.parse' do
+    it 'parses RSS 2.0 items into article hashes', :aggregate_failures do
+      body = <<~XML
+        <?xml version="1.0"?>
+        <rss version="2.0">
+          <channel>
+            <title>Channel</title>
+            <link>https://example.com/</link>
+            <description>Desc</description>
+            <item>
+              <title>First</title>
+              <link>https://example.com/posts/1</link>
+              <description>Hello</description>
+              <guid>post-1</guid>
+              <pubDate>Mon, 01 Jan 2024 12:00:00 GMT</pubDate>
+              <author>Ada</author>
+              <category>News</category>
+            </item>
+          </channel>
+        </rss>
+      XML
+
+      articles = described_class.parse(body)
+
+      expect(articles.size).to eq(1)
+      expect(articles.first).to include(
+        id: 'post-1',
+        title: 'First',
+        description: 'Hello',
+        author: 'Ada',
+        categories: ['News']
+      )
+      expect(articles.first[:url].to_s).to eq('https://example.com/posts/1')
+    end
+
+    it 'parses Atom entries into article hashes', :aggregate_failures do
+      body = <<~XML
+        <?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+          <title>Feed</title>
+          <entry>
+            <id>urn:example:1</id>
+            <title>Entry</title>
+            <link href="https://example.com/e/1" rel="alternate"/>
+            <summary>Summary</summary>
+            <updated>2024-02-01T00:00:00Z</updated>
+            <author><name>Bea</name></author>
+            <category term="Release"/>
+          </entry>
+        </feed>
+      XML
+
+      articles = described_class.parse(body)
+
+      expect(articles.size).to eq(1)
+      expect(articles.first).to include(
+        id: 'urn:example:1',
+        title: 'Entry',
+        description: 'Summary',
+        author: 'Bea',
+        categories: ['Release']
+      )
+      expect(articles.first[:url].to_s).to eq('https://example.com/e/1')
+    end
+
+    it 'returns an empty array for unparseable bodies' do
+      expect(described_class.parse('not xml at all <<<')).to eq([])
+    end
+  end
+
+  describe '.parse_response' do
+    it 'parses a syndication Response' do
+      response = Html2rss::RequestService::Response.new(
+        body: <<~XML,
+          <?xml version="1.0"?>
+          <rss version="2.0">
+            <channel>
+              <title>Channel</title>
+              <link>https://example.com/</link>
+              <description>d</description>
+              <item>
+                <title>Item</title>
+                <link>https://example.com/i</link>
+              </item>
+            </channel>
+          </rss>
+        XML
+        headers: { 'content-type' => 'application/rss+xml' },
+        url: Html2rss::Url.from_absolute('https://example.com/feed.xml')
+      )
+
+      expect(described_class.parse_response(response).first[:title]).to eq('Item')
+    end
+
+    it 'raises when the response is not a feed' do
+      response = Html2rss::RequestService::Response.new(
+        body: '<!DOCTYPE html><html></html>',
+        headers: { 'content-type' => 'text/html' },
+        url: Html2rss::Url.from_absolute('https://example.com/')
+      )
+
+      expect { described_class.parse_response(response) }.to raise_error(ArgumentError, /syndication feed/)
+    end
+  end
+end
+
+# rubocop:enable RSpec/ExampleLength


### PR DESCRIPTION
## Summary
- Add `Syndication::Discovery` / `Parser` / `CandidateCatalog` and `Response#feed_response?` sniff ownership (tightened CT markers; no bare `xml`).
- Add tier-0 `AutoSource::Scraper::NativeFeed` (schema default enabled) with Discovery probe cap = `request_slots` (1).
- Parse direct syndication entry URLs in `FeedPipeline`; steer MCP inspect toward `scrape_url` when alternates exist.

## Stack
- Independent of PageRecon / FeedResolution.
- Part of splitting #480; sibling PRs follow for PageRecon and FeedResolution.

## Test plan
- [x] `make quick` on slice
- [ ] `make ready` (optional CI)
- [ ] Spot-check: page with `rel=alternate` RSS; direct `/feed.xml` URL; `image/svg+xml` is not feedish