### PR TITLE
fix(request): recover body on cross-host redirect stream retry

### DIFF
--- a/lib/html2rss/page_recon/README.md
+++ b/lib/html2rss/page_recon/README.md
@@ -41,6 +41,8 @@ bin/html2rss inspect https://www.example
 
 Cross-host redirects (e.g. `apex.example` → `www.example`) no longer pin a stale `Host` header from the entry URL. `Config::RequestHeaders` omits `Host` by default; Faraday/Net::HTTP sets it per hop from the current request URL.
 
+When the first streamed fetch loses the redirect payload (empty body at the final URL), `FaradayStrategy` retries once without streaming so inspect/recon see the same HTML as a direct canonical URL fetch.
+
 ### What to do
 
 1. **Prefer the canonical URL** — if you know the site lives on `www`, pass that URL to inspect, recon, capture, and scrape.

--- a/lib/html2rss/request_service/faraday_strategy.rb
+++ b/lib/html2rss/request_service/faraday_strategy.rb
@@ -104,7 +104,9 @@ module Html2rss
 
         client.get do |req|
           apply_timeouts(req, deadline:)
-          buffer = prepare_stream_buffer(req) if streaming_buffer
+          next unless streaming_buffer
+
+          buffer = prepare_stream_buffer(req)
           req.options.on_data = on_data_callback(response_guard, buffer)
         end
       end

--- a/spec/lib/html2rss/request_service/faraday_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/faraday_strategy_spec.rb
@@ -139,33 +139,24 @@ RSpec.describe Html2rss::RequestService::FaradayStrategy do # rubocop:disable RS
     expect(retry_request_options.timeout).to be_within(0.001).of(17.6)
     expect(retry_request_options.open_timeout).to eq(5)
     expect(retry_request_options.read_timeout).to eq(10)
-    expect(retry_request_options.on_data).to be_a(Proc)
+    expect(retry_request_options.on_data).to be_nil
     expect(retry_request_options.context).to be_nil
     expect(result.body).to eq('<html>redirected body</html>')
     expect(result.url.to_s).to eq('https://example.com/final')
   end
 
-  it 'enforces streamed byte limits on the redirected fallback path' do # rubocop:disable RSpec/ExampleLength
-    allow(policy).to receive(:max_response_bytes).and_return(5)
+  it 'enforces body byte limits on the redirected fallback path', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+    allow(policy).to receive(:max_decompressed_bytes).and_return(5)
 
     call_count = 0
     allow(connection).to receive(:get) do |&block|
       call_count += 1
-      current_request = call_count == 1 ? request : retry_request
-      block.call(current_request)
-      current_options = current_request.options
-      streamed_env = Faraday::Env.from(
-        request: current_options,
-        response_headers: { 'content-type' => 'text/html' },
-        status: 200
-      )
-      current_options.on_data.call('123', 3, streamed_env)
-      current_options.on_data.call('456', 6, streamed_env) if call_count == 2
-
+      block&.call(call_count == 1 ? request : retry_request)
       call_count == 1 ? empty_redirected_response : recovered_response
     end
 
     expect { execute }.to raise_error(Html2rss::RequestService::ResponseTooLarge, 'Response exceeded 5 bytes')
+    expect(retry_request_options.on_data).to be_nil
   end
 
   it 'raises blocked-surface classification when response body is an anti-bot interstitial' do
@@ -345,6 +336,39 @@ RSpec.describe Html2rss::RequestService::FaradayStrategy do # rubocop:disable RS
       expect(headers).not_to include('Host')
       expect(hop_hosts).to eq([nil, nil])
       expect(result.status).to eq(200)
+      expect(result.url.to_s).to eq('https://www.example/')
+    end
+
+    it 'recovers body when streaming loses redirect payload', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      attempts = 0
+      streaming_middleware = Class.new(Faraday::Middleware) do
+        define_method(:initialize) { |app| @app = app }
+        define_method(:call) do |env|
+          @app.call(env).tap do |response|
+            next unless response.env.url.to_s == 'https://www.example/'
+            next unless attempts.zero?
+
+            attempts += 1
+            response.env.body = ''
+          end
+        end
+      end
+      stubs = Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.get('https://apex.example/') { [301, { 'Location' => 'https://www.example/' }, ''] }
+        stub.get('https://www.example/') { [200, { 'Content-Type' => 'text/html' }, '<html>ok</html>'] }
+      end
+      connection = Faraday.new(url: 'https://apex.example/', headers:) do |faraday|
+        faraday.use streaming_middleware
+        faraday.use Faraday::FollowRedirects::Middleware, limit: policy.max_redirects
+        faraday.adapter :test, stubs
+      end
+      strategy = described_class.new(ctx)
+      strategy.instance_variable_set(:@client, connection)
+
+      result = VCR.turned_off { strategy.execute }
+
+      expect(result.status).to eq(200)
+      expect(result.body).to eq('<html>ok</html>')
       expect(result.url.to_s).to eq('https://www.example/')
     end
   end


### PR DESCRIPTION
## What changed

- `lib/html2rss/request_service/faraday_strategy.rb` — attach `on_data` only when the streamed path is active; the redirect fallback now fetches without streaming so Net::HTTP populates `response.body`.
- `spec/lib/html2rss/request_service/faraday_strategy_spec.rb` — expect no `on_data` on retry; cover empty-body redirect recovery and post-retry size checks via `inspect_body!`.
- `lib/html2rss/page_recon/README.md` — note that inspect/recon retry once without streaming when a streamed redirect returns an empty body.

## Why

`https://chip.de` redirects to `https://www.chip.de/` but inspect reported `unsupported_surface (0 articles)` while a direct `www` fetch returned `high_entropy_surface (10 articles)`.

Root cause: the first streamed fetch can lose its buffer across a cross-host redirect (empty body at the final URL). The existing fallback retried “without streaming” but still set `on_data`, so Net::HTTP never filled `response.body`. Surface classification then ran on empty HTML.

## Risk

- Low — scoped to Faraday redirect retry; direct canonical URL fetches unchanged; byte limits on retry now go through `inspect_body!` (`max_decompressed_bytes`) instead of stream chunk checks.

## Review map

Review map: whole PR is small — start at `lib/html2rss/request_service/faraday_strategy.rb`, then the cross-host redirect examples in `faraday_strategy_spec.rb`.

## Validation

- `mise exec -- bundle exec rspec spec/lib/html2rss/request_service/faraday_strategy_spec.rb spec/lib/html2rss/config/request_headers_spec.rb`
- `mise exec -- bin/html2rss inspect https://chip.de` → `high_entropy_surface (10 articles)` with `Final: https://www.chip.de/`