### PR TITLE
feat(mcp): `test` warn on feed quality audit for curated configs

### DIFF
--- a/lib/html2rss/auto_source/cleanup.rb
+++ b/lib/html2rss/auto_source/cleanup.rb
@@ -47,12 +47,21 @@ module Html2rss
         [:video_chrome, /\AClipped\s+From\s+Video\b/i],
         [:video_chrome, /\AVideo\s*[•·]/i],
         [:template, /\ACreated\s+from\s+Template\s+ID\b/i],
-        [:template, /(\{\{[^}]+\}\}|%\{\w+\})/]
+        [:template, /(\{\{[^}]+\}\}|%\{\w+\})/],
+        [:cta, /\Aread more\z/i],
+        [:cta, /\Alearn more\z/i],
+        [:cta, /\Apdf\z/i]
       ].freeze
       private_constant :JUNK_TITLE_RULES
 
+      # Minimum present-title length before short-title warnings.
+      MIN_TITLE_LENGTH = 4
+
       # Admitted articles plus reason → count tallies for drops.
       Result = Data.define(:articles, :drop_tallies)
+
+      # Read-only ship-quality audit on RSS/article-like items (no mutation).
+      AuditResult = Data.define(:warnings, :metrics, :violations)
 
       class << self
         # @param articles [Array<Article>] extracted article candidates
@@ -88,7 +97,82 @@ module Html2rss
           JUNK_TITLE_RULES.find { |_, pattern| pattern.match?(normalized) }&.first
         end
 
+        # @param items [Array] RSS or article-like objects with title and link/url
+        # @return [AuditResult]
+        def audit_feed_items(items)
+          metrics = initial_audit_metrics(items.size)
+          violations = Hash.new(0)
+          warnings = audit_url_diversity(items, metrics, violations)
+          audit_item_titles(items, metrics, violations)
+          warnings = finalize_audit_warnings(warnings, metrics)
+          log_audit(metrics, warnings, violations)
+          AuditResult.new(warnings:, metrics: metrics.freeze, violations: violations.freeze)
+        end
+
         private
+
+        def initial_audit_metrics(item_count)
+          {
+            item_count:,
+            unique_url_count: 0,
+            junk_title_count: 0,
+            short_title_count: 0,
+            low_word_count: 0
+          }
+        end
+
+        def audit_url_diversity(items, metrics, violations)
+          unique_urls = items.filter_map { |item| url_identity(item_url(item)) }.uniq
+          metrics[:unique_url_count] = unique_urls.size
+          return [] unless items.size >= 2 && unique_urls.size < 2
+
+          violations[:duplicate_urls] += 1
+          [:duplicate_urls]
+        end
+
+        def audit_item_titles(items, metrics, violations)
+          items.each do |item|
+            title = normalize_title(item.title)
+            next if title.empty?
+
+            audit_short_title(title, metrics, violations)
+            audit_title_quality(title, metrics, violations)
+          end
+        end
+
+        def audit_short_title(title, metrics, violations)
+          return unless title.length < MIN_TITLE_LENGTH
+
+          metrics[:short_title_count] += 1
+          violations[:short_title] += 1
+        end
+
+        def audit_title_quality(title, metrics, violations)
+          reason = junk_reason(title)
+          if reason
+            metrics[:junk_title_count] += 1
+            violations[reason] += 1
+          elsif !word_count_at_least?(title, MIN_WORDS)
+            metrics[:low_word_count] += 1
+            violations[:low_word_count] += 1
+          end
+        end
+
+        def finalize_audit_warnings(warnings, metrics)
+          warnings = warnings.dup
+          warnings << :generic_titles if metrics[:junk_title_count].positive?
+          warnings << :short_titles if metrics[:short_title_count].positive?
+          warnings << :low_word_count if metrics[:low_word_count].positive?
+          warnings.freeze
+        end
+
+        def log_audit(metrics, warnings, violations)
+          Log.debug(
+            'Cleanup.audit_feed_items: ' \
+            "item_count=#{metrics[:item_count]} unique_urls=#{metrics[:unique_url_count]} " \
+            "warnings=#{warnings.join(',')} violations=#{violations.keys.join(',')}"
+          )
+        end
 
         def reject_invalid!(articles, tallies)
           tally_reject!(articles, tallies, 'invalid') { |article| !article.valid? }
