### PR TITLE
feat(selectors): default item URL for anchor containers and fail-fast auto fallback

### DIFF
--- a/lib/html2rss/cli.rb
+++ b/lib/html2rss/cli.rb
@@ -280,7 +280,7 @@ module Html2rss
 
     def execute_feed # rubocop:disable Metrics/MethodLength
       yield
-    rescue Faraday::FollowRedirects::RedirectLimitReached => error
+    rescue Html2rss::RequestService::RedirectLimitReached => error
       raise Thor::Error,
             "#{error.message}. already retried the last redirect hop once; " \
             "retry with --max-redirects #{suggested_max_redirects} or use the final URL directly."

--- a/lib/html2rss/feed_pipeline/auto_fallback.rb
+++ b/lib/html2rss/feed_pipeline/auto_fallback.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'faraday/follow_redirects'
-
 module Html2rss
   class FeedPipeline
     # Retries feed extraction across concrete request strategies for the :auto plan.
@@ -24,7 +22,7 @@ module Html2rss
         RequestService::PrivateNetworkDenied,
         RequestService::CrossOriginFollowUpDenied,
         RequestService::ResponseTooLarge,
-        Faraday::FollowRedirects::RedirectLimitReached
+        RequestService::RedirectLimitReached
       ].freeze
 
       ##

--- a/lib/html2rss/feed_pipeline/auto_fallback.rb
+++ b/lib/html2rss/feed_pipeline/auto_fallback.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'faraday/follow_redirects'
+
 module Html2rss
   class FeedPipeline
     # Retries feed extraction across concrete request strategies for the :auto plan.
@@ -10,6 +12,9 @@ module Html2rss
       # Ordered list of concrete request strategies attempted by the :auto plan.
       CHAIN = %i[faraday botasaurus].freeze
 
+      # Deterministic HTTP statuses that indicate permanent failure rather than anti-bot challenges.
+      DETERMINISTIC_HTTP_STATUSES = Set[400, 404, 410, 422, 451].freeze
+
       # Error classes that should abort auto fallback immediately.
       NON_FALLBACK_ERRORS = [
         RequestService::UnknownStrategy,
@@ -18,7 +23,8 @@ module Html2rss
         RequestService::RequestBudgetExceeded,
         RequestService::PrivateNetworkDenied,
         RequestService::CrossOriginFollowUpDenied,
-        RequestService::ResponseTooLarge
+        RequestService::ResponseTooLarge,
+        Faraday::FollowRedirects::RedirectLimitReached
       ].freeze
 
       ##
@@ -32,10 +38,19 @@ module Html2rss
           @last_response = nil
           @entry_resolution = nil
           @resolution_tried = false
+          @aborted = false
         end
 
         # @return [Boolean] true when a strategy already yielded items
         def succeeded? = !result.nil?
+
+        # @return [Boolean] whether attempts were aborted due to deterministic errors
+        def aborted? = @aborted
+
+        # @return [void]
+        def abort!
+          @aborted = true
+        end
 
         # @return [Boolean] whether entry resolution already ran for this chain
         def resolution_tried? = @resolution_tried
@@ -133,7 +148,7 @@ module Html2rss
         AttemptState.new.tap do |state|
           strategies.each_with_index do |strategy, index|
             attempt(strategy:, next_strategy: strategies[index + 1], state:)
-            break if state.succeeded?
+            break if state.succeeded? || state.aborted?
           end
         end
       end
@@ -184,9 +199,19 @@ module Html2rss
                                 state:)
         end
 
+        if deterministic_status?(response)
+          state.abort!
+          Log.debug("#{self.class}: deterministic HTTP #{response.status}; aborting auto fallback")
+          return
+        end
+
         log_info_fallback_zero_items(strategy:, next_strategy:, response:) if next_strategy
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+
+      def deterministic_status?(response)
+        DETERMINISTIC_HTTP_STATUSES.member?(response&.status)
+      end
 
       def articles_for(response:, request_session:)
         pipeline.deduplicated_articles(config:, response:, request_session:)

