### PR TITLE
feat(mcp): add batch operations, catalog config synthesis, and certify tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,17 @@ Read `html2rss://runtime` for a boolean `botasaurus_configured` (the URL is neve
 
 ### Tools
 
-| Name              | When to use                                                                 |
-| ----------------- | --------------------------------------------------------------------------- |
-| `scrape_url`      | One-shot articles now (`payload.items`; empty is still success)             |
-| `inspect_url`     | Weak scrape/capture or recon (final_url, status, scheme_downgrade, feeds)   |
-| `capture_config`  | YAML draft in `payload.yaml`; strive `enhance: true`                        |
-| `validate_config` | Schema-check a `config` hash XOR `yaml` string (`isError` on failure)       |
-| `apply_config`    | RSS in `payload.rss`; `isError` when zero items; confirm `payload.item_count` |
+| Name                      | When to use                                                                    |
+| ------------------------- | ------------------------------------------------------------------------------ |
+| `scrape_url`              | One-shot articles now (`payload.items`; empty is still success)                |
+| `inspect_url`             | Weak scrape/capture or recon (final_url, status, scheme_downgrade, feeds)      |
+| `capture_config`          | YAML draft in `payload.yaml`; strive `enhance: true`                           |
+| `validate_config`         | Schema-check a `config` hash XOR `yaml` string (`isError` on failure)          |
+| `apply_config`            | RSS in `payload.rss`; `isError` when zero items; confirm `payload.item_count`    |
+| `batch_inspect_urls`      | Parallel recon across multiple URLs (`urls`, `strategy`, `concurrency`)        |
+| `batch_scrape_urls`       | Parallel one-shot scrape across multiple URLs (`urls`, `limit`, `concurrency`) |
+| `generate_catalog_config` | Curated-catalog-ready YAML with `directory.topics` & native feed detection     |
+| `certify_config`          | End-to-end quality certification (schema + in-memory live feed validation)     |
 
 ### Resources
 

--- a/lib/html2rss/mcp/batch.rb
+++ b/lib/html2rss/mcp/batch.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+module Html2rss
+  module MCP
+    ##
+    # Concurrency-bounded batch execution over URLs with per-URL error isolation.
+    module Batch
+      # Maximum permitted worker threads for batch operations.
+      MAX_CONCURRENCY = 10
+      # Default worker threads for batch operations.
+      DEFAULT_CONCURRENCY = 5
+
+      # Value object representing the outcome of a batch operation.
+      BatchResult = Data.define(:total, :successful, :results) do
+        ##
+        # @return [Hash{Symbol => Object}]
+        def to_h
+          { total:, successful:, results: }
+        end
+      end
+
+      module_function
+
+      ##
+      # Inspects multiple URLs in parallel with per-URL error isolation.
+      #
+      # @param urls [Array<String>] list of URLs to inspect
+      # @param strategy [Symbol, String] request strategy (+:auto+, +:faraday+, +:botasaurus+)
+      # @param concurrency [Integer] number of worker threads (default 5, max 10)
+      # @return [BatchResult]
+      def inspect_urls(urls:, strategy: :auto, concurrency: DEFAULT_CONCURRENCY)
+        run_batch(urls, concurrency:) { |url| inspect_single_url(url:, strategy:) }
+      end
+
+      ##
+      # Scrapes multiple URLs in parallel with per-URL error isolation.
+      #
+      # @param urls [Array<String>] list of URLs to scrape
+      # @param strategy [Symbol, String] request strategy (+:auto+, +:faraday+, +:botasaurus+)
+      # @param limit [Integer] max articles to extract per URL
+      # @param concurrency [Integer] number of worker threads (default 5, max 10)
+      # @return [BatchResult]
+      def scrape_urls(urls:, strategy: :auto, limit: 10, concurrency: DEFAULT_CONCURRENCY)
+        run_batch(urls, concurrency:) { |url| scrape_single_url(url:, strategy:, limit:) }
+      end
+
+      ##
+      # @param url [String]
+      # @param strategy [Symbol, String]
+      # @return [Hash]
+      def inspect_single_url(url:, strategy:)
+        recon = Inspect.call(url:, strategy:)
+        {
+          url:,
+          ok: true,
+          status_code: recon[:status],
+          final_url: recon[:final_url] || url,
+          alternate_feeds: Array(recon[:alternate_feeds])
+        }
+      rescue StandardError => error
+        { url:, ok: false, error: error.message }
+      end
+      module_function :inspect_single_url
+      private_class_method :inspect_single_url
+
+      ##
+      # @param url [String]
+      # @param strategy [Symbol, String]
+      # @param limit [Integer]
+      # @return [Hash]
+      def scrape_single_url(url:, strategy:, limit:)
+        plan = (strategy || :auto).to_sym
+        feed_result = Html2rss.auto_feed_result(url, strategy: plan, limit:)
+        feed = feed_result.to_json_feed
+        scrape_success_payload(url, feed)
+      rescue StandardError => error
+        { url:, ok: false, error: error.message }
+      end
+      module_function :scrape_single_url
+      private_class_method :scrape_single_url
+
+      def scrape_success_payload(url, feed)
+        items = feed[:items] || []
+        { url:, ok: true, items_count: items.size, items:, channel_title: feed[:title] }
+      end
+      module_function :scrape_success_payload
+      private_class_method :scrape_success_payload
+
+      ##
+      # Dispatches work across a bounded pool of worker threads.
+      #
+      # @param items [Array<Object>]
+      # @param concurrency [Integer]
+      # @return [BatchResult]
+      def run_batch(items, concurrency:, &)
+        list = Array(items)
+        worker_count = worker_pool_size(list.size, concurrency)
+        results = process_queue(list, worker_count, &)
+
+        successful = results.count { |entry| entry[:ok] }
+        BatchResult.new(total: list.size, successful:, results:)
+      end
+      module_function :run_batch
+      private_class_method :run_batch
+
+      def worker_pool_size(item_count, requested_concurrency)
+        return 1 if item_count <= 1
+
+        [[1, requested_concurrency.to_i].max, item_count, MAX_CONCURRENCY].min
+      end
+      module_function :worker_pool_size
+      private_class_method :worker_pool_size
+
+      def process_queue(items, worker_count, &)
+        queue = build_work_queue(items)
+        results = Array.new(items.size)
+
+        threads = Array.new(worker_count) do
+          Thread.new { drain_queue(queue, results, &) } # rubocop:disable ThreadSafety/NewThread
+        end
+        threads.each(&:join)
+        results
+      end
+      module_function :process_queue
+      private_class_method :process_queue
+
+      def build_work_queue(items)
+        Queue.new.tap do |queue|
+          items.each_with_index { |item, index| queue << [item, index] }
+        end
+      end
+      module_function :build_work_queue
+      private_class_method :build_work_queue
+
+      def drain_queue(queue, results)
+        until queue.empty?
+          begin
+            item, index = queue.pop(true)
+          rescue ThreadError
+            break
+          end
+          results[index] = yield(item)
+        end
+      end
+      module_function :drain_queue
+      private_class_method :drain_queue
+    end
+  end
+end

--- a/lib/html2rss/mcp/catalog_config.rb
+++ b/lib/html2rss/mcp/catalog_config.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'public_suffix'
+require 'uri'
+
+module Html2rss
+  module MCP
+    ##
+    # Generates a feed configuration formatted for the curated catalog
+    # and discovers native syndication feeds.
+    module CatalogConfig
+      # Default fallback topic for catalog configs when none are supplied.
+      DEFAULT_TOPICS = ['news'].freeze
+
+      # Value object representing the result of catalog config generation.
+      CatalogResult = Data.define(
+        :yaml, :domain, :native_feed_detected, :alternate_feeds, :articles_count, :suggested_topics
+      ) do
+        ##
+        # @return [Hash{Symbol => Object}]
+        def to_h
+          {
+            yaml:,
+            domain:,
+            native_feed_detected:,
+            alternate_feeds:,
+            articles_count:,
+            suggested_topics:
+          }
+        end
+      end
+
+      module_function
+
+      ##
+      # Generates a catalog-ready feed configuration from a URL.
+      #
+      # @param url [String] source page URL
+      # @param strategy [Symbol, String] request strategy (+:auto+, +:faraday+, +:botasaurus+)
+      # @param topics [Array<String>, nil] optional directory topics
+      # @param title [String, nil] optional explicit title
+      # @param summary [String, nil] optional directory summary (max 160 chars)
+      # @return [CatalogResult]
+      def generate(url:, strategy: :auto, topics: nil, title: nil, summary: nil) # rubocop:disable Metrics/MethodLength
+        validate_topics!(topics) if topics
+        domain = extract_domain(url)
+        recon = Inspect.call(url:, strategy:)
+        alternate_feeds = Array(recon[:alternate_feeds])
+        native_feed_detected = alternate_feeds.any?
+
+        capture_result = Capture.build(url, strategy:)
+        effective_topics = topics || DEFAULT_TOPICS
+        config = assemble_config(capture_result, domain:, title:, summary:, topics: effective_topics)
+
+        CatalogResult.new(
+          yaml: Config.to_yaml(config),
+          domain:,
+          native_feed_detected:,
+          alternate_feeds:,
+          articles_count: capture_result.articles_count,
+          suggested_topics: effective_topics
+        )
+      end
+
+      ##
+      # @param topics [Array<String>]
+      # @raise [ArgumentError] if any topic is not in {Config::Validator::DIRECTORY_TOPICS}
+      def validate_topics!(topics)
+        allowed = Config::Validator::DIRECTORY_TOPICS
+        invalid = Array(topics).reject { |topic| allowed.include?(topic.to_s) }
+        return if invalid.empty?
+
+        raise ArgumentError, "Invalid topic(s): #{invalid.join(', ')}. Allowed topics: #{allowed.join(', ')}"
+      end
+      module_function :validate_topics!
+      private_class_method :validate_topics!
+
+      ##
+      # @param url [String]
+      # @return [String] registrable domain or hostname
+      def extract_domain(url)
+        host = URI.parse(url).host.to_s
+        PublicSuffix.domain(host) || host
+      rescue StandardError
+        URI.parse(url).host.to_s
+      end
+      module_function :extract_domain
+      private_class_method :extract_domain
+
+      ##
+      # @param capture_result [Html2rss::Capture::CaptureResult]
+      # @param domain [String]
+      # @param title [String, nil]
+      # @param summary [String, nil]
+      # @param topics [Array<String>]
+      # @return [Hash]
+      def assemble_config(capture_result, domain:, title:, summary:, topics:)
+        extracted_title = title || capture_result.channel_title || domain
+        directory = { title: extracted_title, summary:, topics: }.compact
+        config = { directory:, **capture_result.config }
+        config[:channel] ||= {}
+        config[:channel][:title] = extracted_title if title || config[:channel][:title].nil?
+        config
+      end
+      module_function :assemble_config
+      private_class_method :assemble_config
+    end
+  end
+end

--- a/lib/html2rss/mcp/certify.rb
+++ b/lib/html2rss/mcp/certify.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Html2rss
+  module MCP
+    ##
+    # Unified feed config quality certification: schema + vocabulary validation
+    # and live RSS item extraction quality checks.
+    module Certify
+      # Value object representing the result of config certification.
+      CertificationReport = Data.define(:valid, :errors, :live_check) do
+        ##
+        # @return [Hash{Symbol => Object}]
+        def to_h
+          { valid:, errors:, live_check: }
+        end
+      end
+
+      module_function
+
+      ##
+      # Validates a feed configuration and optionally tests live feed generation.
+      #
+      # @param config [Hash, nil] feed configuration hash (XOR yaml)
+      # @param yaml [String, nil] feed configuration YAML string (XOR config)
+      # @param check_live_feed [Boolean] whether to run live feed generation
+      # @return [CertificationReport]
+      def check(config: nil, yaml: nil, check_live_feed: true)
+        feed_config = ConfigArgument.parse(config:, yaml:).config
+        validation = Config.validate(feed_config)
+        return schema_failure_report(validation) unless validation.success?
+        return CertificationReport.new(valid: true, errors: nil, live_check: nil) unless check_live_feed
+
+        live_check_report(feed_config)
+      end
+
+      def schema_failure_report(validation)
+        CertificationReport.new(valid: false, errors: validation.errors.to_h, live_check: nil)
+      end
+      module_function :schema_failure_report
+      private_class_method :schema_failure_report
+
+      def live_check_report(feed_config)
+        feed_result = Html2rss.feed_result(feed_config)
+        rss = feed_result.to_rss
+        items = rss.items
+        warnings = []
+        warnings << 'Feed produced 0 items' if items.empty?
+
+        sample_items = extract_sample_items(items, warnings)
+        valid = warnings.empty?
+        live_check = { item_count: items.size, sample_items:, warnings: warnings.uniq }
+        CertificationReport.new(valid:, errors: nil, live_check:)
+      end
+      module_function :live_check_report
+      private_class_method :live_check_report
+
+      def extract_sample_items(items, warnings)
+        items.first(5).map do |item|
+          title = item.title.to_s.strip
+          url = item.link.to_s.strip
+          warnings << "Item without title detected: #{url}" if title.empty?
+          warnings << "Item with non-absolute URL detected: #{url}" unless url.start_with?('http://', 'https://')
+          { title:, url: }
+        end
+      end
+      module_function :extract_sample_items
+      private_class_method :extract_sample_items
+    end
+  end
+end

--- a/lib/html2rss/mcp/contract.rb
+++ b/lib/html2rss/mcp/contract.rb
@@ -96,6 +96,90 @@ module Html2rss
         required: %w[url]
       }.freeze
 
