### PR TITLE
fix(request): stop pinning Host header on cross-host redirects

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -76,7 +76,7 @@ Composable curation seams for inspect → recon → capture → validate/test �
 
 | Fact                                      | Owner                                                                                                          |
 | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| Diagnostic URL fetch + assess             | `PageRecon::Diagnostics` (uses `PageRecon.probe` → `PageRecon::Probe` for fetch; adds scraper/XHR diagnostics) |
+| Diagnostic URL fetch + assess             | `PageRecon::Diagnostics` (uses `PageRecon.probe` → `PageRecon::Probe` for fetch; adds scraper/XHR diagnostics). Module guide: `lib/html2rss/page_recon/README.md` (redirect follow; no default `Host` — Faraday sets per hop) |
 | Curation verdict                          | `Recon::Verdict` on `Recon::Result` (`:build` / `:defer` / `:drop`)                                            |
 | Native feed URL (defer/gate)              | `Syndication::Discovery.best_feed_url` only                                                                    |
 | Config Hash/path/YAML → validated raw     | `Config.resolve_and_validate`                                                                                  |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -74,16 +74,16 @@ Instruction prose SSOT: `Outcome::Playbook`. Module guide: `lib/html2rss/mcp/REA
 
 Composable curation seams for inspect → recon → capture → validate/test → apply:
 
-| Fact                                      | Owner                                                                                                          |
-| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Fact                                      | Owner                                                                                                                                                                                                                         |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Diagnostic URL fetch + assess             | `PageRecon::Diagnostics` (uses `PageRecon.probe` → `PageRecon::Probe` for fetch; adds scraper/XHR diagnostics). Module guide: `lib/html2rss/page_recon/README.md` (redirect follow; no default `Host` — Faraday sets per hop) |
-| Curation verdict                          | `Recon::Verdict` on `Recon::Result` (`:build` / `:defer` / `:drop`)                                            |
-| Native feed URL (defer/gate)              | `Syndication::Discovery.best_feed_url` only                                                                    |
-| Config Hash/path/YAML → validated raw     | `Config.resolve_and_validate`                                                                                  |
-| Validate + live + min_items + RSS         | `Test` → `Test::Result` (+ `FailureKind`, success carries `rss`)                                               |
-| MCP next_step / guidance / playbook prose | `MCP::Outcome` + `Outcome::Playbook` (bare verb `next_step` names)                                             |
-| Capture YAML product                      | `Capture::CaptureResult#yaml` only (facade `Html2rss.capture` returns `CaptureResult`)                         |
-| Batch concurrency                         | `Batch.map` Thread pool (not Ractors); preserves input order (`Recon.batch`, `Batch.batch_*`, MCP)             |
+| Curation verdict                          | `Recon::Verdict` on `Recon::Result` (`:build` / `:defer` / `:drop`)                                                                                                                                                           |
+| Native feed URL (defer/gate)              | `Syndication::Discovery.best_feed_url` only                                                                                                                                                                                   |
+| Config Hash/path/YAML → validated raw     | `Config.resolve_and_validate`                                                                                                                                                                                                 |
+| Validate + live + min_items + RSS         | `Test` → `Test::Result` (+ `FailureKind`, success carries `rss`)                                                                                                                                                              |
+| MCP next_step / guidance / playbook prose | `MCP::Outcome` + `Outcome::Playbook` (bare verb `next_step` names)                                                                                                                                                            |
+| Capture YAML product                      | `Capture::CaptureResult#yaml` only (facade `Html2rss.capture` returns `CaptureResult`)                                                                                                                                        |
+| Batch concurrency                         | `Batch.map` Thread pool (not Ractors); preserves input order (`Recon.batch`, `Batch.batch_*`, MCP)                                                                                                                            |
 
 `apply` zero-item ship gate stays distinct from `Test` min_items. **inspect ≠ recon:** inspect is cheap diagnostics; recon adds verdict and native_feed preference.
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ html2rss schema --write schema/html2rss-config.schema.json
 
 Historic CLI aliases: `feed` → `apply`, `auto` → `scrape`.
 