--- a/lib/html2rss/request_service.rb
+++ b/lib/html2rss/request_service.rb
@@ -29,6 +29,8 @@ module Html2rss
     class CrossOriginFollowUpDenied < Html2rss::Error; end
     # Raised when a response exceeds configured size limits.
     class ResponseTooLarge < Html2rss::Error; end
+    # Raised when HTTP redirect limits are exceeded.
+    class RedirectLimitReached < Html2rss::Error; end
     # Raised when blocked content surfaces are detected.
     class BlockedSurfaceDetected < Html2rss::Error; end
 

--- a/lib/html2rss/request_service/faraday_strategy.rb
+++ b/lib/html2rss/request_service/faraday_strategy.rb
@@ -59,9 +59,13 @@ module Html2rss
       def request_with_terminal_redirect_retry(response_guard, deadline:)
         faraday_request(response_guard, deadline:, streaming_buffer: true)
       rescue Faraday::FollowRedirects::RedirectLimitReached => error
-        raise error unless terminal_redirect_retryable?
+        raise RedirectLimitReached, error.message unless terminal_redirect_retryable?
 
-        retry_from_terminal_redirect!(response_guard, deadline:)
+        begin
+          retry_from_terminal_redirect!(response_guard, deadline:)
+        rescue Faraday::FollowRedirects::RedirectLimitReached => retry_error
+          raise RedirectLimitReached, retry_error.message
+        end
       end
 
       def terminal_redirect_retryable?

--- a/lib/html2rss/selectors.rb
+++ b/lib/html2rss/selectors.rb
@@ -95,13 +95,16 @@ module Html2rss
     # @return [Hash] Hash of attributes for the article.
     def extract_article(item, page_response = response)
       scope = item_scope_for(item, page_response.url)
-      @rss_item_attributes.each_with_object({}) do |selector_key, hash|
+      hash = @rss_item_attributes.each_with_object({}) do |selector_key, h|
         value = scope.select(selector_key)
         next if value.nil?
 
         article_key = SELECTOR_TO_ARTICLE_KEY.fetch(selector_key, selector_key)
-        hash[article_key] = article_key == :enclosures ? wrap_enclosure_value(value) : value
+        h[article_key] = article_key == :enclosures ? wrap_enclosure_value(value) : value
       end
+
+      hash[:url] ||= default_item_url(item, page_response.url) if anchor_element?(item)
+      hash
     end
 
     ##
@@ -157,13 +160,11 @@ module Html2rss
 
       raise InvalidSelectorName, "Attribute selector '#{name}' is reserved for items." if name == ITEMS_SELECTOR_KEY
 
-      selector_key, config = selector_config_for(name)
+      selector_key, config = selector_config_for(name, allow_nil: name == :url)
+      return default_item_url(scope.item, scope.base_url) if fallback_url_selector?(selector_key, config, scope.item)
+      raise InvalidSelectorName, "Selector for '#{selector_key}' is not defined." if config.nil?
 
-      if SPECIAL_ATTRIBUTES.member?(selector_key)
-        select_special(selector_key, scope:, config:)
-      else
-        select_regular(selector_key, scope:, config:)
-      end
+      dispatch_select(selector_key, scope:, config:)
     end
 
     private
@@ -316,6 +317,29 @@ module Html2rss
       url = Url.from_relative(selected, scope.base_url)
 
       { url:, type: config[:content_type] }
+    end
+
+    def anchor_element?(item)
+      item.respond_to?(:name) && item.name.to_s.casecmp('a').zero?
+    end
+
+    def fallback_url_selector?(selector_key, config, item)
+      selector_key == :url && config.nil? && anchor_element?(item)
+    end
+
+    def dispatch_select(selector_key, scope:, config:)
+      if SPECIAL_ATTRIBUTES.member?(selector_key)
+        select_special(selector_key, scope:, config:)
+      else
+        select_regular(selector_key, scope:, config:)
+      end
+    end
+
+    def default_item_url(item, base_url)
+      href = item['href'].to_s.strip
+      return if href.empty?
+
+      Url.from_relative(href, base_url)
     end
   end
 end