+      # Input schema for +batch_inspect_urls+.
+      BATCH_INSPECT_INPUT_SCHEMA = {
+        type: 'object',
+        properties: {
+          urls: {
+            type: 'array',
+            items: URL_PROPERTY,
+            minItems: 1,
+            maxItems: 25,
+            description: 'List of page URLs to inspect (1..25)'
+          }.freeze,
+          strategy: INSPECT_STRATEGY_PROPERTY,
+          concurrency: {
+            type: 'integer',
+            description: 'Max parallel worker threads (1..10, default: 5)',
+            default: 5
+          }
+        }.freeze,
+        required: %w[urls]
+      }.freeze
+
+      # Input schema for +batch_scrape_urls+.
+      BATCH_SCRAPE_INPUT_SCHEMA = {
+        type: 'object',
+        properties: {
+          urls: {
+            type: 'array',
+            items: URL_PROPERTY,
+            minItems: 1,
+            maxItems: 25,
+            description: 'List of page URLs to scrape (1..25)'
+          }.freeze,
+          strategy: STRATEGY_PROPERTY,
+          limit: { type: 'integer', description: 'Max articles per URL to keep (default 10)', default: 10 },
+          concurrency: {
+            type: 'integer',
+            description: 'Max parallel worker threads (1..10, default: 5)',
+            default: 5
+          }
+        }.freeze,
+        required: %w[urls]
+      }.freeze
+
+      # Input schema for +generate_catalog_config+.
+      GENERATE_CATALOG_CONFIG_INPUT_SCHEMA = {
+        type: 'object',
+        properties: {
+          url: URL_PROPERTY,
+          strategy: STRATEGY_PROPERTY,
+          topics: {
+            type: 'array',
+            items: {
+              type: 'string',
+              enum: Config::Validator::DIRECTORY_TOPICS
+            },
+            description: 'Optional directory topics (from DIRECTORY_TOPICS vocabulary)'
+          }.freeze,
+          title: {
+            type: 'string',
+            description: 'Optional feed and directory title'
+          },
+          summary: {
+            type: 'string',
+            maxLength: 160,
+            description: 'Optional directory summary (max 160 characters)'
+          }
+        }.freeze,
+        required: %w[url]
+      }.freeze
+
+      # Input schema for +certify_config+.
+      CERTIFY_INPUT_SCHEMA = {
+        type: 'object',
+        properties: {
+          **CONFIG_XOR_PROPERTIES,
+          check_live_feed: {
+            type: 'boolean',
+            default: true,
+            description: 'Whether to execute in-memory live feed generation and item quality checks'
+          }
+        }.freeze,
+        oneOf: XOR_ONE_OF
+      }.freeze
+
       # Tool annotations for open-world read-only tools.
       ANNOTATIONS_OPEN_WORLD = {
         read_only_hint: true,
@@ -113,7 +197,11 @@ module Html2rss
         inspect_url: 'Inspect URL',
         capture_config: 'Capture feed config',
         validate_config: 'Validate feed config',
-        apply_config: 'Apply feed config'
+        apply_config: 'Apply feed config',
+        batch_inspect_urls: 'Batch inspect URLs',
+        batch_scrape_urls: 'Batch scrape URLs',
+        generate_catalog_config: 'Generate catalog config',
+        certify_config: 'Certify feed config'
       }.freeze
 
       class << self