+### Inspect output
+
+Inspect follows redirects and reports the landing URL in `final_url`. CLI text shows a `Final:` line **only when** the landing URL differs from what you typed — that line means the redirect succeeded, not that inspect stopped early.
+
+Cross-host redirects (e.g. `https://apex.example/` → `https://www.example/`) set `Host` per hop via Faraday/Net::HTTP; html2rss does not pin the entry hostname. When `final_url` differs and status is 4xx, retry on `final_url` or pass the site's canonical hostname. Details: [`lib/html2rss/page_recon/README.md`](lib/html2rss/page_recon/README.md).
+
 ## Capture API
 
 `Html2rss.capture` returns a `Capture::CaptureResult`. Use `result.yaml` or `result.config`.

--- a/lib/html2rss/config.rb
+++ b/lib/html2rss/config.rb
@@ -370,8 +370,7 @@ module Html2rss
     def normalized_headers(validated_config)
       validated_config[:headers] = RequestHeaders.normalize(
         validated_config[:headers],
-        channel_language: validated_config.dig(:channel, :language),
-        url: validated_config.dig(:channel, :url)
+        channel_language: validated_config.dig(:channel, :language)
       )
       validated_config
     end

--- a/lib/html2rss/config/request_headers.rb
+++ b/lib/html2rss/config/request_headers.rb
@@ -59,20 +59,17 @@ module Html2rss
         #
         # @param headers [Hash, nil] caller provided headers
         # @param channel_language [String, nil] language defined on the channel
-        # @param url [String] request URL used to infer the Host header
         # @return [Hash{String => String}] normalized HTTP headers
-        def normalize(headers, channel_language:, url:)
-          new(headers || {}, channel_language:, url:).to_h
+        def normalize(headers, channel_language:)
+          new(headers || {}, channel_language:).to_h
         end
       end
 
       # @param headers [Hash{String, Symbol => String}] caller-provided headers
       # @param channel_language [String, nil] channel language hint for Accept-Language
-      # @param url [String, Html2rss::Url, nil] request URL used to infer Host
-      def initialize(headers, channel_language:, url:)
+      def initialize(headers, channel_language:)
         @headers = headers
         @channel_language = channel_language
-        @url = url
       end
 
       ##
@@ -86,14 +83,13 @@ module Html2rss
 
         defaults['Accept'] = normalize_accept(accept_override)
         defaults['Accept-Language'] = build_accept_language
-        defaults['Host'] ||= request_host
 
         defaults.compact
       end
 
       private
 
-      attr_reader :headers, :channel_language, :url
+      attr_reader :headers, :channel_language
 
       def normalize_custom_headers(custom)
         custom.transform_keys { canonicalize(_1) }
@@ -133,12 +129,6 @@ module Html2rss
         return primary if region.nil?
 
         "#{primary}-#{region},#{primary};q=0.9"
-      end
-
-      def request_host
-        return nil if url.nil? || url.empty?
-
-        Html2rss::Url.from_absolute(url).host
       end
     end
   end

--- a/lib/html2rss/mcp/README.md
+++ b/lib/html2rss/mcp/README.md
@@ -73,3 +73,7 @@ Do not duplicate playbook prose in `server.rb`.
 ## Strategy note
 
 `scrape` / `capture` with `strategy: "auto"` run the full AutoFallback chain. `inspect` maps `auto` to Faraday for cheap diagnostics; pin `botasaurus` when you need browser rendering for inspect.
+
+## Inspect redirects
+
+`payload.final_url` is the post-redirect landing URL. When it differs from the URL you passed and `status` is 4xx, inspect still followed redirects — retry on `final_url` or pass the site's canonical hostname (often `www`). Cross-host redirects set `Host` per hop; html2rss does not pin the entry hostname. See [`page_recon/README.md`](../page_recon/README.md).

