### PR TITLE
feat(config): expand DIRECTORY_TOPICS with health, culture, education, rights, transport

### DIFF
--- a/lib/html2rss/config/validator.rb
+++ b/lib/html2rss/config/validator.rb
@@ -19,6 +19,7 @@ module Html2rss
       DIRECTORY_TOPICS = %w[
         sports energy tech science news entertainment jobs finance
         security travel environment consumer civic product research
+        health culture education rights transport
       ].freeze
 
       # Contract for the top-level `channel` section.

--- a/schema/html2rss-config.schema.json
+++ b/schema/html2rss-config.schema.json
@@ -97,7 +97,12 @@
               "consumer",
               "civic",
               "product",
-              "research"
+              "research",
+              "health",
+              "culture",
+              "education",
+              "rights",
+              "transport"
             ]
           },
           "minItems": 1

--- a/spec/lib/html2rss/config_spec.rb
+++ b/spec/lib/html2rss/config_spec.rb
@@ -343,6 +343,11 @@ RSpec.describe Html2rss::Config do
         expect(result.to_h.dig(:directory, :summary)).to eq('Latest headlines from Example.')
         expect(result.to_h.dig(:directory, :topics)).to eq(%w[sports news])
       end
+
+      it 'accepts newly added topics such as health, culture, education, rights, and transport' do
+        expanded = config.merge(directory: { title: 'T', topics: %w[health culture education rights transport] })
+        expect(described_class.validate(expanded)).to be_success
+      end
     end
 
     context 'when directory title is missing' do


### PR DESCRIPTION
## Summary

Expands the controlled directory topic taxonomy in `Html2rss::Config::Validator::DIRECTORY_TOPICS` from 15 to 20 topics by adding:
- `health` — public health, epidemiology, healthcare access, medical advisories
- `culture` — arts, cultural heritage, museums, libraries, archives, philosophy, literature
- `education` — open knowledge, universities, curricula, open educational resources, academic policy
- `rights` — human rights, civil liberties, legal justice, court rulings, press freedom
- `transport` — public transit, civil aviation safety, maritime navigation, rail & mobility policy

## Verification
- `make schema` — synced `schema/html2rss-config.schema.json`
- `make ready` — 1,706 examples, 0 failures; RuboCop 0 offenses; 98.4% coverage