--- a/lib/html2rss/mcp/outcome.rb
+++ b/lib/html2rss/mcp/outcome.rb
@@ -7,7 +7,7 @@ module Html2rss
     ##
     # Typed MCP tool result. Owns next-step policy and guidance copy so the
     # protocol adapter does not branch on quality heuristics.
-    class Outcome
+    class Outcome # rubocop:disable Metrics/ClassLength
       # Matches {ConfigArgument} XOR {ArgumentError} messages.
       XOR_ERROR = /exactly one of config or yaml/
       NextStep = Data.define(:name, :guidance)
@@ -16,7 +16,8 @@ module Html2rss
       # Closed set of agent next actions. Invalid names cannot be constructed.
       class NextStep
         # Wire names for +next_step+.
-        NAMES = %i[done inspect_url validate_config apply_config scrape_url capture_config read_runtime].freeze
+        NAMES = %i[done inspect_url validate_config apply_config scrape_url capture_config read_runtime
+                   certify_config].freeze
         # Default guidance copy keyed by {NAMES}.
         GUIDANCE = {
           done: 'Done. Read payload for the result.',
@@ -28,7 +29,8 @@ module Html2rss
                       'and promotes native RSS/Atom when present.',
           capture_config: 'Call capture_config for a reusable YAML draft, then follow next_step.',
           read_runtime: 'Read html2rss://runtime. Set BOTASAURUS_SCRAPER_URL on the MCP process ' \
-                        'if botasaurus_configured is false.'
+                        'if botasaurus_configured is false.',
+          certify_config: 'Call certify_config to run quality-gate validation on the feed config.'
         }.freeze
 
         ##
@@ -123,6 +125,39 @@ module Html2rss
           ok = !empty
           next_step = ok ? NextStep.done : NextStep.inspect_url
           new(ok:, next_step:, guidance: next_step.guidance, payload: { rss:, item_count: })
