### PR TITLE
feat(request): carry timeout_phase on RequestTimedOut

### DIFF
--- a/lib/html2rss/request_service.rb
+++ b/lib/html2rss/request_service.rb
@@ -31,8 +31,20 @@ module Html2rss
     class ResponseTooLarge < Html2rss::Error; end
     # Raised when blocked content surfaces are detected.
     class BlockedSurfaceDetected < Html2rss::Error; end
+
     # Raised when a request times out.
-    class RequestTimedOut < Html2rss::Error; end
+    class RequestTimedOut < Html2rss::Error
+      ##
+      # @param message [String, nil] timeout failure summary
+      # @param timeout_phase [String, nil] scrape-api stage when known (+queue+/+boot+/+work+)
+      def initialize(message = nil, timeout_phase: nil)
+        @timeout_phase = timeout_phase
+        super(message)
+      end
+
+      # @return [String, nil] scrape-api timeout stage, or nil for transport/budget timeouts
+      attr_reader :timeout_phase
+    end
 
     # Raised when Botasaurus configuration is missing or invalid.
     class BotasaurusConfigurationError < Html2rss::Error

--- a/lib/html2rss/request_service/botasaurus_contract.rb
+++ b/lib/html2rss/request_service/botasaurus_contract.rb
@@ -43,7 +43,7 @@ module Html2rss
       MAX_RETRIES = 3
 
       # Allowlisted ScrapeDiagnostics keys nested under diagnostics.
-      DIAGNOSTICS_KEYS = %w[request_id attempts strategy_used render_ms execution_tier challenge].freeze
+      DIAGNOSTICS_KEYS = %w[request_id attempts strategy_used render_ms execution_tier challenge timeout_phase].freeze
       # Allowlisted ChallengeSignal keys nested under diagnostics.challenge.
       CHALLENGE_KEYS = %w[blocked detected marker].freeze
 
@@ -185,10 +185,17 @@ module Html2rss
             'Botasaurus challenge block detected.'
         end
 
+        # @return [String, nil] scrape-api timeout stage when present on diagnostics
+        def timeout_phase
+          value = diagnostics['timeout_phase']
+          value.is_a?(String) && !value.empty? ? value : nil
+        end
+
         # @return [String] actionable upstream failure summary
         def failure_message
           details = ["status=#{transport_status}", "error_category=#{error_category}", "error=#{error}"]
           details << "request_id=#{request_id}" if request_id
+          details << "timeout_phase=#{timeout_phase}" if timeout_phase
           "Botasaurus scrape failed (#{details.join(', ')})."
         end
 

--- a/lib/html2rss/request_service/botasaurus_strategy.rb
+++ b/lib/html2rss/request_service/botasaurus_strategy.rb
@@ -59,7 +59,7 @@ module Html2rss
         return unless error.timeout?
 
         log_timeout!(reason: 'botasaurus_upstream')
-        raise RequestTimedOut, error.failure_message
+        raise RequestTimedOut.new(error.failure_message, timeout_phase: error.timeout_phase)
       end
 
       def response_url(final_url)

--- a/spec/fixtures/botasaurus/openapi.yaml
+++ b/spec/fixtures/botasaurus/openapi.yaml
@@ -174,12 +174,15 @@ paths:
             application/json:
               example:
                 url: https://example.com
-                error: Scrape timed out after 45 seconds
+                error: Scrape timed out after 45 seconds (phase=work)
                 error_category: timeout
                 diagnostics:
                   request_id: b01ef2f8-f641-4e75-8ef2-0b73f7b4f372
-                  attempts: 0
-                  render_ms: 0
+                  attempts: 1
+                  strategy_used: get
+                  render_ms: 45012
+                  execution_tier: browser_driver
+                  timeout_phase: work
               schema:
                 $ref: '#/components/schemas/ScrapeError'
 components:
@@ -324,6 +327,15 @@ components:
           examples:
           - blocked: false
             detected: false