--- a/lib/html2rss/page_recon/README.md
+++ b/lib/html2rss/page_recon/README.md
@@ -1,0 +1,67 @@
+# PageRecon — inspect diagnostics
+
+`PageRecon::Diagnostics` powers the **inspect** verb (CLI, MCP, `Html2rss.inspect`). It fetches once via `PageRecon.probe`, classifies the surface, counts cheap AutoSource articles, and reports redirect facts. Full curation contract: `CONTEXT.md` § Frozen contract.
+
+## What inspect reports
+
+| Field | Meaning |
+| --- | --- |
+| `requested_url` | URL you passed in |
+| `final_url` | URL after redirects (may differ from requested) |
+| `status` | HTTP status of the **final** response |
+| `scheme_downgrade` | `true` when HTTPS entry landed on HTTP |
+| `alternate_feeds` | `rel=alternate` RSS/Atom links found in HTML |
+| `surface_category` | AutoSource surface class (`high_entropy_surface`, `unsupported_surface`, …) |
+| `articles_count` | Cheap AutoSource extract (limit 10) — diagnostic only, not ship quality |
+| `strategy` | Concrete transport used (`inspect` maps `auto` → Faraday) |
+
+CLI text output omits `requested_url`; it prints the requested URL as the card title. The `Final:` line appears **only when** `final_url` differs from `requested_url`:
+
+```text
+https://apex.example/
+        Final:    https://www.example/ (HTTP 200)
+        Surface:  high_entropy_surface (10 articles)
+```
+
+That `Final:` line means the redirect **did** happen — not that inspect stopped at the apex host.
+
+## Apex → www redirects
+
+Some publishers redirect apex domains to `www` (301). html2rss follows redirects and records the landing URL in `final_url`.
+
+Observed behavior:
+
+```bash
+bin/html2rss inspect https://apex.example
+# Final: https://www.example/ (HTTP 200), high_entropy_surface, articles
+
+bin/html2rss inspect https://www.example
+# high_entropy_surface, articles (no Final: line — requested equals final)
+```
+
+Cross-host redirects (e.g. `apex.example` → `www.example`) no longer pin a stale `Host` header from the entry URL. `Config::RequestHeaders` omits `Host` by default; Faraday/Net::HTTP sets it per hop from the current request URL.
+
+### What to do
+
+1. **Prefer the canonical URL** — if you know the site lives on `www`, pass that URL to inspect, recon, capture, and scrape.
+2. **Read the `Final:` line** — when `final_url` differs from what you typed and status is 4xx, retry inspect on `final_url` before assuming the site is unreachable.
+3. **Do not treat apex 403 as “redirect skipped”** — check JSON output (`--format json`) for `requested_url` vs `final_url` when text output is ambiguous.
+4. **Blocked surfaces** — if the canonical URL still fails, try `strategy: botasaurus` on inspect (MCP) or escalate to recon/capture with browser strategy; Faraday-only inspect is intentionally cheap.
+
+## inspect ≠ recon
+
+| Verb | Adds beyond diagnostics |
+| --- | --- |
+| inspect | Scraper eligibility, XHR hints (Botasaurus), surface + article count |
+| recon | Verdict (`:build` / `:defer` / `:drop`), native feed preference |
+
+Follow golden-path `next_step` from MCP envelopes; do not call recon when inspect already answers the question.
+
+## Ownership
+
+| Concern | Owner |
+| --- | --- |
+| Diagnostic fetch + assess | `PageRecon::Diagnostics` → `PageRecon.probe` |
+| Surface class + cheap article count | `PageRecon::Assessment` |
+| Redirect follow + terminal retry | `RequestService::FaradayStrategy` |
+| Outbound header normalization | `Config::RequestHeaders` (no default `Host`; explicit override only) |

--- a/lib/html2rss/page_recon/README.md
+++ b/lib/html2rss/page_recon/README.md
@@ -4,16 +4,16 @@
 
 ## What inspect reports
 
-| Field | Meaning |
-| --- | --- |
-| `requested_url` | URL you passed in |
-| `final_url` | URL after redirects (may differ from requested) |
-| `status` | HTTP status of the **final** response |
-| `scheme_downgrade` | `true` when HTTPS entry landed on HTTP |
-| `alternate_feeds` | `rel=alternate` RSS/Atom links found in HTML |
+| Field              | Meaning                                                                     |
+| ------------------ | --------------------------------------------------------------------------- |
+| `requested_url`    | URL you passed in                                                           |
+| `final_url`        | URL after redirects (may differ from requested)                             |
+| `status`           | HTTP status of the **final** response                                       |
+| `scheme_downgrade` | `true` when HTTPS entry landed on HTTP                                      |
+| `alternate_feeds`  | `rel=alternate` RSS/Atom links found in HTML                                |
 | `surface_category` | AutoSource surface class (`high_entropy_surface`, `unsupported_surface`, …) |