@@ -170,6 +254,13 @@ module Html2rss
 
         def url_identity(url)
           url&.without_fragment&.to_s
+        end
+
+        def item_url(item)
+          raw = item.respond_to?(:link) ? item.link : item.url
+          raw.nil? || raw.to_s.empty? ? nil : Html2rss::Url.from_absolute(raw.to_s)
+        rescue ArgumentError
+          nil
         end
 
         def normalize_title(title)

--- a/lib/html2rss/mcp/outcome.rb
+++ b/lib/html2rss/mcp/outcome.rb
@@ -210,9 +210,15 @@ module Html2rss
         end
 
         def test_guidance(test_result, next_step)
-          return next_step.guidance if test_result.success
+          base = if test_result.success
+                   next_step.guidance
+                 else
+                   test_result.error_message || next_step.guidance
+                 end
+          warnings = test_result.quality_report&.warnings
+          return base if warnings.nil? || warnings.empty?
 
-          test_result.error_message || next_step.guidance
+          "#{base} Review payload.quality_report warnings: #{warnings.join(', ')}."
         end
 
         def capture_payload(yaml:, articles_count:, has_selectors:, channel_title:, requested_strategy:, # rubocop:disable Metrics/ParameterLists

--- a/lib/html2rss/mcp/outcome/playbook.rb
+++ b/lib/html2rss/mcp/outcome/playbook.rb
@@ -21,8 +21,8 @@ module Html2rss
           capture: 'Call capture for a reusable YAML draft, then follow next_step.',
           read_runtime: 'Read html2rss://runtime. Set BOTASAURUS_SCRAPER_URL on the MCP process ' \
                         'if botasaurus_configured is false.',
-          test: 'Call test next (schema + live extraction). Confirm payload.item_count ' \
-                'and failure_kind before shipping.'
+          test: 'Call test next (schema + live extraction). Confirm payload.item_count, ' \
+                'failure_kind, and payload.quality_report warnings before shipping.'
         }.freeze
 
         class << self
@@ -39,7 +39,7 @@ module Html2rss
                  - Empty scrape is still success (articles-now). Follow next_step / guidance (read_runtime if Botasaurus unset).
               2. Need a reusable feed YAML? → capture → test → apply
                  - capture returns YAML inside payload.yaml. Draft only: if destination is html2rss-configs, rewrite for directory.topics and explicit channel title/url. Strive enhance: true (false only when chrome leaks).
-                 - test runs schema + live extraction (min items). apply is the ship gate (isError on zero items). Confirm payload.item_count.
+                 - test runs schema + live extraction (min items). apply is the ship gate (isError on zero items). Confirm payload.item_count and payload.quality_report warnings.
                  - validate alone is for schema-only checks; on success next_step is test.
               3. Weak scrape/capture or recon (final URL, status, https→http, rel=alternate feeds)? → inspect (or batch_inspect). When alternates warrant it, inspect next_step is recon.
               4. Have a config already? → validate (must succeed) → test → apply

--- a/lib/html2rss/mcp/server/tools.rb
+++ b/lib/html2rss/mcp/server/tools.rb
@@ -93,7 +93,8 @@ module Html2rss
             kind: :config_xor,
             description: 'Validate schema and execute live extraction (asserting >= min_items items). ' \
                          'Call after capture or validate; on success next_step is apply. ' \