+        timeout_phase:
+          anyOf:
+          - $ref: '#/components/schemas/TimeoutPhase'
+          - type: 'null'
+          description: 'When `error_category` is `timeout`, which stage burned the
+            budget: `queue` (threadpool wait), `boot` (browser/driver start), or `work`
+            (navigate/wait/scroll). Null for non-timeout outcomes.'
+          examples:
+          - work
       type: object
       required:
       - request_id
@@ -411,9 +423,9 @@ components:
         wait_timeout_seconds:
           type: integer
           title: Wait Timeout Seconds
-          description: Selector wait timeout in seconds. Values outside [1, 30] are
-            clamped into that range so scrape still runs; they are not rejected with
-            422.
+          description: Selector wait timeout in seconds. Values outside [1, SCRAPE_WORK_TIMEOUT_SECONDS]
+            are clamped into that range so scrape still runs; they are not rejected
+            with 422.
           default: 15
           examples:
           - 15
@@ -603,8 +615,6 @@ components:
           title: Xhr Responses
           description: JSON XHR/fetch sub-resource bodies captured on the browser
             tier (empty on the HTTP-request tier).
-          examples:
-          - []
         diagnostics:
           $ref: '#/components/schemas/ScrapeDiagnostics'
           description: Per-request tracing, strategy, timing, and challenge signals.
@@ -622,6 +632,13 @@ components:
       - html
       - diagnostics
       title: ScrapeSuccess
+    TimeoutPhase:
+      type: string
+      enum:
+      - queue
+      - boot
+      - work
+      title: TimeoutPhase
     WindowSize:
       properties:
         width:

--- a/spec/lib/html2rss/request_service/botasaurus_contract_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_contract_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
 
     it 'locks wait default and documented clamp without schema min/max', :aggregate_failures do
       wait = schemas.dig('ScrapeRequest', 'properties', 'wait_timeout_seconds')
-      clamp = "[#{described_class::MIN_WAIT_TIMEOUT_SECONDS}, #{described_class::MAX_WAIT_TIMEOUT_SECONDS}]"
+      clamp = "[#{described_class::MIN_WAIT_TIMEOUT_SECONDS}, SCRAPE_WORK_TIMEOUT_SECONDS]"
       expect(described_class::DEFAULT_WAIT_TIMEOUT_SECONDS).to eq(wait.fetch('default'))
       expect(wait.fetch('description')).to include(clamp)
       expect(wait.keys).not_to include('minimum', 'maximum')
@@ -301,6 +301,41 @@ RSpec.describe Html2rss::RequestService::BotasaurusContract do
       let(:transport_status) { 502 }
 
       it { is_expected.to be_timeout }
+    end
+  end
+
+  describe 'Error#timeout_phase' do
+    subject(:parsed) { described_class::Error.new(payload:, transport_status: 504) }
+
+    let(:payload) do
+      {
+        'error' => 'Scraper at capacity; retry shortly',
+        'error_category' => 'timeout',
+        'diagnostics' => {
+          'request_id' => 'req-queue',
+          'timeout_phase' => 'queue'
+        }
+      }
+    end
+
+    it 'parses timeout_phase from diagnostics and includes it in failure_message', :aggregate_failures do
+      expect(parsed.timeout_phase).to eq('queue')
+      expect(parsed.failure_message).to include('timeout_phase=queue')
+    end
+
+    context 'when timeout_phase is absent' do
+      let(:payload) do
+        {
+          'error' => 'Scrape timed out after 20 seconds',
+          'error_category' => 'timeout',
+          'diagnostics' => { 'request_id' => 'req-timeout' }
+        }
+      end
+
+      it 'leaves timeout_phase nil and omits it from failure_message', :aggregate_failures do
+        expect(parsed.timeout_phase).to be_nil
+        expect(parsed.failure_message).not_to include('timeout_phase=')
+      end
     end
   end
 

--- a/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/botasaurus_strategy_spec.rb
@@ -441,6 +441,32 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
             /error_category=timeout.*req-504/
           )
       end