-| `articles_count` | Cheap AutoSource extract (limit 10) — diagnostic only, not ship quality |
-| `strategy` | Concrete transport used (`inspect` maps `auto` → Faraday) |
+| `articles_count`   | Cheap AutoSource extract (limit 10) — diagnostic only, not ship quality     |
+| `strategy`         | Concrete transport used (`inspect` maps `auto` → Faraday)                   |
 
 CLI text output omits `requested_url`; it prints the requested URL as the card title. The `Final:` line appears **only when** `final_url` differs from `requested_url`:
 
@@ -50,18 +50,18 @@ Cross-host redirects (e.g. `apex.example` → `www.example`) no longer pin a sta
 
 ## inspect ≠ recon
 
-| Verb | Adds beyond diagnostics |
-| --- | --- |
+| Verb    | Adds beyond diagnostics                                              |
+| ------- | -------------------------------------------------------------------- |
 | inspect | Scraper eligibility, XHR hints (Botasaurus), surface + article count |
-| recon | Verdict (`:build` / `:defer` / `:drop`), native feed preference |
+| recon   | Verdict (`:build` / `:defer` / `:drop`), native feed preference      |
 
 Follow golden-path `next_step` from MCP envelopes; do not call recon when inspect already answers the question.
 
 ## Ownership
 
-| Concern | Owner |
-| --- | --- |
-| Diagnostic fetch + assess | `PageRecon::Diagnostics` → `PageRecon.probe` |
-| Surface class + cheap article count | `PageRecon::Assessment` |
-| Redirect follow + terminal retry | `RequestService::FaradayStrategy` |
-| Outbound header normalization | `Config::RequestHeaders` (no default `Host`; explicit override only) |
+| Concern                             | Owner                                                                |
+| ----------------------------------- | -------------------------------------------------------------------- |
+| Diagnostic fetch + assess           | `PageRecon::Diagnostics` → `PageRecon.probe`                         |
+| Surface class + cheap article count | `PageRecon::Assessment`                                              |
+| Redirect follow + terminal retry    | `RequestService::FaradayStrategy`                                    |
+| Outbound header normalization       | `Config::RequestHeaders` (no default `Host`; explicit override only) |

--- a/spec/lib/html2rss/config/request_headers_spec.rb
+++ b/spec/lib/html2rss/config/request_headers_spec.rb
@@ -4,12 +4,11 @@ require 'spec_helper'
 
 RSpec.describe Html2rss::Config::RequestHeaders do
   subject(:normalized) do
-    described_class.normalize(headers, channel_language:, url:)
+    described_class.normalize(headers, channel_language:)
   end
 
   let(:headers) { {} }
   let(:channel_language) { 'de-DE' }
-  let(:url) { 'https://example.com/feed' }
 
   describe '.browser_defaults' do
     it 'returns a mutable copy of the default headers' do
@@ -28,8 +27,8 @@ RSpec.describe Html2rss::Config::RequestHeaders do
         expect(normalized).to include('Accept-Language' => 'de-DE,de;q=0.9')
       end
 
-      it 'infers the Host header from the URL' do
-        expect(normalized).to include('Host' => 'example.com')
+      it 'does not add a Host header' do
+        expect(normalized).not_to include('Host')
       end
     end
 
@@ -53,19 +52,19 @@ RSpec.describe Html2rss::Config::RequestHeaders do
       end
     end
 
+    context 'when Host is explicitly provided' do
+      let(:headers) { { 'Host' => 'custom.example' } }
+
+      it 'preserves the caller override' do
+        expect(normalized).to include('Host' => 'custom.example')
+      end
+    end
+
     context 'when the channel language is blank' do
       let(:channel_language) { '  ' }
 
       it 'falls back to en-US' do
         expect(normalized).to include('Accept-Language' => 'en-US,en;q=0.9')