-                         'Returns test summary in payload with sample items, timing, and failure_kind.',
+                         'Returns test summary in payload with sample items, timing, failure_kind, ' \
+                         'and quality_report (warnings for duplicate URLs, junk titles, native feed).',
             input_schema: Contract::TEST_INPUT_SCHEMA,
             call: lambda { |config: nil, yaml: nil, min_items: 1, **kwargs|
               feed_config = ConfigArgument.parse(config:, yaml:).config

--- a/lib/html2rss/test.rb
+++ b/lib/html2rss/test.rb
@@ -58,6 +58,32 @@ module Html2rss
     ##
     # Immutable outcome of a configuration test. Success carries +rss+ XML from the
     # first live extraction; failures carry a typed {FailureKind}.
+    QualityReport = Data.define(:warnings, :metrics, :native_feed, :defer_reason) do
+      ##
+      # @return [Hash{Symbol => Object}]
+      def to_h
+        {
+          warnings: warnings.map(&:to_s),
+          metrics:,
+          **(native_feed ? { native_feed:, defer_reason: defer_reason.to_s } : {})
+        }.compact
+      end
+
+      ##
+      # @param audit [Html2rss::AutoSource::Cleanup::AuditResult]
+      # @param native_feed [String, nil]
+      # @return [QualityReport]
+      def self.from_audit(audit, native_feed: nil)
+        report_warnings = audit.warnings.dup
+        defer_reason = nil
+        if native_feed
+          report_warnings << :native_feed_present unless report_warnings.include?(:native_feed_present)
+          defer_reason = :native_feed
+        end
+        new(warnings: report_warnings.freeze, metrics: audit.metrics, native_feed:, defer_reason:)
+      end
+    end
+
     Result = Data.define(
       :success,
       :item_count,
@@ -69,8 +95,15 @@ module Html2rss
       :validation_errors,
       :error_message,
       :failure_kind,
-      :rss
+      :rss,
+      :quality_report
     ) do
+      def initialize(success:, item_count:, sample_items:, channel_title:, channel_url:, # rubocop:disable Metrics/ParameterLists
+                     strategy_used:, duration_seconds:, validation_errors:, error_message:,
+                     failure_kind:, rss:, quality_report: nil)
+        super
+      end
+
       ##
       # @return [Boolean] whether the schema validation succeeded
       def valid_schema?
@@ -97,7 +130,8 @@ module Html2rss
           validation_errors:,
           error_message:,
           failure_kind: failure_kind&.to_sym,
-          rss:
+          rss:,
+          quality_report: quality_report&.to_h
         }.compact
       end
     end
@@ -127,6 +161,11 @@ module Html2rss
         rss_xml = rss_doc.to_s
         item_count = rss_doc.items.size
         sample_items = extract_samples(rss_doc.items)
+        quality_report = build_quality_report(
+          rss_doc.items,
+          channel_url: raw_config.dig(:channel, :url).to_s,
+          raw_config:
+        )
 
         channel_title = feed_result.channel_title
         channel_url = raw_config.dig(:channel, :url).to_s
@@ -144,7 +183,8 @@ module Html2rss
           validation_errors: nil,
           error_message: passed ? nil : "Extracted #{item_count} items (minimum required: #{min_items})",
           failure_kind: passed ? nil : FailureKind.coerce(:min_items),
-          rss: passed ? rss_xml : nil
+          rss: passed ? rss_xml : nil,
+          quality_report:
         )
       rescue StandardError => error
         duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
@@ -163,6 +203,28 @@ module Html2rss
     end
     private_class_method :extract_samples
 