+
+      it 'leaves timeout_phase nil when diagnostics omit it', :aggregate_failures do
+        expect { execute }.to raise_error(Html2rss::RequestService::RequestTimedOut) do |error|
+          expect(error.timeout_phase).to be_nil
+        end
+      end
+    end
+
+    context 'when scrape envelope returns 504 with timeout_phase' do
+      let(:response_status) { 504 }
+      let(:response_payload) do
+        {
+          url: 'https://example.com/',
+          error: 'Browser failed to start in time',
+          error_category: 'timeout',
+          diagnostics: { request_id: 'req-boot', timeout_phase: 'boot' }
+        }
+      end
+
+      it 'raises RequestTimedOut carrying timeout_phase and failure_message', :aggregate_failures do
+        expect { execute }.to raise_error(Html2rss::RequestService::RequestTimedOut) do |error|
+          expect(error.timeout_phase).to eq('boot')
+          expect(error.message).to include('timeout_phase=boot')
+          expect(error.message).to include('req-boot')
+        end
+      end
     end
 
     context 'when upstream returns non-200 status with error details' do
@@ -526,6 +552,14 @@ RSpec.describe Html2rss::RequestService::BotasaurusStrategy do
 
       expect { execute }
         .to raise_error(Html2rss::RequestService::RequestTimedOut, /Timed out/)
+    end
+
+    it 'leaves timeout_phase nil on transport-hop timeouts', :aggregate_failures do
+      allow(connection).to receive(:post).and_raise(Faraday::TimeoutError, 'Timed out')
+
+      expect { execute }.to raise_error(Html2rss::RequestService::RequestTimedOut) do |error|
+        expect(error.timeout_phase).to be_nil
+      end
     end
 
     it 'maps network errors to BotasaurusConnectionFailed' do

--- a/spec/lib/html2rss/request_service_spec.rb
+++ b/spec/lib/html2rss/request_service_spec.rb
@@ -25,6 +25,17 @@ RSpec.describe Html2rss::RequestService do
     end
   end
 
+  describe 'RequestTimedOut' do
+    it 'exposes optional timeout_phase', :aggregate_failures do
+      timed_out = described_class::RequestTimedOut.new('timed out', timeout_phase: 'work')
+      transport = described_class::RequestTimedOut.new('timed out')
+
+      expect(timed_out.timeout_phase).to eq('work')
+      expect(timed_out.message).to eq('timed out')
+      expect(transport.timeout_phase).to be_nil
+    end
+  end
+
   describe '.default_strategy_name' do
     specify(:aggregate_failures) do
       expect(described_class.default_strategy_name).to be :faraday


### PR DESCRIPTION
## What changed

- Add `timeout_phase` to `RequestTimedOut` diagnostics (`DIAGNOSTICS_KEYS`) with a typed reader.
- Preserve scrape-api queue/boot/work phase through the Botasaurus client seam (`botasaurus_contract`, `botasaurus_strategy`).
- Include phase in `failure_message` so logs/API surfaces stay honest.
- Fixture OpenAPI + contract/strategy/`RequestService` specs for the new field.

## Why

Downstream (html2rss-web) needs to distinguish capacity timeouts (queue/boot) from a slow target site instead of always blaming the site with GATEWAY_TIMEOUT.

## Risk

- Additive client allowlist only — old responses without `timeout_phase` remain valid (`nil` phase).
- Web end-to-end honesty needs a gem release past `81189aef`; web uses `respond_to?` so pre-bump stays safe.

## Review map

Review map: whole PR is small — start at `lib/html2rss/request_service.rb` and the Botasaurus contract/strategy pair.

## Validation

- `make ready` exit 0

## Adjacent

- scrape-api: https://github.com/html2rss/botasaurus-scrape-api/pull/52
- html2rss: https://github.com/html2rss/html2rss/pull/484
- html2rss-web: https://github.com/html2rss/html2rss-web/pull/1111

Rollout: merge scrape-api → release/bump gem → merge web (web uses `respond_to?` so pre-bump is safe).