-      end
-    end
-
-    context 'when the URL is blank' do
-      let(:url) { nil }
-
-      it 'does not add a Host header' do
-        expect(normalized).not_to include('Host')
       end
     end
   end

--- a/spec/lib/html2rss/request_service/faraday_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/faraday_strategy_spec.rb
@@ -295,6 +295,60 @@ RSpec.describe Html2rss::RequestService::FaradayStrategy do # rubocop:disable RS
     end
   end
 
+  describe 'cross-host redirect Host header' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+    let(:headers) do
+      Html2rss::Config::RequestHeaders.normalize({}, channel_language: 'en-US')
+    end
+    let(:ctx) do
+      Html2rss::RequestService::Context.new(
+        url: 'https://apex.example/',
+        headers:,
+        policy:,
+        budget:
+      )
+    end
+    let(:hop_hosts) { [] }
+    let(:host_capture_middleware) do
+      store = hop_hosts
+      Class.new(Faraday::Middleware) do
+        define_method(:initialize) { |app| @app = app }
+        define_method(:call) do |env|
+          store << env.request_headers['Host']
+          @app.call(env)
+        end
+      end
+    end
+    let(:test_connection) do
+      stubs = Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.get('https://apex.example/') { [301, { 'Location' => 'https://www.example/' }, ''] }
+        stub.get('https://www.example/') { [200, { 'Content-Type' => 'text/html' }, '<html>ok</html>'] }
+      end
+
+      Faraday.new(url: 'https://apex.example/', headers:) do |faraday|
+        faraday.use host_capture_middleware
+        faraday.use Faraday::FollowRedirects::Middleware, limit: policy.max_redirects
+        faraday.adapter :test, stubs
+      end
+    end
+
+    before do
+      allow(Faraday).to receive(:new).and_call_original
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(100.0, 100.0, 100.0)
+    end
+
+    it 'does not pin the entry Host on redirect hops', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      strategy = described_class.new(ctx)
+      strategy.instance_variable_set(:@client, test_connection)
+
+      result = VCR.turned_off { strategy.execute }
+
+      expect(headers).not_to include('Host')
+      expect(hop_hosts).to eq([nil, nil])
+      expect(result.status).to eq(200)
+      expect(result.url.to_s).to eq('https://www.example/')
+    end
+  end
+
   describe described_class::PeerIpValidator do # rubocop:disable RSpec/MultipleMemoizedHelpers
     let(:mock_socket) { instance_double(IPSocket, peeraddr: ['AF_INET', 443, '93.184.216.34', '93.184.216.34']) }
     let(:mock_net_http) do


### PR DESCRIPTION
## What changed

- `RequestHeaders` no longer infers `Host` from the entry URL — Faraday/Net::HTTP derives it per hop
- Removed dead `request_host` helper and unused `url:` argument from header normalization
- Added unit regression in `faraday_strategy_spec` for apex→www 301 chains (`apex.example` → `www.example`)
- Updated `request_headers_spec`: no default `Host`; explicit config override still passes through
- Added `lib/html2rss/page_recon/README.md` documenting inspect redirect semantics

## Why

Cross-host redirects (e.g. apex → www) followed correctly at the URL layer but sent a stale `Host` header pinned from the entry URL. CDNs often return 403 when `Host` does not match the connection target, making inspect/scrape appear broken after redirect.

### Root cause

PR #289 added browser-like defaults including inferred `Host` at config time. `Faraday::FollowRedirects` updates the request URL per hop but not explicit headers — stale `Host` overrode transport defaults.

## Risk

- Low — sites that require a non-DNS `Host` can still set `headers.Host` in feed config
- Botasaurus path unchanged (headers come from config as before)

## Review map

Review map: whole PR is small — start at `lib/html2rss/config/request_headers.rb`, then `faraday_strategy_spec.rb`.

## Validation

- `bundle exec rspec spec/lib/html2rss/config/request_headers_spec.rb spec/lib/html2rss/request_service/faraday_strategy_spec.rb` — 23 examples, 0 failures
- `make quick` — lint clean, 23 examples, 0 failures