+    def build_quality_report(items, channel_url:, raw_config:)
+      audit = AutoSource::Cleanup.audit_feed_items(items)
+      native_feed = probe_native_feed(channel_url, raw_config)&.to_s
+      QualityReport.from_audit(audit, native_feed:)
+    end
+    private_class_method :build_quality_report
+
+    def probe_native_feed(channel_url, raw_config)
+      return nil if channel_url.to_s.empty?
+
+      config = Config.from_hash(raw_config)
+      resources = FeedPipeline::RuntimePolicy.resources_for(config)
+      strategy = FeedPipeline::StrategyPlan.concrete_for_diagnostic(raw_config[:strategy])
+      session = RequestSession.build(
+        config:, strategy:, budget: resources.budget, policy: resources.policy
+      )
+      Syndication::Discovery.best_feed_url(page_url: channel_url, request_session: session)
+    rescue StandardError
+      nil
+    end
+    private_class_method :probe_native_feed
+
     def validation_failure_result(errors, raw_config) # rubocop:disable Metrics/MethodLength
       Result.new(
         success: false,
@@ -175,7 +237,8 @@ module Html2rss
         validation_errors: errors,
         error_message: 'Configuration schema validation failed',
         failure_kind: FailureKind.coerce(:schema),
-        rss: nil
+        rss: nil,
+        quality_report: nil
       )
     end
     private_class_method :validation_failure_result
@@ -192,7 +255,8 @@ module Html2rss
         validation_errors: nil,
         error_message: "#{error.class}: #{error.message}",
         failure_kind: FailureKind.coerce(:execution),
-        rss: nil
+        rss: nil,
+        quality_report: nil
       )
     end
     private_class_method :execution_failure_result

--- a/lib/html2rss/test.rb
+++ b/lib/html2rss/test.rb
@@ -56,8 +56,7 @@ module Html2rss
     end
 
     ##
-    # Immutable outcome of a configuration test. Success carries +rss+ XML from the
-    # first live extraction; failures carry a typed {FailureKind}.
+    # Ship-quality audit summary for a configuration test (warn-only).
     QualityReport = Data.define(:warnings, :metrics, :native_feed, :defer_reason) do
       ##
       # @return [Hash{Symbol => Object}]
@@ -84,6 +83,9 @@ module Html2rss
       end
     end
 
+    ##
+    # Immutable outcome of a configuration test. Success carries +rss+ XML from the
+    # first live extraction; failures carry a typed {FailureKind}.
     Result = Data.define(
       :success,
       :item_count,
@@ -98,6 +100,19 @@ module Html2rss
       :rss,
       :quality_report
     ) do
+      ##
+      # @param success [Boolean]
+      # @param item_count [Integer]
+      # @param sample_items [Array<Hash>]
+      # @param channel_title [String, nil]
+      # @param channel_url [String, nil]
+      # @param strategy_used [Symbol, nil]
+      # @param duration_seconds [Float]
+      # @param validation_errors [Hash, nil]
+      # @param error_message [String, nil]
+      # @param failure_kind [FailureKind, nil]
+      # @param rss [String, nil]
+      # @param quality_report [QualityReport, nil]
       def initialize(success:, item_count:, sample_items:, channel_title:, channel_url:, # rubocop:disable Metrics/ParameterLists
                      strategy_used:, duration_seconds:, validation_errors:, error_message:,
                      failure_kind:, rss:, quality_report: nil)

--- a/spec/lib/html2rss/auto_source/cleanup_spec.rb
+++ b/spec/lib/html2rss/auto_source/cleanup_spec.rb
@@ -273,4 +273,60 @@ RSpec.describe Html2rss::AutoSource::Cleanup do
       end
     end
   end