--- a/spec/lib/html2rss/cli_spec.rb
+++ b/spec/lib/html2rss/cli_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe Html2rss::CLI do
     context 'when the redirect limit is hit' do
       before do
         allow(Html2rss).to receive(:auto_feed_result).and_raise(
-          Faraday::FollowRedirects::RedirectLimitReached,
+          Html2rss::RequestService::RedirectLimitReached,
           'too many redirects; last one to: https://www.example.com/'
         )
       end
@@ -427,7 +427,7 @@ RSpec.describe Html2rss::CLI do
   describe 'redirect failures' do
     before do
       allow(Html2rss).to receive(:feed).and_raise(
-        Faraday::FollowRedirects::RedirectLimitReached,
+        Html2rss::RequestService::RedirectLimitReached,
         'too many redirects; last one to: https://www.example.com/'
       )
       allow(Html2rss).to receive(:config_from_yaml_file).and_return({ url: 'https://example.com' })

--- a/spec/lib/html2rss/feed_pipeline/auto_fallback_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline/auto_fallback_spec.rb
@@ -4,9 +4,9 @@ require 'spec_helper'
 
 RSpec.describe Html2rss::FeedPipeline::AutoFallback do
   describe '::NON_FALLBACK_ERRORS' do
-    it 'includes Faraday RedirectLimitReached' do
+    it 'includes RequestService::RedirectLimitReached' do
       expect(described_class::NON_FALLBACK_ERRORS)
-        .to include(Faraday::FollowRedirects::RedirectLimitReached)
+        .to include(Html2rss::RequestService::RedirectLimitReached)
     end
 
     it 'does not abort auto when Faraday reports an unsupported content type' do

--- a/spec/lib/html2rss/feed_pipeline/auto_fallback_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline/auto_fallback_spec.rb
@@ -4,6 +4,11 @@ require 'spec_helper'
 
 RSpec.describe Html2rss::FeedPipeline::AutoFallback do
   describe '::NON_FALLBACK_ERRORS' do
+    it 'includes Faraday RedirectLimitReached' do
+      expect(described_class::NON_FALLBACK_ERRORS)
+        .to include(Faraday::FollowRedirects::RedirectLimitReached)
+    end
+
     it 'does not abort auto when Faraday reports an unsupported content type' do
       expect(described_class::NON_FALLBACK_ERRORS)
         .not_to include(Html2rss::RequestService::UnsupportedResponseContentType)

--- a/spec/lib/html2rss/feed_pipeline_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline_spec.rb
@@ -245,6 +245,46 @@ RSpec.describe Html2rss::FeedPipeline do
         end
       end
 