+        end
+
+        ##
+        # @param batch_result [Html2rss::MCP::Batch::BatchResult]
+        # @return [Outcome]
+        def batch_inspect(batch_result)
+          next_step = batch_result.successful.positive? ? NextStep.done : NextStep.inspect_url
+          new(ok: true, next_step:, guidance: next_step.guidance, payload: batch_result.to_h)
+        end
+
+        ##
+        # @param batch_result [Html2rss::MCP::Batch::BatchResult]
+        # @return [Outcome]
+        def batch_scrape(batch_result)
+          next_step = batch_result.successful.positive? ? NextStep.done : NextStep.scrape_url
+          new(ok: true, next_step:, guidance: next_step.guidance, payload: batch_result.to_h)
+        end
+
+        ##
+        # @param catalog_result [Html2rss::MCP::CatalogConfig::CatalogResult]
+        # @return [Outcome]
+        def catalog_config(catalog_result)
+          next_step = NextStep.certify_config
+          new(ok: true, next_step:, guidance: next_step.guidance, payload: catalog_result.to_h)
+        end
+
+        ##
+        # @param report [Html2rss::MCP::Certify::CertificationReport]
+        # @return [Outcome]
+        def certify(report)
+          ok = report.valid
+          next_step = ok ? NextStep.done : NextStep.validate_config
+          new(ok:, next_step:, guidance: next_step.guidance, payload: report.to_h)
         end
 
         ##

--- a/lib/html2rss/mcp/server.rb
+++ b/lib/html2rss/mcp/server.rb
@@ -144,18 +144,18 @@ module Html2rss
           <<~TEXT.strip
             html2rss MCP — decide which tool to call:
 
-            1. Need articles now (no saved config)? → scrape_url (1 call)
+            1. Need articles now (no saved config)? → scrape_url (or batch_scrape_urls for multiple)
                - strategy "auto" runs Faraday → Botasaurus AutoFallback. Do not retry with explicit faraday after auto.
                - Empty scrape is still success (articles-now). Follow next_step / guidance (read_runtime if Botasaurus unset).
-            2. Need a reusable feed YAML? → capture_config → validate_config → apply_config
-               - capture_config returns YAML inside payload.yaml. Draft only: if destination is html2rss-configs, rewrite for directory.topics and explicit channel title/url. Strive enhance: true (false only when chrome leaks).
-               - validate_config / apply_config accept config hash XOR yaml string.
-               - apply_config isError when zero RSS items (ship gate). Confirm payload.item_count.
-            3. Weak scrape/capture or recon (final URL, status, https→http, rel=alternate feeds)? → inspect_url only if weak or recon.
-            4. Have a config already? → validate_config (must succeed) → apply_config
+            2. Need a reusable feed YAML? → capture_config (or generate_catalog_config for catalog feeds) → certify_config / validate_config → apply_config
+               - capture_config returns YAML inside payload.yaml.
+               - generate_catalog_config formats catalog YAML with directory.topics, title, and detects native feeds.
+               - certify_config validates schema and tests live feed extraction in 1 step.
+            3. Weak scrape/capture or recon (final URL, status, https→http, rel=alternate feeds)? → inspect_url (or batch_inspect_urls).
+            4. Have a config already? → certify_config or validate_config → apply_config
             5. Schema / extractors / strategies / runtime → resources html2rss://schema|extractors|strategies|runtime
 