+
+  describe '.audit_feed_items' do
+    def rss_item(title:, url:)
+      instance_double(RSS::Rss::Channel::Item, title:, link: url)
+    end
+
+    it 'returns no warnings for a clean multi-item feed', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      items = [
+        rss_item(title: 'First Article Title Here', url: 'https://example.com/a'),
+        rss_item(title: 'Second Article Title Here', url: 'https://example.com/b')
+      ]
+      audit = described_class.audit_feed_items(items)
+
+      expect(audit.warnings).to be_empty
+      expect(audit.metrics).to include(item_count: 2, unique_url_count: 2, junk_title_count: 0)
+    end
+
+    it 'warns on duplicate URLs', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      items = [
+        rss_item(title: 'Story One Title Here', url: 'https://example.com/same'),
+        rss_item(title: 'Story Two Title Here', url: 'https://example.com/same')
+      ]
+      audit = described_class.audit_feed_items(items)
+
+      expect(audit.warnings).to include(:duplicate_urls)
+      expect(audit.metrics[:junk_title_count]).to eq(0)
+    end
+
+    it 'warns on CTA titles', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      items = [
+        rss_item(title: 'Read More', url: 'https://example.com/a'),
+        rss_item(title: 'Valid Article Title Here', url: 'https://example.com/b')
+      ]
+      audit = described_class.audit_feed_items(items)
+
+      expect(audit.warnings).to include(:generic_titles)
+      expect(audit.metrics[:junk_title_count]).to eq(1)
+    end
+
+    it 'warns on short titles', :aggregate_failures do
+      audit = described_class.audit_feed_items([rss_item(title: 'Ok', url: 'https://example.com/a')])
+
+      expect(audit.warnings).to include(:short_titles, :low_word_count)
+      expect(audit.metrics[:junk_title_count]).to eq(0)
+    end
+
+    [
+      { title: 'Read More', reason: :cta },
+      { title: 'learn more', reason: :cta },
+      { title: 'PDF', reason: :cta }
+    ].each do |example|
+      it "returns junk_reason #{example[:reason].inspect} for #{example[:title].inspect}" do
+        expect(described_class.junk_reason(example[:title])).to eq(example[:reason])
+      end
+    end
+  end
 end

--- a/spec/lib/html2rss/mcp/server_spec.rb
+++ b/spec/lib/html2rss/mcp/server_spec.rb
@@ -295,6 +295,26 @@ RSpec.describe Html2rss::MCP::Server do
         expect(envelope[:payload]).to include(item_count: 2, channel_title: 'Example')
       end
 
+      it 'includes quality_report in payload when present', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+        quality_report = Html2rss::Test::QualityReport.new(
+          warnings: [:duplicate_urls],
+          metrics: { item_count: 2, unique_url_count: 1, junk_title_count: 0, short_title_count: 0,
+                     low_word_count: 0 },
+          native_feed: nil,
+          defer_reason: nil
+        )
+        allow(Html2rss).to receive(:test).and_return(test_result(success: true, quality_report:))
+
+        result = call_tool.call('test', { config: valid_config, min_items: 1 })
+        envelope = JSON.parse(result.dig(:result, :content, 0, :text), symbolize_names: true)
+
+        expect(envelope[:payload][:quality_report]).to include(
+          warnings: ['duplicate_urls'],
+          metrics: hash_including(item_count: 2, unique_url_count: 1)
+        )
+        expect(envelope[:guidance]).to include('quality_report warnings: duplicate_urls')
+      end
+
       it 'preserves config strategy when MCP omits strategy argument', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
         config_with_strategy = valid_config.merge(strategy: :faraday)
         allow(Html2rss::Test).to receive(:call).and_return(test_result(success: true))

--- a/spec/lib/html2rss/test_spec.rb
+++ b/spec/lib/html2rss/test_spec.rb
@@ -24,17 +24,25 @@ RSpec.describe Html2rss::Test do
     }
   end
 
-  let(:fake_rss_item) do
-    instance_double(
-      RSS::Rss::Channel::Item,
-      title: 'Article 1',
-      link: 'https://example.com/news/1',
-      pubDate: nil
-    )
+  let(:fake_rss_items) do
+    [
+      instance_double(
+        RSS::Rss::Channel::Item,
+        title: 'First Example Article Title',
+        link: 'https://example.com/news/1',
+        pubDate: nil
+      ),
+      instance_double(
+        RSS::Rss::Channel::Item,
+        title: 'Second Example Article Title',
+        link: 'https://example.com/news/2',
+        pubDate: nil
+      )
+    ]
   end
 
   let(:fake_rss) do
-    instance_double(RSS::Rss, items: [fake_rss_item])
+    instance_double(RSS::Rss, items: fake_rss_items)
   end
 
   let(:fake_feed_result) do