+      context 'when Faraday returns deterministic HTTP 404 Not Found' do # rubocop:disable RSpec/NestedGroups, RSpec/MultipleMemoizedHelpers
+        let(:strategy_results) do
+          {
+            faraday: Html2rss::RequestService::Response.new(
+              body: '<html><body><h1>404 Not Found</h1></body></html>',
+              url: Html2rss::Url.from_absolute('https://example.com/news'),
+              headers: { 'content-type' => 'text/html' },
+              status: 404
+            ),
+            botasaurus: item_response
+          }
+        end
+
+        # rubocop:disable RSpec/ExampleLength
+        it 'aborts auto fallback immediately without attempting Botasaurus', :aggregate_failures do
+          expect { pipeline.to_result }.to raise_error(Html2rss::NoFeedItemsExtracted) do |error|
+            expect(error.attempts.size).to eq(1)
+            expect(error.attempts.first[:strategy]).to eq(:faraday)
+          end
+          expect(Html2rss::RequestService).to have_received(:execute).with(anything, strategy: :faraday).once
+          expect(Html2rss::RequestService).not_to have_received(:execute).with(anything, strategy: :botasaurus)
+        end
+        # rubocop:enable RSpec/ExampleLength
+      end
+
+      context 'when Faraday raises Faraday::FollowRedirects::RedirectLimitReached' do # rubocop:disable RSpec/NestedGroups, RSpec/MultipleMemoizedHelpers
+        let(:strategy_results) do
+          {
+            faraday: Faraday::FollowRedirects::RedirectLimitReached.new('redirect limit reached'),
+            botasaurus: item_response
+          }
+        end
+
+        it 'aborts immediately without attempting Botasaurus', :aggregate_failures do
+          expect { pipeline.to_result }.to raise_error(Faraday::FollowRedirects::RedirectLimitReached)
+          expect(Html2rss::RequestService).to have_received(:execute).with(anything, strategy: :faraday).once
+          expect(Html2rss::RequestService).not_to have_received(:execute).with(anything, strategy: :botasaurus)
+        end
+      end
+
       context 'when Faraday raises UnsupportedResponseContentType' do # rubocop:disable RSpec/NestedGroups, RSpec/MultipleMemoizedHelpers
         let(:strategy_results) do
           {

--- a/spec/lib/html2rss/feed_pipeline_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline_spec.rb
@@ -270,16 +270,16 @@ RSpec.describe Html2rss::FeedPipeline do
         # rubocop:enable RSpec/ExampleLength
       end
 
-      context 'when Faraday raises Faraday::FollowRedirects::RedirectLimitReached' do # rubocop:disable RSpec/NestedGroups, RSpec/MultipleMemoizedHelpers
+      context 'when Faraday raises RequestService::RedirectLimitReached' do # rubocop:disable RSpec/NestedGroups, RSpec/MultipleMemoizedHelpers
         let(:strategy_results) do
           {
-            faraday: Faraday::FollowRedirects::RedirectLimitReached.new('redirect limit reached'),
+            faraday: Html2rss::RequestService::RedirectLimitReached.new('redirect limit reached'),
             botasaurus: item_response
           }
         end
 
         it 'aborts immediately without attempting Botasaurus', :aggregate_failures do
-          expect { pipeline.to_result }.to raise_error(Faraday::FollowRedirects::RedirectLimitReached)
+          expect { pipeline.to_result }.to raise_error(Html2rss::RequestService::RedirectLimitReached)
           expect(Html2rss::RequestService).to have_received(:execute).with(anything, strategy: :faraday).once
           expect(Html2rss::RequestService).not_to have_received(:execute).with(anything, strategy: :botasaurus)
         end

--- a/spec/lib/html2rss/request_service/faraday_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/faraday_strategy_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe Html2rss::RequestService::FaradayStrategy do # rubocop:disable RS
         raise Faraday::FollowRedirects::RedirectLimitReached, 'too many redirects'
       end
 
-      expect { execute }.to raise_error(Faraday::FollowRedirects::RedirectLimitReached, /too many redirects/)
+      expect { execute }.to raise_error(Html2rss::RequestService::RedirectLimitReached, /too many redirects/)
       expect(connection).to have_received(:get).twice
       expect(budget).to have_received(:consume!).once
     end
@@ -290,7 +290,7 @@ RSpec.describe Html2rss::RequestService::FaradayStrategy do # rubocop:disable RS
         raise Faraday::FollowRedirects::RedirectLimitReached, 'too many redirects'
       end
 
-      expect { execute }.to raise_error(Faraday::FollowRedirects::RedirectLimitReached, /too many redirects/)
+      expect { execute }.to raise_error(Html2rss::RequestService::RedirectLimitReached, /too many redirects/)
       expect(connection).to have_received(:get).once
     end
   end

--- a/spec/lib/html2rss/selectors_spec.rb
+++ b/spec/lib/html2rss/selectors_spec.rb
@@ -112,6 +112,28 @@ RSpec.describe Html2rss::Selectors do
       end
     end
 
+    context 'when items selector is an anchor element and url selector is omitted' do
+      let(:selectors) do
+        {
+          items: { selector: 'a.card', enhance: false },
+          title: { selector: 'h3' }
+        }
+      end
+      let(:body) do
+        <<~HTML
+          <html><body>
+            <a class="card" href="/posts/first"><h3>First Post</h3></a>
+            <a class="card" href="/posts/second"><h3>Second Post</h3></a>
+          </body></html>
+        HTML
+      end
+
+      it 'automatically extracts the url from the anchor href attribute', :aggregate_failures do
+        urls = instance.articles.map { |article| article.url.to_s }
+        expect(urls).to eq(%w[http://example.com/posts/first http://example.com/posts/second])
+      end
+    end
+
     context 'when an enclosure selector is configured' do
       let(:selectors) do
         {
@@ -221,6 +243,17 @@ RSpec.describe Html2rss::Selectors do
 
     it 'returns the selected value' do
       expect(value).to eq('article1')
+    end
+
+    context 'when selecting :url on an anchor element without an explicit url selector' do
+      subject(:value) { instance.select(:url, item).to_s }
+
+      let(:item) { Nokogiri::HTML(body).at('a') }
+      let(:body) { '<html><body><a href="/target">Item</a></body></html>' }
+
+      it 'extracts and resolves the url directly from the item element' do
+        expect(value).to eq('http://example.com/target')
+      end
     end
 
     context 'when name is not a referencing a selector' do


### PR DESCRIPTION
## What changed

- **Smart Anchor Container Default URL (`Html2rss::Selectors`)**:
  - Automatically extracts and resolves the `href` attribute from the item element when the container is an `<a>` tag and `url:` is omitted in feed `selectors` configuration (supporting both `enhance: true` and `enhance: false`).
  - Added fallback in `#select(:url, item)` so attribute references to `url` resolve directly from the item element.
- **Fail-Fast AutoFallback on Deterministic Errors (`Html2rss::FeedPipeline::AutoFallback`)**:
  - Added domain exception `Html2rss::RequestService::RedirectLimitReached < Html2rss::Error` to encapsulate `Faraday::FollowRedirects::RedirectLimitReached` within `RequestService::FaradayStrategy`, removing Faraday dependencies from `AutoFallback` and `CLI`.
  - Added `RequestService::RedirectLimitReached` to `NON_FALLBACK_ERRORS` to fail fast on circular redirect chains.
  - Added `DETERMINISTIC_HTTP_STATUSES` (`400`, `404`, `410`, `422`, `451`) and short-circuited strategy fallback loops in `AttemptState` when deterministic responses are encountered, preventing unnecessary Botasaurus Chromium browser spins.
- **Test Coverage**:
  - Added unit and integration specs in `spec/lib/html2rss/selectors_spec.rb`, `spec/lib/html2rss/feed_pipeline/auto_fallback_spec.rb`, `spec/lib/html2rss/feed_pipeline_spec.rb`, `spec/lib/html2rss/request_service/faraday_strategy_spec.rb`, and `spec/lib/html2rss/cli_spec.rb`.

## Why

1. Reduces YAML config boilerplate when scraping responsive `<a class="card">` layouts where the item boundary is already the article anchor.
2. Eliminates wasted compute and 15–30s headless browser timeouts when attempting to scrape missing resources (404/410) or broken redirect loops.
3. Encapsulates transport library exceptions (`Faraday`) inside `RequestService`, keeping higher orchestration layers (`AutoFallback`, `CLI`) bound only to domain exceptions.

## Risk

- Low. Default URL extraction only activates when `url:` is omitted from the selectors config and the item root is an `<a>` tag with an `href` attribute. Fail-fast status aborts are limited to deterministic HTTP error codes and redirect loops.

## Review map

1. `lib/html2rss/request_service.rb` & `lib/html2rss/request_service/faraday_strategy.rb` — domain exception definition & Faraday error mapping
2. `lib/html2rss/feed_pipeline/auto_fallback.rb` — non-fallback errors & deterministic status abort
3. `lib/html2rss/selectors.rb` — anchor container URL extraction
4. `lib/html2rss/cli.rb` — domain redirect error handling

## Validation

- `bundle exec rspec spec/lib/html2rss/selectors_spec.rb spec/lib/html2rss/feed_pipeline/auto_fallback_spec.rb spec/lib/html2rss/feed_pipeline_spec.rb spec/lib/html2rss/request_service/faraday_strategy_spec.rb spec/lib/html2rss/cli_spec.rb`
- `make quick` (0 offenses, 84 examples, 0 failures)
- `make lint` (355 files inspected, 0 offenses detected)
- `make lint-yard` (0 offenses)
- `make schema` (0 diff)
- `make test` (1,711 examples, 0 failures, 98.45% line coverage)
- `make ready` (clean exit 0)