### PR TITLE
chore(ci): run yard-lint in yard job

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -36,8 +36,6 @@ jobs:
           bundler-cache: true
       - name: Run linting
         run: make lint
-      - name: Run YARD lint
-        run: make lint-yard
       - name: Generate config schema
         run: bundle exec rake config:schema
       - name: Ensure config schema is committed
@@ -56,6 +54,8 @@ jobs:
           ruby-version: "4.0"
           bundler-cache: true
       - run: gem install redcarpet
+      - name: Run YARD lint
+        run: make lint-yard
       - name: Generate documentation
         run: make docs
       - name: Upload documentation


### PR DESCRIPTION
## Summary
- Move `make lint-yard` from the `lint` CI job to the `yard` CI job
- Keep local `make lint-yard` / `bin/ready` unchanged

## Test plan
- [ ] CI `lint` job passes without yard-lint step
- [ ] CI `yard` job runs yard-lint before docs generation