@@ -59,21 +67,46 @@ RSpec.describe Html2rss::Test do
     context 'when schema is valid and items are extracted' do
       before do
         allow(Html2rss).to receive(:feed_result).and_return(fake_feed_result)
+        allow(Html2rss::Syndication::Discovery).to receive(:best_feed_url).and_return(nil)
       end
 
       it 'returns a successful Test::Result with article count, samples, and rss', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
         result = described_class.call(valid_config, min_items: 1)
         expect(result.success).to be(true)
-        expect(result.item_count).to eq(1)
-        expect(result.sample_items.size).to eq(1)
+        expect(result.item_count).to eq(2)
+        expect(result.sample_items.size).to eq(2)
         expect(result.rss).to be_a(String)
         expect(result.failure_kind).to be_nil
+      end
+
+      it 'attaches quality_report from feed audit', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+        result = described_class.call(valid_config, min_items: 1)
+
+        expect(result.quality_report).to be_a(Html2rss::Test::QualityReport)
+        expect(result.quality_report.warnings).to be_empty
+        expect(result.quality_report.metrics).to include(item_count: 2, unique_url_count: 2)
+        expect(result.to_h[:quality_report]).to include(
+          warnings: [],
+          metrics: hash_including(item_count: 2)
+        )
+      end
+
+      it 'advises when a native feed is discovered at channel.url', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+        native = Html2rss::Url.from_absolute('https://example.com/feed.xml')
+        allow(Html2rss::Syndication::Discovery).to receive(:best_feed_url).and_return(native)
+
+        result = described_class.call(valid_config, min_items: 1)
+
+        expect(result.quality_report.warnings).to include(:native_feed_present)
+        expect(result.quality_report.native_feed).to eq('https://example.com/feed.xml')
+        expect(result.quality_report.defer_reason).to eq(:native_feed)
+        expect(result.success).to be(true)
       end
 
       it 'fails if extracted items are below min_items', :aggregate_failures do
         result = described_class.call(valid_config, min_items: 5)
         expect(result.success).to be(false)
-        expect(result.error_message).to include('Extracted 1 items (minimum required: 5)')
+        expect(result.error_message).to include('Extracted 2 items (minimum required: 5)')
         expect(result.failure_kind).to eq(Html2rss::Test::FailureKind.coerce(:min_items))
         expect(result.rss).to be_nil
       end


### PR DESCRIPTION
## What changed

- `Cleanup.audit_feed_items` — read-only ship-quality audit (duplicate URLs, CTA/PDF titles, short/low-word titles) on existing `junk_reason` owner
- `Test::QualityReport` attached to `test` results; native-feed advisory via `Syndication::Discovery.best_feed_url`
- MCP/CLI `test` payload exposes `quality_report`; playbook guidance when warnings present
- Warn-only in this PR — `success` still gated by `min_items` only (phase 1a)

## Why

Curators enforce html2rss-configs pitfalls (link diversity, generic titles, native RSS defer) by hand because the gem only checks item count. Selector-built feeds bypass `AutoSource::Cleanup` at ship time. This codifies phase 1a of the configs-pitfalls uplift: surface quality signals on the existing `test` verb without adding new tools.

## Risk

- Low for runtime behavior — warnings do not fail `test` yet
- MCP clients may ignore new `quality_report` keys (additive payload)
- Native-feed probe adds one Discovery call per `test` run

## Review map

Review map: whole PR is small — start at `lib/html2rss/auto_source/cleanup.rb` (audit rules), then `lib/html2rss/test.rb` (wire integration).

## Validation

- `bundle exec rspec spec/lib/html2rss/auto_source/cleanup_spec.rb spec/lib/html2rss/test_spec.rb spec/lib/html2rss/mcp/server_spec.rb` — 125 examples, 0 failures
- `make ready` — exit 2 on master due to pre-existing schema drift (unrelated to this branch)