-            Prefer capture_config for durable config; scrape_url for one-shot extraction.
+            Prefer capture_config / generate_catalog_config for durable config; scrape_url / batch_scrape_urls for one-shot extraction.
             Follow envelope next_step and guidance. Botasaurus needs BOTASAURUS_SCRAPER_URL in this process env (boolean at html2rss://runtime; the URL is never returned).
           TEXT
         end
@@ -198,6 +198,10 @@ module Html2rss
           register_capture_config(server)
           register_validate_config(server)
           register_apply_config(server)
+          register_batch_inspect_urls(server)
+          register_batch_scrape_urls(server)
+          register_generate_catalog_config(server)
+          register_certify_config(server)
         end
 
         def register_scrape_url(server)
@@ -308,6 +312,71 @@ module Html2rss
           feed_result = Html2rss.feed_result(feed_config)
           rss = feed_result.to_rss
           Outcome.apply(rss: rss.to_s, item_count: rss.items.size, empty: feed_result.empty?)
+        end
+
+        def register_batch_inspect_urls(server)
+          define_envelope_tool(
+            server,
+            name: 'batch_inspect_urls',
+            description: 'Inspect multiple URLs in parallel with per-URL error isolation. ' \
+                         'Returns final redirected URLs, status codes, and rel="alternate" feeds.',
+            input_schema: Contract::BATCH_INSPECT_INPUT_SCHEMA
+          ) do |server_context:, urls:, strategy: 'auto', concurrency: Batch::DEFAULT_CONCURRENCY| # rubocop:disable Lint/UnusedBlockArgument
+            batch_inspect_outcome(urls:, strategy:, concurrency:)
+          end
+        end
+
+        def batch_inspect_outcome(urls:, strategy:, concurrency:)
+          Outcome.batch_inspect(Batch.inspect_urls(urls:, strategy:, concurrency:))
+        end
+
+        def register_batch_scrape_urls(server)
+          define_envelope_tool(
+            server,
+            name: 'batch_scrape_urls',
+            description: 'Scrape multiple URLs in parallel with per-URL error isolation. ' \
+                         'Returns structured JSON Feed items and extraction counts.',
+            input_schema: Contract::BATCH_SCRAPE_INPUT_SCHEMA
+          ) do |server_context:, urls:, strategy: 'auto', limit: 10, concurrency: Batch::DEFAULT_CONCURRENCY| # rubocop:disable Lint/UnusedBlockArgument
+            batch_scrape_outcome(urls:, strategy:, limit:, concurrency:)
+          end
+        end
+
+        def batch_scrape_outcome(urls:, strategy:, limit:, concurrency:)
+          Outcome.batch_scrape(Batch.scrape_urls(urls:, strategy:, limit:, concurrency:))
+        end
+
+        def register_generate_catalog_config(server)
+          define_envelope_tool(
+            server,
+            name: 'generate_catalog_config',
+            description: 'Generate a curated-catalog-ready feed config YAML and detect native feeds. ' \
+                         'Resolves domain via PublicSuffix and sets directory metadata.',
+            input_schema: Contract::GENERATE_CATALOG_CONFIG_INPUT_SCHEMA
+          ) do |server_context:, url:, strategy: 'auto', topics: nil, title: nil, summary: nil| # rubocop:disable Lint/UnusedBlockArgument, Metrics/ParameterLists
+            catalog_config_outcome(url:, strategy:, topics:, title:, summary:)
+          end
+        end
+
+        def catalog_config_outcome(url:, strategy:, topics:, title:, summary:)
+          Outcome.catalog_config(CatalogConfig.generate(url:, strategy:, topics:, title:, summary:))
+        end
+
+        def register_certify_config(server)
+          define_envelope_tool(
+            server,
+            name: 'certify_config',
+            description: 'Comprehensive feed config quality certification: validates schema and ' \
+                         'optionally runs in-memory live extraction to check item count and title/URL health.',
+            input_schema: Contract::CERTIFY_INPUT_SCHEMA,
+            annotations: Contract::ANNOTATIONS_VALIDATE
+          ) do |server_context:, config: nil, yaml: nil, check_live_feed: true| # rubocop:disable Lint/UnusedBlockArgument
+            certify_outcome(config:, yaml:, check_live_feed:)
+          end
+        end
+
+        def certify_outcome(config:, yaml:, check_live_feed:)
+          Outcome.certify(Certify.check(config:, yaml:, check_live_feed:))
         end
 
         def register_resources(server) # rubocop:disable Metrics/MethodLength

--- a/spec/lib/html2rss/mcp/batch_spec.rb
+++ b/spec/lib/html2rss/mcp/batch_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Html2rss::MCP::Batch do
+  describe '.inspect_urls' do
+    let(:urls) { ['https://example.com/one', 'https://example.com/two'] }
+
+    before do
+      allow(Html2rss::MCP::Inspect).to receive(:call) do |url:, strategy:| # rubocop:disable Lint/UnusedBlockArgument
+        raise StandardError, 'Connection failed' if url.include?('two')
+
+        { status: 200, final_url: url, alternate_feeds: [{ href: "#{url}/feed.xml" }] }
+      end
+    end
+
+    # rubocop:disable RSpec/ExampleLength
+    it 'processes URLs in parallel and isolates per-URL errors', :aggregate_failures do
+      result = described_class.inspect_urls(urls:, strategy: :auto, concurrency: 2)
+
+      expect(result.total).to eq(2)
+      expect(result.successful).to eq(1)
+      expect(result.results.size).to eq(2)
+
+      first = result.results.first
+      expect(first[:url]).to eq('https://example.com/one')
+      expect(first[:ok]).to be(true)
+      expect(first[:status_code]).to eq(200)
+      expect(first[:alternate_feeds]).to eq([{ href: 'https://example.com/one/feed.xml' }])
+
+      second = result.results.last
+      expect(second[:url]).to eq('https://example.com/two')
+      expect(second[:ok]).to be(false)
+      expect(second[:error]).to eq('Connection failed')
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    it 'handles an empty url list', :aggregate_failures do
+      result = described_class.inspect_urls(urls: [])
+
+      expect(result.total).to eq(0)
+      expect(result.successful).to eq(0)
+      expect(result.results).to be_empty
+    end
+  end
+
+  describe '.scrape_urls' do
+    let(:urls) { ['https://example.com/a', 'https://example.com/b'] }
+
+    before do
+      status = Html2rss::Status.build(articles: [], dedup_dropped: 0, admission_drops: {})
+      feed_result_a = instance_double(
+        Html2rss::FeedResult,
+        to_json_feed: { title: 'Feed A', items: [{ title: 'Item 1', url: 'https://example.com/a/1' }] },
+        status:
+      )
+      allow(Html2rss).to receive(:auto_feed_result).with('https://example.com/a', strategy: :auto, limit: 10)
+                                                   .and_return(feed_result_a)
+      allow(Html2rss).to receive(:auto_feed_result).with('https://example.com/b', strategy: :auto, limit: 10)
+                                                   .and_raise(StandardError, 'Scrape timed out')
+    end
+
+    # rubocop:disable RSpec/ExampleLength
+    it 'scrapes URLs in parallel and records structured items and errors', :aggregate_failures do
+      result = described_class.scrape_urls(urls:, strategy: :auto, limit: 10, concurrency: 2)
+
+      expect(result.total).to eq(2)
+      expect(result.successful).to eq(1)
+
+      first = result.results.first
+      expect(first[:ok]).to be(true)
+      expect(first[:channel_title]).to eq('Feed A')
+      expect(first[:items_count]).to eq(1)
+      expect(first[:items]).to eq([{ title: 'Item 1', url: 'https://example.com/a/1' }])
+
+      second = result.results.last
+      expect(second[:ok]).to be(false)
+      expect(second[:error]).to eq('Scrape timed out')
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
+end

--- a/spec/lib/html2rss/mcp/catalog_config_spec.rb
+++ b/spec/lib/html2rss/mcp/catalog_config_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Html2rss::MCP::CatalogConfig do
+  describe '.generate' do
+    let(:url) { 'https://www.bsi.bund.de/news' }
+    let(:capture_result) do
+      instance_double(
+        Html2rss::Capture::CaptureResult,
+        config: {
+          channel: { url:, title: 'BSI News', time_zone: 'UTC' },
+          selectors: { items: { selector: 'article.news', enhance: true } }
+        },
+        articles_count: 5,
+        channel_title: 'BSI News'
+      )
+    end
+
+    before do
+      allow(Html2rss::Capture).to receive(:build).with(url, strategy: :auto).and_return(capture_result)
+      allow(Html2rss::MCP::Inspect).to receive(:call).with(url:, strategy: :auto).and_return(
+        { status: 200, alternate_feeds: [{ href: 'https://www.bsi.bund.de/news/feed.xml' }] }
+      )
+    end
+
+    # rubocop:disable RSpec/ExampleLength
+    it 'generates a catalog-ready YAML configuration with extracted domain and native feed detection',
+       :aggregate_failures do
+      result = described_class.generate(url:, topics: %w[security tech], summary: 'BSI Security News')
+
+      expect(result.domain).to eq('bund.de')
+      expect(result.native_feed_detected).to be(true)
+      expect(result.alternate_feeds).to eq([{ href: 'https://www.bsi.bund.de/news/feed.xml' }])
+      expect(result.articles_count).to eq(5)
+      expect(result.suggested_topics).to eq(%w[security tech])
+
+      parsed = Html2rss::Config.from_yaml(result.yaml)
+      expect(parsed.dig(:directory, :title)).to eq('BSI News')
+      expect(parsed.dig(:directory, :topics)).to eq(%w[security tech])
+      expect(parsed.dig(:directory, :summary)).to eq('BSI Security News')
+      expect(parsed.dig(:channel, :title)).to eq('BSI News')
+      expect(parsed.dig(:selectors, :items, :selector)).to eq('article.news')
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    it 'falls back to default topic when topics are not provided', :aggregate_failures do
+      result = described_class.generate(url:)
+
+      expect(result.suggested_topics).to eq(['news'])
+      parsed = Html2rss::Config.from_yaml(result.yaml)
+      expect(parsed.dig(:directory, :topics)).to eq(['news'])
+    end
+
+    it 'raises ArgumentError when invalid topics are provided' do
+      expect do
+        described_class.generate(url:, topics: ['invalid_topic_xyz'])
+      end.to raise_error(ArgumentError, /Invalid topic\(s\): invalid_topic_xyz/)
+    end
+  end
+end

--- a/spec/lib/html2rss/mcp/certify_spec.rb
+++ b/spec/lib/html2rss/mcp/certify_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Html2rss::MCP::Certify do
+  describe '.check' do
+    let(:valid_config) do
+      {
+        channel: { url: 'https://example.com', title: 'Example' },
+        selectors: {
+          items: { selector: 'article' },
+          title: { selector: 'h2' },
+          url: { selector: 'a', extractor: 'href' }
+        }
+      }
+    end
+
+    it 'returns a report with valid: false when schema validation fails', :aggregate_failures do
+      report = described_class.check(config: { channel: { url: 'not-a-url' } })
+
+      expect(report.valid).to be(false)
+      expect(report.errors).not_to be_nil
+      expect(report.live_check).to be_nil
+    end
+
+    it 'returns valid: true without live check when check_live_feed is false', :aggregate_failures do
+      report = described_class.check(config: valid_config, check_live_feed: false)
+
+      expect(report.valid).to be(true)
+      expect(report.errors).to be_nil
+      expect(report.live_check).to be_nil
+    end
+
+    # rubocop:disable RSpec/ExampleLength
+    it 'returns valid: true with live check metrics when items exist', :aggregate_failures do
+      rss_item = instance_double(
+        RSS::Rss::Channel::Item,
+        title: 'Article 1',
+        link: 'https://example.com/articles/1'
+      )
+      rss = instance_double(RSS::Rss, items: [rss_item])
+      allow(Html2rss).to receive(:feed_result).and_return(
+        instance_double(Html2rss::FeedResult, to_rss: rss, empty?: false)
+      )
+
+      report = described_class.check(config: valid_config, check_live_feed: true)
+
+      expect(report.valid).to be(true)
+      expect(report.errors).to be_nil
+      expect(report.live_check[:item_count]).to eq(1)
+      expect(report.live_check[:sample_items]).to eq([{ title: 'Article 1', url: 'https://example.com/articles/1' }])
+      expect(report.live_check[:warnings]).to be_empty
+    end
+
+    it 'returns valid: false and flags warning when feed produces zero items', :aggregate_failures do
+      empty_rss = instance_double(RSS::Rss, items: [])
+      allow(Html2rss).to receive(:feed_result).and_return(
+        instance_double(Html2rss::FeedResult, to_rss: empty_rss, empty?: true)
+      )
+
+      report = described_class.check(config: valid_config, check_live_feed: true)
+
+      expect(report.valid).to be(false)
+      expect(report.live_check[:warnings]).to include('Feed produced 0 items')
+    end
+
+    it 'flags non-absolute URL warning when item has relative URL', :aggregate_failures do
+      relative_item = instance_double(
+        RSS::Rss::Channel::Item,
+        title: 'Article Rel',
+        link: '/relative/path'
+      )
+      relative_rss = instance_double(RSS::Rss, items: [relative_item])
+      allow(Html2rss).to receive(:feed_result).and_return(
+        instance_double(Html2rss::FeedResult, to_rss: relative_rss, empty?: false)
+      )
+
+      report = described_class.check(config: valid_config, check_live_feed: true)
+
+      expect(report.valid).to be(false)
+      expect(report.live_check[:warnings]).to include('Item with non-absolute URL detected: /relative/path')
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
+end

--- a/spec/lib/html2rss/mcp/contract_spec.rb
+++ b/spec/lib/html2rss/mcp/contract_spec.rb
@@ -79,6 +79,65 @@ RSpec.describe Html2rss::MCP::Contract do
     end
   end
 
+  describe 'BATCH_INSPECT_INPUT_SCHEMA' do
+    let(:schema) { MCP::Tool::InputSchema.new(described_class::BATCH_INSPECT_INPUT_SCHEMA) }
+
+    it 'validates valid arguments', :aggregate_failures do
+      expect { schema.validate_arguments({ urls: ['https://example.com'] }) }.not_to raise_error
+      expect { schema.validate_arguments({ urls: ['https://example.com'], strategy: 'faraday', concurrency: 3 }) }
+        .not_to raise_error
+    end
+
+    it 'rejects empty urls array or missing urls', :aggregate_failures do
+      expect { schema.validate_arguments({}) }.to raise_error(MCP::Tool::InputSchema::ValidationError)
+      expect { schema.validate_arguments({ urls: [] }) }.to raise_error(MCP::Tool::InputSchema::ValidationError)
+    end
+  end
+
+  describe 'BATCH_SCRAPE_INPUT_SCHEMA' do
+    let(:schema) { MCP::Tool::InputSchema.new(described_class::BATCH_SCRAPE_INPUT_SCHEMA) }
+
+    it 'validates valid arguments' do
+      expect { schema.validate_arguments({ urls: ['https://example.com'], limit: 5 }) }.not_to raise_error
+    end
+
+    it 'rejects missing urls' do
+      expect { schema.validate_arguments({ limit: 5 }) }.to raise_error(MCP::Tool::InputSchema::ValidationError)
+    end
+  end
+
+  describe 'GENERATE_CATALOG_CONFIG_INPUT_SCHEMA' do
+    let(:schema) { MCP::Tool::InputSchema.new(described_class::GENERATE_CATALOG_CONFIG_INPUT_SCHEMA) }
+
+    it 'validates valid arguments', :aggregate_failures do
+      expect { schema.validate_arguments({ url: 'https://example.com' }) }.not_to raise_error
+      expect do
+        schema.validate_arguments({ url: 'https://example.com', topics: %w[news tech], title: 'Example' })
+      end.not_to raise_error
+    end
+
+    it 'rejects invalid topic enum' do
+      expect do
+        schema.validate_arguments({ url: 'https://example.com', topics: ['invalid_xyz'] })
+      end.to raise_error(MCP::Tool::InputSchema::ValidationError)
+    end
+  end
+
+  describe 'CERTIFY_INPUT_SCHEMA' do
+    let(:schema) { MCP::Tool::InputSchema.new(described_class::CERTIFY_INPUT_SCHEMA) }
+
+    it 'validates valid arguments', :aggregate_failures do
+      expect { schema.validate_arguments({ config: config_hash }) }.not_to raise_error
+      expect { schema.validate_arguments({ yaml: config_yaml, check_live_feed: false }) }.not_to raise_error
+    end
+
+    it 'rejects missing or XOR violating arguments', :aggregate_failures do
+      expect { schema.validate_arguments({}) }.to raise_error(MCP::Tool::InputSchema::ValidationError)
+      expect { schema.validate_arguments({ config: config_hash, yaml: config_yaml }) }
+        .to raise_error(MCP::Tool::InputSchema::ValidationError)
+    end
+  end
+
   describe '.output_schema' do
     it 'validates an Outcome wire hash' do
       wire = Html2rss::MCP::Outcome.apply(rss: '<rss/>', item_count: 1).to_h

--- a/spec/lib/html2rss/mcp/outcome_spec.rb
+++ b/spec/lib/html2rss/mcp/outcome_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Html2rss::MCP::Outcome do
     it 'exposes the closed set of wire names' do
       expect(described_class::NAMES.map(&:to_s)).to contain_exactly(
         'done', 'inspect_url', 'validate_config', 'apply_config',
-        'scrape_url', 'capture_config', 'read_runtime'
+        'scrape_url', 'capture_config', 'read_runtime', 'certify_config'
       )
     end
 
@@ -149,6 +149,81 @@ RSpec.describe Html2rss::MCP::Outcome do
 
       expect(outcome).to have_attributes(ok: false, next_step: have_attributes(name: :inspect_url))
     end
+  end
+
+  describe '.batch_inspect' do
+    it 'points at done when there is at least one successful result', :aggregate_failures do
+      batch_result = Html2rss::MCP::Batch::BatchResult.new(total: 1, successful: 1, results: [{ ok: true }])
+      outcome = described_class.batch_inspect(batch_result)
+
+      expect(outcome.ok).to be(true)
+      expect(outcome.next_step.name).to eq(:done)
+      expect(outcome.payload).to eq(total: 1, successful: 1, results: [{ ok: true }])
+    end
+
+    it 'points at inspect_url when there are zero successful results' do
+      batch_result = Html2rss::MCP::Batch::BatchResult.new(total: 1, successful: 0, results: [{ ok: false }])
+      outcome = described_class.batch_inspect(batch_result)
+
+      expect(outcome.next_step.name).to eq(:inspect_url)
+    end
+  end
+
+  describe '.batch_scrape' do
+    it 'points at done when there is at least one successful result', :aggregate_failures do
+      batch_result = Html2rss::MCP::Batch::BatchResult.new(total: 1, successful: 1, results: [{ ok: true }])
+      outcome = described_class.batch_scrape(batch_result)
+
+      expect(outcome.ok).to be(true)
+      expect(outcome.next_step.name).to eq(:done)
+    end
+
+    it 'points at scrape_url when there are zero successful results' do
+      batch_result = Html2rss::MCP::Batch::BatchResult.new(total: 1, successful: 0, results: [{ ok: false }])
+      outcome = described_class.batch_scrape(batch_result)
+
+      expect(outcome.next_step.name).to eq(:scrape_url)
+    end
+  end
+
+  describe '.catalog_config' do
+    # rubocop:disable RSpec/ExampleLength
+    it 'points at certify_config and includes catalog payload', :aggregate_failures do
+      catalog_result = Html2rss::MCP::CatalogConfig::CatalogResult.new(
+        yaml: 'yaml', domain: 'example.com', native_feed_detected: false,
+        alternate_feeds: [], articles_count: 5, suggested_topics: ['news']
+      )
+      outcome = described_class.catalog_config(catalog_result)
+
+      expect(outcome.ok).to be(true)
+      expect(outcome.next_step.name).to eq(:certify_config)
+      expect(outcome.payload[:domain]).to eq('example.com')
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
+
+  describe '.certify' do
+    # rubocop:disable RSpec/ExampleLength
+    it 'is ok and points at done when report is valid', :aggregate_failures do
+      report = Html2rss::MCP::Certify::CertificationReport.new(
+        valid: true, errors: nil, live_check: { item_count: 5 }
+      )
+      outcome = described_class.certify(report)
+
+      expect(outcome.ok).to be(true)
+      expect(outcome.next_step.name).to eq(:done)
+    end
+
+    it 'is not ok and points at validate_config when report is invalid', :aggregate_failures do
+      report = Html2rss::MCP::Certify::CertificationReport.new(
+        valid: false, errors: { channel: ['error'] }, live_check: nil
+      )
+      outcome = described_class.certify(report)
+
+      expect(outcome.ok).to be(false)
+      expect(outcome.next_step.name).to eq(:validate_config)
+    end
+    # rubocop:enable RSpec/ExampleLength
   end
 
   describe '.from_error' do

--- a/spec/lib/html2rss/mcp/server_spec.rb
+++ b/spec/lib/html2rss/mcp/server_spec.rb
@@ -63,13 +63,14 @@ RSpec.describe Html2rss::MCP::Server do
       expect(protocol_server.title).to eq('html2rss')
       expect(protocol_server.configuration.validate_tool_call_results?).to be(true)
       expect(protocol_server.tools.keys).to contain_exactly(
-        'scrape_url', 'inspect_url', 'capture_config', 'validate_config', 'apply_config'
+        'scrape_url', 'inspect_url', 'capture_config', 'validate_config', 'apply_config',
+        'batch_inspect_urls', 'batch_scrape_urls', 'generate_catalog_config', 'certify_config'
       )
       expect(protocol_server.prompts.keys).to contain_exactly('scrape-webpage', 'capture-feed-config')
       expect(protocol_server.instructions).to include('Faraday → Botasaurus AutoFallback')
       expect(protocol_server.instructions).to include('html2rss://runtime')
-      expect(protocol_server.instructions).to include('Strive enhance: true')
-      expect(protocol_server.instructions).to include('payload.item_count')
+      expect(protocol_server.instructions).to include('generate_catalog_config')
+      expect(protocol_server.instructions).to include('certify_config')
       expect(protocol_server.instructions).not_to include('_meta')
       expect(protocol_server.instructions).not_to include('try explicit "faraday"')
       expect(protocol_server.tools['validate_config'].description).to include('html2rss://schema')
@@ -337,6 +338,93 @@ RSpec.describe Html2rss::MCP::Server do
         expect(envelope[:payload]).to include(strategy: 'faraday')
       end
       # rubocop:enable RSpec/ExampleLength
+    end
+
+    describe 'batch_inspect_urls' do
+      let(:batch_result) do
+        Html2rss::MCP::Batch::BatchResult.new(
+          total: 2, successful: 2,
+          results: [{ url: 'https://example.com/1', ok: true }, { url: 'https://example.com/2', ok: true }]
+        )
+      end
+
+      before do
+        allow(Html2rss::MCP::Batch).to receive(:inspect_urls).and_return(batch_result)
+      end
+
+      it 'returns batch inspection payload and next_step done', :aggregate_failures do
+        result = call_tool.call('batch_inspect_urls', { urls: ['https://example.com/1', 'https://example.com/2'] })
+        envelope = JSON.parse(result.dig(:result, :content, 0, :text), symbolize_names: true)
+
+        expect(result.dig(:result, :isError)).to be(false)
+        expect(envelope).to include(ok: true, next_step: 'done')
+        expect(envelope[:payload]).to include(total: 2, successful: 2)
+      end
+    end
+
+    describe 'batch_scrape_urls' do
+      let(:batch_result) do
+        Html2rss::MCP::Batch::BatchResult.new(
+          total: 1, successful: 1,
+          results: [{ url: 'https://example.com', ok: true, items_count: 3 }]
+        )
+      end
+
+      before do
+        allow(Html2rss::MCP::Batch).to receive(:scrape_urls).and_return(batch_result)
+      end
+
+      it 'returns batch scrape payload and next_step done', :aggregate_failures do
+        result = call_tool.call('batch_scrape_urls', { urls: ['https://example.com'] })
+        envelope = JSON.parse(result.dig(:result, :content, 0, :text), symbolize_names: true)
+
+        expect(result.dig(:result, :isError)).to be(false)
+        expect(envelope).to include(ok: true, next_step: 'done')
+        expect(envelope[:payload]).to include(total: 1, successful: 1)
+      end
+    end
+
+    describe 'generate_catalog_config' do
+      let(:catalog_result) do
+        Html2rss::MCP::CatalogConfig::CatalogResult.new(
+          yaml: "directory:\n  title: Example\n", domain: 'example.com', native_feed_detected: false,
+          alternate_feeds: [], articles_count: 5, suggested_topics: ['news']
+        )
+      end
+
+      before do
+        allow(Html2rss::MCP::CatalogConfig).to receive(:generate).and_return(catalog_result)
+      end
+
+      it 'returns generated catalog config and next_step certify_config', :aggregate_failures do
+        result = call_tool.call('generate_catalog_config', { url: 'https://example.com' })
+        envelope = JSON.parse(result.dig(:result, :content, 0, :text), symbolize_names: true)
+
+        expect(result.dig(:result, :isError)).to be(false)
+        expect(envelope).to include(ok: true, next_step: 'certify_config')
+        expect(envelope[:payload]).to include(domain: 'example.com', yaml: "directory:\n  title: Example\n")
+      end
+    end
+
+    describe 'certify_config' do
+      let(:report) do
+        Html2rss::MCP::Certify::CertificationReport.new(
+          valid: true, errors: nil, live_check: { item_count: 3, warnings: [] }
+        )
+      end
+
+      before do
+        allow(Html2rss::MCP::Certify).to receive(:check).and_return(report)
+      end
+
+      it 'returns certification report payload and next_step done', :aggregate_failures do
+        result = call_tool.call('certify_config', { config: valid_config })
+        envelope = JSON.parse(result.dig(:result, :content, 0, :text), symbolize_names: true)
+
+        expect(result.dig(:result, :isError)).to be(false)
+        expect(envelope).to include(ok: true, next_step: 'done')
+        expect(envelope[:payload]).to include(valid: true)
+      end
     end
 
     describe 'error paths' do


### PR DESCRIPTION
## What changed

- **Batch inspection & scraping (`Html2rss::MCP::Batch`)**:
  - Added `batch_inspect_urls` tool with concurrency bounding (1..10, default 5) and per-URL error isolation to discover final URLs, status codes, and `rel="alternate"` feeds.
  - Added `batch_scrape_urls` tool for parallel JSON Feed item extraction across multiple targets.
- **Catalog-ready feed config synthesis (`Html2rss::MCP::CatalogConfig`)**:
  - Added `generate_catalog_config` tool resolving registrable domains via `PublicSuffix`, discovering first-party syndication feeds, running selector capture (`Html2rss::Capture.build`), and formatting catalog YAML with `directory: { topics, title, summary }` and `channel`.
- **Unified config certification (`Html2rss::MCP::Certify`)**:
  - Added `certify_config` tool combining schema validation against `DIRECTORY_TOPICS` vocabulary and in-memory live feed generation (`Html2rss.feed_result`) with title and URL health assertions.
- **MCP Wire Contracts & Diagnostics (`Contract`, `Outcome`, `Server`)**:
  - Registered all 4 new tools with explicit input schemas, annotations, human titles, and decision-tree instructions.
  - Added `:certify_config` next-step routing in `Outcome`.
- **Documentation**:
  - Updated MCP Tools table in `README.md`.

## Why

Extends the `html2rss` MCP server to support efficient multi-URL reconnaissance, curated feed-catalog YAML authoring, and end-to-end quality validation without requiring multiple manual round-trips.

## Risk

- Low. The new batch, catalog, and certify tools are additive extensions under `Html2rss::MCP` and lazy-load dependencies only when invoked. Existing single-target tools (`scrape_url`, `inspect_url`, `capture_config`, `validate_config`, `apply_config`) remain unchanged.

## Review map

1. `lib/html2rss/mcp/batch.rb` — bounded worker queue batch engine & error isolation
2. `lib/html2rss/mcp/catalog_config.rb` — domain resolution, native feed detection, and catalog YAML assembly
3. `lib/html2rss/mcp/certify.rb` — schema + live extraction validation checks
4. `lib/html2rss/mcp/server.rb` & `lib/html2rss/mcp/contract.rb` — tool registration and JSON Schema contracts
5. `spec/lib/html2rss/mcp/` — unit and integration test suite

## Validation

- `bundle exec rspec spec/lib/html2rss/mcp/` (117 examples, 0 failures)
- `make ready` (RuboCop 0 offenses across 355 files, YARD lint 0 offenses, RSpec 1735 examples 0 failures with 98.45% coverage, schema/fixtures/docs verified)