### PR TITLE
feat(curation): harden inspect→capture→test for configs curator pitfalls

### DIFF
--- a/lib/html2rss.rb
+++ b/lib/html2rss.rb
@@ -34,9 +34,10 @@ module Html2rss # rubocop:disable Metrics/ModuleLength
   #
   # @param url [String] source page URL
   # @param strategy [Symbol] request strategy (:auto, :faraday, :botasaurus)
+  # @param deep [Boolean] when true and strategy is :auto, one Botasaurus hop if configured
   # @return [Html2rss::PageRecon::Diagnostics::Report]
-  def self.inspect(url, strategy: :auto, **)
-    PageRecon::Diagnostics.call(url:, strategy:, **)
+  def self.inspect(url, strategy: :auto, deep: false, **)
+    PageRecon::Diagnostics.call(url:, strategy:, deep:, **)
   end
 
   ##
@@ -95,7 +96,7 @@ module Html2rss # rubocop:disable Metrics/ModuleLength
   # @param strategy [Symbol, nil] optional strategy override
   # @param strict_quality [Boolean] when true, fail on ship-quality audit thresholds
   # @return [Html2rss::Test::Result]
-  def self.test(config_input, feed_name = nil, min_items: 1, params: {}, strategy: nil, strict_quality: false)
+  def self.test(config_input, feed_name = nil, min_items: 1, params: {}, strategy: nil, strict_quality: false) # rubocop:disable Metrics/ParameterLists
     Test.call(config_input, feed_name, min_items:, params:, strategy:, strict_quality:)
   end
 

--- a/lib/html2rss.rb
+++ b/lib/html2rss.rb
@@ -93,9 +93,10 @@ module Html2rss # rubocop:disable Metrics/ModuleLength
   # @param min_items [Integer] minimum required items (default: 1)
   # @param params [Hash] dynamic feed params
   # @param strategy [Symbol, nil] optional strategy override
+  # @param strict_quality [Boolean] when true, fail on ship-quality audit thresholds
   # @return [Html2rss::Test::Result]
-  def self.test(config_input, feed_name = nil, min_items: 1, params: {}, strategy: nil)
-    Test.call(config_input, feed_name, min_items:, params:, strategy:)
+  def self.test(config_input, feed_name = nil, min_items: 1, params: {}, strategy: nil, strict_quality: false)
+    Test.call(config_input, feed_name, min_items:, params:, strategy:, strict_quality:)
   end
 
   ##

--- a/lib/html2rss/capture.rb
+++ b/lib/html2rss/capture.rb
@@ -21,11 +21,15 @@ module Html2rss
     # Minimum matched segment/article pairs required to emit an items selector.
     MIN_SELECTOR_MATCHES = 2
 
+    # Admission drops at or above this sum default enhance to false (chrome-heavy listing).
+    CHROME_DROP_THRESHOLD = 3
+    private_constant :CHROME_DROP_THRESHOLD
+
     ##
     # Result of a capture operation (config plus quality meta).
     CaptureResult = Data.define(
       :config, :yaml, :articles_count, :channel_title, :has_selectors, :segment_strategy,
-      :admission_drops, :selected_strategy, :inferred_topics, :native_feed
+      :admission_drops, :selected_strategy, :inferred_topics, :native_feed, :suggested_channel_url
     ) do
       # rubocop:disable Metrics/ParameterLists
       ##
@@ -39,8 +43,10 @@ module Html2rss
       # @param selected_strategy [Symbol, nil]
       # @param inferred_topics [Array<String>]
       # @param native_feed [String, nil]
+      # @param suggested_channel_url [String, nil]
       def initialize(config:, articles_count:, channel_title:, has_selectors:, segment_strategy:, # rubocop:disable Metrics/MethodLength
-                     yaml: nil, admission_drops: {}, selected_strategy: nil, inferred_topics: [], native_feed: nil)
+                     yaml: nil, admission_drops: {}, selected_strategy: nil, inferred_topics: [], native_feed: nil,
+                     suggested_channel_url: nil)
         super(
           config:,
           yaml: yaml || "#{SCHEMA_MODELINE}\n#{Config.to_yaml(config)}",
@@ -51,7 +57,8 @@ module Html2rss
           admission_drops:,
           selected_strategy:,
           inferred_topics:,
-          native_feed:
+          native_feed:,
+          suggested_channel_url:
         )
       end
       # rubocop:enable Metrics/ParameterLists
@@ -119,6 +126,7 @@ module Html2rss
     # @return [CaptureResult]
     def build # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       outcome = FeedPipeline.new(raw_config).to_outcome
+      @admission_drops = outcome.admission_drops
       selectors, segment_strategy = derive_selectors(outcome.response, outcome.articles)
       ch_title = @title || channel_title_from(outcome.response)
       topics = @topics || infer_topics("#{@url} #{ch_title}")
@@ -142,7 +150,8 @@ module Html2rss
         admission_drops: outcome.admission_drops,
         selected_strategy: outcome.selected_strategy,
         inferred_topics: topics,
-        native_feed:
+        native_feed:,
+        suggested_channel_url: suggested_channel_url(outcome)
       )
     end
 
@@ -260,13 +269,12 @@ module Html2rss
     end
 
     def hint_selectors
-      enhance = @enhance_option.nil? || @enhance_option
-      [{ items: { selector: @items_selector_hint, enhance: } }, :hint]
+      [{ items: { selector: @items_selector_hint, enhance: resolve_enhance } }, :hint]
     end
 
     def select_enhance_selectors(sst, articles) # rubocop:disable Metrics/MethodLength -- strategy loop + gate
       link_resolver = Scoring::LinkResolver.new(@url)
-      enhance = @enhance_option.nil? || @enhance_option
+      enhance = resolve_enhance
 
       SEGMENT_STRATEGIES.each do |strategy|
         segments = AutoSource::Segmenter.call(
@@ -427,6 +435,26 @@ module Html2rss
     def channel_title_from(response)
       Channel.from_response(response).title
     rescue StandardError
+      nil
+    end
+
+    def resolve_enhance
+      return @enhance_option unless @enhance_option.nil?
+
+      drops = (@admission_drops || {}).values.sum
+      drops < CHROME_DROP_THRESHOLD
+    end
+
+    def suggested_channel_url(outcome)
+      entry = outcome.scrape_target.entry_url.to_s
+      effective = outcome.scrape_target.effective_url.to_s
+      return effective unless Url.from_absolute(entry).same_document?(Url.from_absolute(effective))
+
+      final = outcome.response.url.to_s
+      return final unless Url.from_absolute(@url).same_document?(Url.from_absolute(final))
+
+      nil
+    rescue ArgumentError
       nil
     end
   end

--- a/lib/html2rss/cli.rb
+++ b/lib/html2rss/cli.rb
@@ -143,6 +143,8 @@ module Html2rss
     desc 'test [CONFIG_INPUT] [feed_name]', 'Validate schema AND execute live extraction (fails on 0 items)'
     method_option :params, type: :hash, default: {}
     method_option :min_items, type: :numeric, default: 1, desc: 'Minimum required articles to pass'
+    method_option :strict_quality, type: :boolean, default: false,
+                                   desc: 'Fail when ship-quality audit thresholds are exceeded'
     method_option :strategy, type: :string, desc: STRATEGY_OPTION_DESC, enum: STRATEGY_OPTION_ENUM
     method_option :json, type: :boolean, desc: 'Output test outcome as JSON', default: false
     method_option :xml, type: :boolean, desc: 'Dump RSS XML alongside summary', default: false
@@ -157,7 +159,8 @@ module Html2rss
         feed_name,
         min_items: options.fetch(:min_items, 1).to_i,
         params: options[:params] || {},
-        strategy: options[:strategy]
+        strategy: options[:strategy],
+        strict_quality: options.fetch(:strict_quality, false)
       )
 
       if options[:json]

--- a/lib/html2rss/cli.rb
+++ b/lib/html2rss/cli.rb
@@ -52,6 +52,8 @@ module Html2rss
     probe_target_options
     desc 'inspect [TARGET]', 'Fetch diagnostics for a URL (final URL, status, alternates, surface)'
     method_option :format, type: :string, enum: %w[text json], default: 'text'
+    method_option :deep, type: :boolean, default: false,
+                         desc: 'Single Botasaurus diagnostic hop when BOTASAURUS_SCRAPER_URL is set'
     # @param target [String, nil] URL, file, or '-' for stdin
     # @return [void]
     def inspect(target = nil)
@@ -59,7 +61,7 @@ module Html2rss
         results = if batch_mode
                     Html2rss.batch_inspect(urls, strategy: current_strategy).results
                   else
-                    [Html2rss.inspect(urls.first, strategy: current_strategy).to_wire_h]
+                    [Html2rss.inspect(urls.first, strategy: current_strategy, deep: options[:deep]).to_wire_h]
                   end
         Render.inspect_output(results, format: options[:format], batch_mode:)
       end
@@ -245,6 +247,21 @@ module Html2rss
     # @return [void]
     def mcp
       Html2rss::MCP.start(transport: options[:transport].to_sym, port: options[:port])
+    end
+
+    desc 'doctor [TYPE]', 'Runtime preflight checks (botasaurus)'
+    method_option :sample, type: :string, desc: 'Optional URL for a Botasaurus sample scrape'
+    # @param type [String, nil] check type (default: botasaurus)
+    # @return [void]
+    def doctor(type = 'botasaurus')
+      case type.to_s
+      when 'botasaurus'
+        result = Html2rss::Doctor::Botasaurus.call(sample_url: options[:sample])
+        explain_json!(result.to_h)
+        raise Thor::Error, result.message unless result.ok
+      else
+        raise Thor::Error, "Unknown doctor type: #{type}. Supported: botasaurus"
+      end
     end
 
     private

--- a/lib/html2rss/doctor/botasaurus.rb
+++ b/lib/html2rss/doctor/botasaurus.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'faraday'
+require 'json'
+
+module Html2rss
+  ##
+  # CLI runtime health checks for optional scrape dependencies.
+  module Doctor
+    ##
+    # Preflight checks for Botasaurus scrape-api connectivity.
+    module Botasaurus
+      ##
+      # One named doctor check outcome.
+      Check = Data.define(:name, :ok, :detail) do
+        ##
+        # @return [Hash{Symbol => Object}]
+        def to_h
+          { name: name.to_s, ok:, detail: }
+        end
+      end
+
+      ##
+      # Aggregate doctor command outcome.
+      Result = Data.define(:ok, :checks, :message) do
+        ##
+        # @return [Hash{Symbol => Object}]
+        def to_h
+          { ok:, message:, checks: checks.map(&:to_h) }
+        end
+      end
+
+      module_function
+
+      ENV_VAR = 'BOTASAURUS_SCRAPER_URL'
+      private_constant :ENV_VAR
+
+      ##
+      # @param sample_url [String, nil] optional URL for a sample scrape smoke test
+      # @return [Result]
+      def call(sample_url: nil) # rubocop:disable Metrics/AbcSize
+        checks = [env_check_record]
+        return missing_env_failure(checks) unless checks.first.ok
+
+        checks << health_check_record(checks.first.detail[:base_url])
+        return failure(checks, 'Botasaurus health check failed.') unless checks.last.ok
+
+        checks << sample_scrape_record(sample_url) if sample_url
+        return failure(checks, 'Sample scrape failed.') if sample_url && !checks.last.ok
+
+        Log.info('doctor botasaurus: preflight passed')
+        Result.new(ok: true, checks:, message: 'Botasaurus preflight passed.')
+      end
+
+      ##
+      # @return [Hash{Symbol => Object}]
+      def env_check
+        base = ENV.fetch(ENV_VAR, '').strip
+        {
+          configured: MCP::Runtime.botasaurus_configured?,
+          var: ENV_VAR,
+          base_url: base.empty? ? nil : base
+        }
+      end
+
+      ##
+      # @param base_url [String]
+      # @return [Hash{Symbol => Object}]
+      def health_check(base_url)
+        uri = Url.for_channel(base_url)
+        client = Faraday.new(url: uri.to_s.chomp('/'), request: { timeout: 5 })
+        response = client.get('/health')
+        body = JSON.parse(response.body)
+        { ok: response.status == 200, status: response.status, version: body['version'] }
+      rescue StandardError => error
+        { ok: false, error: "#{error.class}: #{error.message}" }
+      end
+
+      ##
+      # @param url [String]
+      # @return [Hash{Symbol => Object}]
+      def sample_scrape(url)
+        wire = PageRecon::Diagnostics.call(url:, strategy: :botasaurus).to_wire_h
+        {
+          ok: wire[:status].to_i.between?(200, 399),
+          status: wire[:status],
+          articles_count: wire[:articles_count]
+        }
+      rescue StandardError => error
+        { ok: false, error: "#{error.class}: #{error.message}" }
+      end
+
+      def env_check_record
+        env = env_check
+        Check.new(name: :env, ok: env[:configured], detail: { var: env[:var], base_url_set: !env[:base_url].nil? })
+      end
+      module_function :env_check_record
+      private_class_method :env_check_record
+
+      def health_check_record(base_url)
+        return Check.new(name: :health, ok: false, detail: { error: 'missing base URL' }) unless base_url
+
+        health = health_check(base_url)
+        Check.new(name: :health, ok: health[:ok], detail: health)
+      end
+      module_function :health_check_record
+      private_class_method :health_check_record
+
+      def sample_scrape_record(url)
+        sample = sample_scrape(url)
+        Check.new(name: :sample_scrape, ok: sample[:ok], detail: sample)
+      end
+      module_function :sample_scrape_record
+      private_class_method :sample_scrape_record
+
+      def missing_env_failure(checks)
+        Log.info("doctor botasaurus: #{ENV_VAR} unset")
+        failure(checks, "Set #{ENV_VAR} to the scrape-api base URL.")
+      end
+      module_function :missing_env_failure
+      private_class_method :missing_env_failure
+
+      def failure(checks, message)
+        Result.new(ok: false, checks:, message:)
+      end
+      module_function :failure
+      private_class_method :failure
+    end
+  end
+end

--- a/lib/html2rss/doctor/botasaurus.rb
+++ b/lib/html2rss/doctor/botasaurus.rb
@@ -39,10 +39,11 @@ module Html2rss
       # @param sample_url [String, nil] optional URL for a sample scrape smoke test
       # @return [Result]
       def call(sample_url: nil) # rubocop:disable Metrics/AbcSize
-        checks = [env_check_record]
+        env = env_check
+        checks = [env_check_record(env)]
         return missing_env_failure(checks) unless checks.first.ok
 
-        checks << health_check_record(checks.first.detail[:base_url])
+        checks << health_check_record(env[:base_url])
         return failure(checks, 'Botasaurus health check failed.') unless checks.last.ok
 
         checks << sample_scrape_record(sample_url) if sample_url
@@ -90,8 +91,7 @@ module Html2rss
         { ok: false, error: "#{error.class}: #{error.message}" }
       end
 
-      def env_check_record
-        env = env_check
+      def env_check_record(env = env_check)
         Check.new(name: :env, ok: env[:configured], detail: { var: env[:var], base_url_set: !env[:base_url].nil? })
       end
       module_function :env_check_record

--- a/lib/html2rss/html/article_extractor/heading_extractor.rb
+++ b/lib/html2rss/html/article_extractor/heading_extractor.rb
@@ -19,8 +19,11 @@ module Html2rss
             tags = article_tag.css(HEADING_TAGS.join(','))
             if tags.any?
               select_best_heading(tags)
-            elsif fallback_anchorless && selected_anchor.nil?
-              fallback_heading(article_tag)
+            else
+              labeled = heading_from_aria_or_title(article_tag)
+              return labeled if labeled
+
+              fallback_heading(article_tag) if fallback_anchorless && selected_anchor.nil?
             end
           end
 
@@ -46,6 +49,20 @@ module Html2rss
               'strong, b, [class*="title"], [class*="font-bold"], [class*="font-semibold"]'
             )
             fallback_tags.find { |t| !Navigator::TextExtractor.call(t).to_s.strip.empty? }
+          end
+
+          def heading_from_aria_or_title(article_tag)
+            article_tag.css('[aria-label]').each do |node|
+              next if node['aria-label'].to_s.strip.empty?
+
+              return node
+            end
+            article_tag.css('[title]').each do |node|
+              next if node['title'].to_s.strip.empty?
+
+              return node
+            end
+            nil
           end
         end
       end

--- a/lib/html2rss/mcp/contract.rb
+++ b/lib/html2rss/mcp/contract.rb
@@ -78,6 +78,11 @@ module Html2rss
         properties: {
           **CONFIG_XOR_PROPERTIES,
           min_items: { type: 'integer', description: 'Minimum required items (default: 1)', default: 1 },
+          strict_quality: {
+            type: 'boolean',
+            description: 'Fail when ship-quality audit thresholds are exceeded (default: false)',
+            default: false
+          },
           strategy: STRATEGY_PROPERTY
         }.freeze,
         oneOf: XOR_ONE_OF

--- a/lib/html2rss/mcp/outcome.rb
+++ b/lib/html2rss/mcp/outcome.rb
@@ -70,7 +70,8 @@ module Html2rss
         # @return [Outcome]
         def inspect(report:)
           next_step = inspect_next_step(report)
-          new(ok: true, next_step:, guidance: next_step.guidance, payload: report.to_wire_h)
+          guidance = Playbook.inspect_guidance(report)
+          new(ok: true, next_step:, guidance:, payload: report.to_wire_h)
         end
 
         ##
@@ -78,7 +79,8 @@ module Html2rss
         # @return [Outcome]
         def recon(result:)
           next_step = recon_next_step(result)
-          new(ok: true, next_step:, guidance: next_step.guidance, payload: result.to_h)
+          guidance = Playbook.recon_guidance(result, next_step)
+          new(ok: true, next_step:, guidance:, payload: result.to_h)
         end
 
         ##
@@ -91,13 +93,16 @@ module Html2rss
         # @param selected_strategy [Symbol, String, nil]
         # @param admission_drops [Hash]
         # @param native_feed [String, nil]
+        # @param suggested_channel_url [String, nil]
         # @return [Outcome]
         def capture(yaml:, articles_count:, has_selectors:, channel_title:, requested_strategy:, # rubocop:disable Metrics/ParameterLists
-                    segment_strategy: nil, selected_strategy: nil, admission_drops: {}, native_feed: nil)
+                    segment_strategy: nil, selected_strategy: nil, admission_drops: {}, native_feed: nil,
+                    suggested_channel_url: nil)
           next_step = capture_next_step(articles_count:, has_selectors:, native_feed:)
           new(ok: true, next_step:, guidance: next_step.guidance, payload: capture_payload(
             yaml:, articles_count:, has_selectors:, channel_title:, requested_strategy:,
-            segment_strategy:, selected_strategy:, admission_drops:, native_feed:
+            segment_strategy:, selected_strategy:, admission_drops:, native_feed:,
+            suggested_channel_url:
           ))
         end
 
@@ -222,10 +227,12 @@ module Html2rss
         end
 
         def capture_payload(yaml:, articles_count:, has_selectors:, channel_title:, requested_strategy:, # rubocop:disable Metrics/ParameterLists
-                            segment_strategy:, selected_strategy:, admission_drops:, native_feed: nil)
+                            segment_strategy:, selected_strategy:, admission_drops:, native_feed: nil,
+                            suggested_channel_url: nil)
           {
             yaml:, articles_count:, has_selectors:, channel_title:, requested_strategy: requested_strategy.to_s,
             **(native_feed ? { native_feed: native_feed.to_s } : {}),
+            **(suggested_channel_url ? { suggested_channel_url: suggested_channel_url.to_s } : {}),
             **(segment_strategy ? { segment_strategy: segment_strategy.to_s } : {}),
             **(selected_strategy ? { selected_strategy: selected_strategy.to_s } : {}),
             **(admission_drops.any? ? { admission_drops: } : {})

--- a/lib/html2rss/mcp/outcome.rb
+++ b/lib/html2rss/mcp/outcome.rb
@@ -204,7 +204,7 @@ module Html2rss
 
           kind = test_result.failure_kind
           return NextStep.validate if kind&.schema?
-          return NextStep.capture if kind&.execution? || kind&.min_items?
+          return NextStep.capture if kind&.execution? || kind&.min_items? || kind&.quality?
 
           NextStep.capture
         end

--- a/lib/html2rss/mcp/outcome/playbook.rb
+++ b/lib/html2rss/mcp/outcome/playbook.rb
@@ -12,7 +12,7 @@ module Html2rss
         GUIDANCE = {
           done: 'Done. Read payload for the result.',
           inspect: 'Call inspect next. Read payload for diagnostics (final_url, status, ' \
-                   'scheme_downgrade, alternate_feeds).',
+                   'scheme_downgrade, alternate_feeds, likely_js_shell, redirect_summary).',
           recon: 'Call recon next. Read payload for verdict and native_feed preference.',
           validate: 'Call validate with payload.yaml or a config hash (XOR, not both).',
           apply: 'Call apply next. Confirm payload.item_count before shipping.',
@@ -39,10 +39,10 @@ module Html2rss
                  - strategy "auto" runs Faraday → Botasaurus AutoFallback. Do not retry with explicit faraday after auto.
                  - Empty scrape is still success (articles-now). Follow next_step / guidance (read_runtime if Botasaurus unset).
               2. Need a reusable feed YAML? → capture → test → apply
-                 - capture returns YAML inside payload.yaml. Draft only: if destination is html2rss-configs, rewrite for directory.topics and explicit channel title/url. Strive enhance: true (false only when chrome leaks).
+                 - capture returns YAML inside payload.yaml. Draft only: if destination is html2rss-configs, rewrite for directory.topics and explicit channel title/url. Default enhance follows capture evidence (false when admission_drops show chrome); override only when needed.
                  - test runs schema + live extraction (min items). apply is the ship gate (isError on zero items). Confirm payload.item_count and payload.quality_report warnings.
                  - validate alone is for schema-only checks; on success next_step is test.
-              3. Weak scrape/capture or recon (final URL, status, https→http, rel=alternate feeds)? → inspect (or batch_inspect). When alternates warrant it, inspect next_step is recon.
+              3. Weak scrape/capture or recon (final URL, status, https→http, rel=alternate feeds)? → inspect (or batch_inspect). Read likely_js_shell vs blocked_surface when articles_count is 0. When alternates warrant it, inspect next_step is recon.
               4. Have a config already? → validate (must succeed) → test → apply
               5. Schema / extractors / strategies / runtime → resources html2rss://schema|extractors|strategies|runtime
                  - runtime publishes version, mcp_contract_version, catalog_fingerprint, tools, botasaurus_configured.
@@ -71,12 +71,49 @@ module Html2rss
           def capture_feed_config_prompt(url)
             <<~MSG.strip
               Build a reusable html2rss feed config for #{url}:
-              1) capture — YAML is payload.yaml. Check payload.articles_count and payload.has_selectors. Strive to keep enhance: true (false only when chrome leaks into items). When payload.native_feed is set, follow next_step (done — use the native feed).
+              1) capture — YAML is payload.yaml. Check payload.articles_count, payload.has_selectors, and payload.suggested_channel_url. enhance defaults from admission evidence (false when chrome drops are high). When payload.native_feed is set, follow next_step (done — use the native feed).
               2) Follow next_step. If weak or you need recon, inspect then recon when alternates warrant it. Auto already hops to Botasaurus; do not retry capture with botasaurus unless Faraday was blocked.
               3) test with yaml (or config hash) — schema + live extraction. On :schema failure, validate; on :execution/:min_items, recapture.
               4) apply — isError if zero items. Confirm payload.item_count before shipping.
               If the destination is html2rss-configs, rewrite the draft for directory.topics and explicit channel title/url. Return YAML.
             MSG
+          end
+
+          ##
+          # @param report [PageRecon::Diagnostics::Report]
+          # @return [String]
+          def inspect_guidance(report)
+            return GUIDANCE.fetch(:inspect) unless report.articles_count.zero?
+
+            empty_extract_guidance(report.data)
+          end
+
+          ##
+          # @param data [Hash{Symbol => Object}]
+          # @return [String]
+          def empty_extract_guidance(data) # rubocop:disable Metrics/MethodLength
+            if data[:blocked_surface] || data[:surface_category].to_s == 'blocked_surface'
+              return 'Blocked or anti-bot interstitial likely. Retry scrape with strategy botasaurus once ' \
+                     '(or CLI inspect --deep when BOTASAURUS_SCRAPER_URL is set). ' \
+                     'Do not retry explicit faraday after auto.'
+            end
+            if data[:likely_js_shell]
+              return 'JS-rendered shell likely (html_present, zero articles). Use strategy auto or botasaurus; ' \
+                     'CLI inspect --deep for one Botasaurus diagnostic hop.'
+            end
+
+            'Empty extract on a static-looking page. Verify redirect_summary.final_url and surface; ' \
+              'capture may need selector hints.'
+          end
+
+          ##
+          # @param result [Html2rss::Recon::Result]
+          # @param next_step [Outcome::NextStep]
+          # @return [String]
+          def recon_guidance(result, next_step)
+            return next_step.guidance unless result.scheme_downgrade
+
+            "#{next_step.guidance} HTTPS→HTTP downgrade detected: try one Botasaurus scrape before DROP."
           end
         end
       end

--- a/lib/html2rss/mcp/server/tools.rb
+++ b/lib/html2rss/mcp/server/tools.rb
@@ -94,11 +94,12 @@ module Html2rss
             description: 'Validate schema and execute live extraction (asserting >= min_items items). ' \
                          'Call after capture or validate; on success next_step is apply. ' \
                          'Returns test summary in payload with sample items, timing, failure_kind, ' \
-                         'and quality_report (warnings for duplicate URLs, junk titles, native feed).',
+                         'and quality_report (warnings for duplicate URLs, junk titles, native feed). ' \
+                         'Set strict_quality to fail on duplicate URLs, >50% junk titles, or short titles.',
             input_schema: Contract::TEST_INPUT_SCHEMA,
-            call: lambda { |config: nil, yaml: nil, min_items: 1, **kwargs|
+            call: lambda { |config: nil, yaml: nil, min_items: 1, strict_quality: false, **kwargs|
               feed_config = ConfigArgument.parse(config:, yaml:).config
-              test_args = { min_items: }
+              test_args = { min_items:, strict_quality: }
               test_args[:strategy] = Runtime.coerce_strategy(kwargs[:strategy]) if kwargs.key?(:strategy)
               test_result = Html2rss.test(feed_config, **test_args)
               Outcome.test(test_result)

--- a/lib/html2rss/mcp/server/tools.rb
+++ b/lib/html2rss/mcp/server/tools.rb
@@ -25,7 +25,9 @@ module Html2rss
             input_schema: Contract::INSPECT_INPUT_SCHEMA,
             call: lambda { |url:, strategy: 'auto', **|
               Outcome.inspect(
-                report: PageRecon::Diagnostics.call(url:, strategy: Runtime.coerce_strategy(strategy))
+                report: PageRecon::Diagnostics.call(
+                  url:, strategy: Runtime.coerce_strategy(strategy), deep: false
+                )
               )
             }
           },
@@ -71,7 +73,8 @@ module Html2rss
                          'Use when the goal is a durable YAML (then test → apply). ' \
                          'Returns YAML inside payload.yaml (same serializer as CLI capture). ' \
                          'Draft only — catalog feeds still need directory.topics and title/url; ' \
-                         'strive enhance: true. Full schema options live in resource html2rss://schema.',
+                         'enhance defaults from admission evidence (false when chrome drops are high). ' \
+                         'Full schema options live in resource html2rss://schema.',
             input_schema: Contract::CAPTURE_INPUT_SCHEMA,
             handler: :capture_outcome
           },
@@ -236,7 +239,8 @@ module Html2rss
               segment_strategy: result.segment_strategy,
               selected_strategy: result.selected_strategy,
               admission_drops: result.admission_drops,
-              native_feed: result.native_feed
+              native_feed: result.native_feed,
+              suggested_channel_url: result.suggested_channel_url
             )
           end
 

--- a/lib/html2rss/page_recon/diagnostics.rb
+++ b/lib/html2rss/page_recon/diagnostics.rb
@@ -5,7 +5,7 @@ module Html2rss
     ##
     # Diagnostic inspect path (not Capture or Recon ownership). Fetches via {.probe},
     # then adds scraper/XHR diagnostics for curation inspect surfaces.
-    module Diagnostics
+    module Diagnostics # rubocop:disable Metrics/ModuleLength -- diagnostic wire fields stay co-located
       ##
       # Typed diagnostic report for inspect wire payloads and Outcome policy.
       Report = Data.define(:data) do
@@ -28,14 +28,19 @@ module Html2rss
         end
       end
 
+      # Minimum HTML body size to treat zero-article weak surfaces as likely JS shells.
+      JS_SHELL_MIN_BODY_BYTES = 8_192
+      private_constant :JS_SHELL_MIN_BODY_BYTES
+
       module_function
 
       ##
       # @param url [String]
       # @param strategy [String, Symbol]
+      # @param deep [Boolean] when true and strategy is auto, one Botasaurus hop if configured
       # @return [Report]
-      def call(url:, strategy: :auto)
-        probe = PageRecon.probe(url, strategy:)
+      def call(url:, strategy: :auto, deep: false)
+        probe = PageRecon.probe(url, strategy: resolve_inspect_strategy(strategy, deep:))
         recon = probe.result
         response = probe.response
 
@@ -113,13 +118,64 @@ module Html2rss
       def build_data(probe, recon, response)
         data = recon.to_h.merge(
           strategy: probe.strategy,
-          scraper_eligibility: scraper_info(safe_parsed_body(response))
+          scraper_eligibility: scraper_info(safe_parsed_body(response)),
+          html_present: html_present?(recon, response),
+          likely_js_shell: likely_js_shell?(recon, response),
+          redirect_summary: redirect_summary(recon)
         )
         data[:xhr_capture] = xhr_capture_info(response) if probe.strategy == :botasaurus
+        log_js_shell(data, response.body&.bytesize.to_i) if data[:likely_js_shell]
         data
       end
       module_function :build_data
       private_class_method :build_data
+
+      def resolve_inspect_strategy(strategy, deep:)
+        name = (strategy || :auto).to_sym
+        return :botasaurus if deep && name == :auto && MCP::Runtime.botasaurus_configured?
+
+        name
+      end
+      module_function :resolve_inspect_strategy
+      private_class_method :resolve_inspect_strategy
+
+      def html_present?(recon, response)
+        recon.html_response && !response.body.to_s.empty?
+      end
+      module_function :html_present?
+      private_class_method :html_present?
+
+      def likely_js_shell?(recon, response)
+        return false unless html_present?(recon, response)
+        return false if recon.articles_count.positive?
+        return false if recon.blocked_surface || recon.surface_category == :blocked_surface
+
+        return true if recon.surface_category == :app_shell
+
+        response.body.bytesize >= JS_SHELL_MIN_BODY_BYTES &&
+          SurfaceCategory.coerce(recon.surface_category).weak?
+      end
+      module_function :likely_js_shell?
+      private_class_method :likely_js_shell?
+
+      def redirect_summary(recon)
+        {
+          requested_url: recon.requested_url,
+          final_url: recon.final_url,
+          status: recon.status,
+          scheme_downgrade: recon.scheme_downgrade
+        }
+      end
+      module_function :redirect_summary
+      private_class_method :redirect_summary
+
+      def log_js_shell(data, body_bytesize)
+        Log.debug(
+          "Diagnostics js_shell: bytesize=#{body_bytesize} surface_category=#{data[:surface_category]}"
+        )
+      end
+      module_function :log_js_shell
+      private_class_method :log_js_shell
 
       def safe_parsed_body(response)
         return unless response.html_response?

--- a/lib/html2rss/recon.rb
+++ b/lib/html2rss/recon.rb
@@ -193,7 +193,10 @@ module Html2rss
     def build_notes(recon, native_feed, response)
       notes = []
       notes << "native_rss=#{native_feed}" if native_feed
-      notes << 'scheme_downgrade' if recon.scheme_downgrade
+      if recon.scheme_downgrade
+        notes << 'scheme_downgrade'
+        notes << 'botasaurus_retry=Try strategy botasaurus once before DROP (HTTPS→HTTP may need JS fetch)'
+      end
       notes << "blocked=#{recon.blocked_surface}" if recon.blocked_surface
       notes << "html_bytes=#{response.body&.bytesize}" if response.body
       notes

--- a/lib/html2rss/test.rb
+++ b/lib/html2rss/test.rb
@@ -13,7 +13,7 @@ module Html2rss
     # Closed failure classification for a failed test run.
     class FailureKind
       # Closed set of test failure wire names.
-      NAMES = Set[:schema, :execution, :min_items].freeze
+      NAMES = Set[:schema, :execution, :min_items, :quality].freeze
 
       class << self
         ##
@@ -45,6 +45,10 @@ module Html2rss
       ##
       # @return [Boolean]
       def min_items? = name == :min_items
+
+      ##
+      # @return [Boolean]
+      def quality? = name == :quality
 
       ##
       # @return [Symbol]
@@ -159,8 +163,10 @@ module Html2rss
     # @param min_items [Integer] minimum extracted items required to pass
     # @param params [Hash] optional dynamic feed parameters
     # @param strategy [Symbol, nil] optional strategy override
+    # @param strict_quality [Boolean] when true, fail on ship-quality audit thresholds
     # @return [Html2rss::Test::Result]
-    def call(config_input, feed_name = nil, min_items: 1, params: {}, strategy: nil) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+    def call(config_input, feed_name = nil, min_items: 1, params: {}, strategy: nil, # rubocop:disable Metrics/ParameterLists
+             strict_quality: false) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
       raw_config, validation = Config.resolve_and_validate(config_input, feed_name:, params:)
       return validation_failure_result(validation.errors.to_h, raw_config) unless validation.success?
 
@@ -185,7 +191,13 @@ module Html2rss
         channel_title = feed_result.channel_title
         channel_url = raw_config.dig(:channel, :url).to_s
         strategy_used = feed_result.status.selected_strategy || raw_config[:strategy] || :faraday
-        passed = item_count >= min_items
+        min_items_passed = item_count >= min_items
+        quality_failed = strict_quality && min_items_passed && quality_failure?(quality_report)
+        passed = min_items_passed && !quality_failed
+        failure_kind, error_message = outcome_failure(min_items_passed:, quality_failed:, item_count:, min_items:,
+                                                      quality_report:)
+
+        log_strict_quality_failure(failure_kind, item_count) if quality_failed
 
         Result.new(
           success: passed,
@@ -196,8 +208,8 @@ module Html2rss
           strategy_used:,
           duration_seconds: duration.round(3),
           validation_errors: nil,
-          error_message: passed ? nil : "Extracted #{item_count} items (minimum required: #{min_items})",
-          failure_kind: passed ? nil : FailureKind.coerce(:min_items),
+          error_message:,
+          failure_kind:,
           rss: passed ? rss_xml : nil,
           quality_report:
         )
@@ -224,6 +236,59 @@ module Html2rss
       QualityReport.from_audit(audit, native_feed:)
     end
     private_class_method :build_quality_report
+
+    def quality_failure?(quality_report)
+      metrics = quality_report.metrics
+      item_count = metrics[:item_count]
+      return false if item_count.zero?
+
+      duplicate_urls_failure?(metrics) || junk_title_ratio_failure?(metrics) || short_title_failure?(metrics)
+    end
+    private_class_method :quality_failure?
+
+    def duplicate_urls_failure?(metrics)
+      metrics[:item_count] >= 2 && metrics[:unique_url_count] < 2
+    end
+    private_class_method :duplicate_urls_failure?
+
+    def junk_title_ratio_failure?(metrics)
+      metrics[:junk_title_count] > (metrics[:item_count] / 2.0)
+    end
+    private_class_method :junk_title_ratio_failure?
+
+    def short_title_failure?(metrics)
+      metrics[:short_title_count].positive?
+    end
+    private_class_method :short_title_failure?
+
+    def outcome_failure(min_items_passed:, quality_failed:, item_count:, min_items:, quality_report:)
+      return [nil, nil] if min_items_passed && !quality_failed
+      return [FailureKind.coerce(:min_items),
+              "Extracted #{item_count} items (minimum required: #{min_items})"] unless min_items_passed
+
+      [FailureKind.coerce(:quality), quality_failure_message(quality_report)]
+    end
+    private_class_method :outcome_failure
+
+    def quality_failure_message(quality_report)
+      reasons = quality_failure_reasons(quality_report.metrics)
+      "Feed quality check failed (#{reasons.join(', ')})"
+    end
+    private_class_method :quality_failure_message
+
+    def quality_failure_reasons(metrics)
+      reasons = []
+      reasons << 'duplicate_urls' if duplicate_urls_failure?(metrics)
+      reasons << 'generic_titles' if junk_title_ratio_failure?(metrics)
+      reasons << 'short_titles' if short_title_failure?(metrics)
+      reasons
+    end
+    private_class_method :quality_failure_reasons
+
+    def log_strict_quality_failure(failure_kind, item_count)
+      Log.info("Test strict quality: failure_kind=#{failure_kind.to_sym} item_count=#{item_count}")
+    end
+    private_class_method :log_strict_quality_failure
 
     def probe_native_feed(channel_url, raw_config)
       return nil if channel_url.to_s.empty?

--- a/lib/html2rss/test.rb
+++ b/lib/html2rss/test.rb
@@ -165,8 +165,8 @@ module Html2rss
     # @param strategy [Symbol, nil] optional strategy override
     # @param strict_quality [Boolean] when true, fail on ship-quality audit thresholds
     # @return [Html2rss::Test::Result]
-    def call(config_input, feed_name = nil, min_items: 1, params: {}, strategy: nil, # rubocop:disable Metrics/ParameterLists
-             strict_quality: false) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+    def call(config_input, feed_name = nil, min_items: 1, params: {}, strategy: nil, # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+             strict_quality: false)
       raw_config, validation = Config.resolve_and_validate(config_input, feed_name:, params:)
       return validation_failure_result(validation.errors.to_h, raw_config) unless validation.success?
 
@@ -185,7 +185,8 @@ module Html2rss
         quality_report = build_quality_report(
           rss_doc.items,
           channel_url: raw_config.dig(:channel, :url).to_s,
-          raw_config:
+          raw_config:,
+          feed_result:
         )
 
         channel_title = feed_result.channel_title
@@ -230,12 +231,42 @@ module Html2rss
     end
     private_class_method :extract_samples
 
-    def build_quality_report(items, channel_url:, raw_config:)
+    def build_quality_report(items, channel_url:, raw_config:, feed_result:)
       audit = AutoSource::Cleanup.audit_feed_items(items)
       native_feed = probe_native_feed(channel_url, raw_config)&.to_s
-      QualityReport.from_audit(audit, native_feed:)
+      report = QualityReport.from_audit(audit, native_feed:)
+      append_url_mismatch_warning(report, channel_url, feed_result)
     end
     private_class_method :build_quality_report
+
+    def append_url_mismatch_warning(report, channel_url, feed_result)
+      return report unless url_mismatch?(channel_url, feed_result)
+
+      warnings = report.warnings.dup
+      warnings << :url_mismatch unless warnings.include?(:url_mismatch)
+      QualityReport.new(
+        warnings: warnings.freeze,
+        metrics: report.metrics.merge(url_mismatch: true),
+        native_feed: report.native_feed,
+        defer_reason: report.defer_reason
+      )
+    end
+    private_class_method :append_url_mismatch_warning
+
+    def url_mismatch?(channel_url, feed_result)
+      status = feed_result&.status
+      return false unless status
+
+      configured = channel_url.to_s
+      final = status.scrape_url.to_s
+      final = status.entry_url.to_s if final.empty?
+      return false if configured.empty? || final.empty?
+
+      !Url.from_absolute(configured).same_document?(Url.from_absolute(final))
+    rescue ArgumentError
+      false
+    end
+    private_class_method :url_mismatch?
 
     def quality_failure?(quality_report)
       metrics = quality_report.metrics
@@ -263,8 +294,10 @@ module Html2rss
 
     def outcome_failure(min_items_passed:, quality_failed:, item_count:, min_items:, quality_report:)
       return [nil, nil] if min_items_passed && !quality_failed
-      return [FailureKind.coerce(:min_items),
-              "Extracted #{item_count} items (minimum required: #{min_items})"] unless min_items_passed
+      unless min_items_passed
+        return [FailureKind.coerce(:min_items),
+                "Extracted #{item_count} items (minimum required: #{min_items})"]
+      end
 
       [FailureKind.coerce(:quality), quality_failure_message(quality_report)]
     end

--- a/spec/lib/html2rss/capture_spec.rb
+++ b/spec/lib/html2rss/capture_spec.rb
@@ -17,13 +17,15 @@ RSpec.describe Html2rss::Capture do
     )
   end
 
-  def stub_outcome(response, articles:, admission_drops: {}, selected_strategy: nil)
+  def stub_outcome(response, articles:, admission_drops: {}, selected_strategy: nil, scrape_target: nil) # rubocop:disable Metrics/MethodLength
+    target = scrape_target || Html2rss::ScrapeTarget.new(entry_url: url, effective_url: url)
     outcome = instance_double(
       Html2rss::FeedPipeline::PipelineOutcome,
       response:,
       articles:,
       admission_drops:,
-      selected_strategy:
+      selected_strategy:,
+      scrape_target: target
     )
     allow(Html2rss::FeedPipeline).to receive(:new)
       .and_return(instance_double(Html2rss::FeedPipeline, to_outcome: outcome))
@@ -316,6 +318,38 @@ RSpec.describe Html2rss::Capture do
       expect(result.segment_strategy).to eq(:cluster)
       expect(result.has_selectors).to be true
       expect(result.config.dig(:selectors, :items, :enhance)).to be true
+    end
+  end
+
+  context 'when admission drops indicate chrome-heavy listing' do
+    it 'defaults enhance to false', :aggregate_failures do
+      response = html_response(File.read('spec/fixtures/local_feed_test.html'))
+      articles = Html2rss::AutoSource.new(response, Html2rss::AutoSource::DEFAULT_CONFIG).articles
+      stub_outcome(response, articles:, admission_drops: { junk: 2, credit: 1 })
+
+      result = described_class.new(url).build
+
+      expect(result.config.dig(:selectors, :items, :enhance)).to be(false)
+    end
+  end
+
+  context 'when FeedResolution rewrites the scrape URL' do
+    it 'surfaces suggested_channel_url without mutating channel.url', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      response = html_response(
+        File.read('spec/fixtures/local_feed_test.html'),
+        page_url: 'https://example.com/blog/list'
+      )
+      articles = Html2rss::AutoSource.new(response, Html2rss::AutoSource::DEFAULT_CONFIG).articles
+      target = Html2rss::ScrapeTarget.new(
+        entry_url: url,
+        effective_url: 'https://example.com/blog/list'
+      )
+      stub_outcome(response, articles:, scrape_target: target)
+
+      result = described_class.new(url).build
+
+      expect(result.config.dig(:channel, :url)).to eq(url)
+      expect(result.suggested_channel_url).to eq('https://example.com/blog/list')
     end
   end
 end

--- a/spec/lib/html2rss/cli_spec.rb
+++ b/spec/lib/html2rss/cli_spec.rb
@@ -391,7 +391,7 @@ RSpec.describe Html2rss::CLI do
         )
       end
 
-      it 'forwards --strict-quality to Html2rss.test' do
+      it 'forwards --strict-quality to Html2rss.test' do # rubocop:disable RSpec/ExampleLength
         allow(Html2rss).to receive(:test).and_return(test_result_success)
 
         cli.invoke(:test, ['config.yml'], { strict_quality: true })

--- a/spec/lib/html2rss/cli_spec.rb
+++ b/spec/lib/html2rss/cli_spec.rb
@@ -390,6 +390,18 @@ RSpec.describe Html2rss::CLI do
           hash_including(min_items: 0)
         )
       end
+
+      it 'forwards --strict-quality to Html2rss.test' do
+        allow(Html2rss).to receive(:test).and_return(test_result_success)
+
+        cli.invoke(:test, ['config.yml'], { strict_quality: true })
+
+        expect(Html2rss).to have_received(:test).with(
+          'config.yml',
+          nil,
+          hash_including(strict_quality: true)
+        )
+      end
     end
 
     context 'when test fails' do

--- a/spec/lib/html2rss/doctor/botasaurus_spec.rb
+++ b/spec/lib/html2rss/doctor/botasaurus_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Html2rss::Doctor::Botasaurus do
+  describe '.call' do
+    it 'reports missing env without leaking secrets', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      ClimateControl.modify(BOTASAURUS_SCRAPER_URL: nil) do
+        result = described_class.call
+
+        expect(result.ok).to be(false)
+        expect(result.message).to include('BOTASAURUS_SCRAPER_URL')
+        expect(result.checks.first.detail).to include(var: 'BOTASAURUS_SCRAPER_URL')
+      end
+    end
+
+    it 'passes when health responds 200', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      conn = instance_double(Faraday::Connection)
+      response = instance_double(Faraday::Response, status: 200, body: '{"version":"1.2.3"}')
+      allow(Faraday).to receive(:new).and_return(conn)
+      allow(conn).to receive(:get).with('/health').and_return(response)
+
+      ClimateControl.modify(BOTASAURUS_SCRAPER_URL: 'http://127.0.0.1:4010') do
+        result = described_class.call
+
+        expect(result.ok).to be(true)
+        expect(result.checks.map(&:name)).to include(:env, :health)
+      end
+    end
+  end
+end

--- a/spec/lib/html2rss/doctor/botasaurus_spec.rb
+++ b/spec/lib/html2rss/doctor/botasaurus_spec.rb
@@ -26,6 +26,90 @@ RSpec.describe Html2rss::Doctor::Botasaurus do
 
         expect(result.ok).to be(true)
         expect(result.checks.map(&:name)).to include(:env, :health)
+        expect(result.to_h).to include(ok: true, message: 'Botasaurus preflight passed.')
+      end
+    end
+
+    it 'fails when health responds non-200', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      conn = instance_double(Faraday::Connection)
+      response = instance_double(Faraday::Response, status: 503, body: '{}')
+      allow(Faraday).to receive(:new).and_return(conn)
+      allow(conn).to receive(:get).with('/health').and_return(response)
+
+      ClimateControl.modify(BOTASAURUS_SCRAPER_URL: 'http://127.0.0.1:4010') do
+        result = described_class.call
+
+        expect(result.ok).to be(false)
+        expect(result.message).to eq('Botasaurus health check failed.')
+        expect(result.checks.find { |check| check.name == :health }.detail).to include(status: 503, ok: false)
+      end
+    end
+
+    it 'fails when health request raises', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      allow(Faraday).to receive(:new).and_raise(Faraday::ConnectionFailed, 'connection refused')
+
+      ClimateControl.modify(BOTASAURUS_SCRAPER_URL: 'http://127.0.0.1:4010') do
+        result = described_class.call
+
+        expect(result.ok).to be(false)
+        expect(result.checks.find { |check| check.name == :health }.detail[:error]).to include('ConnectionFailed')
+      end
+    end
+
+    it 'runs sample scrape when sample_url is given', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      conn = instance_double(Faraday::Connection)
+      response = instance_double(Faraday::Response, status: 200, body: '{"version":"1.2.3"}')
+      allow(Faraday).to receive(:new).and_return(conn)
+      allow(conn).to receive(:get).with('/health').and_return(response)
+      report = instance_double(
+        Html2rss::PageRecon::Diagnostics::Report,
+        to_wire_h: { status: 200, articles_count: 2 }
+      )
+      allow(Html2rss::PageRecon::Diagnostics).to receive(:call)
+        .with(url: 'https://example.com', strategy: :botasaurus)
+        .and_return(report)
+
+      ClimateControl.modify(BOTASAURUS_SCRAPER_URL: 'http://127.0.0.1:4010') do
+        result = described_class.call(sample_url: 'https://example.com')
+
+        expect(result.ok).to be(true)
+        expect(result.checks.map(&:name)).to include(:sample_scrape)
+        expect(result.checks.last.detail).to include(articles_count: 2)
+      end
+    end
+
+    it 'fails when sample scrape returns a bad status', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      conn = instance_double(Faraday::Connection)
+      response = instance_double(Faraday::Response, status: 200, body: '{"version":"1.2.3"}')
+      allow(Faraday).to receive(:new).and_return(conn)
+      allow(conn).to receive(:get).with('/health').and_return(response)
+      report = instance_double(
+        Html2rss::PageRecon::Diagnostics::Report,
+        to_wire_h: { status: 403, articles_count: 0 }
+      )
+      allow(Html2rss::PageRecon::Diagnostics).to receive(:call).and_return(report)
+
+      ClimateControl.modify(BOTASAURUS_SCRAPER_URL: 'http://127.0.0.1:4010') do
+        result = described_class.call(sample_url: 'https://example.com')
+
+        expect(result.ok).to be(false)
+        expect(result.message).to eq('Sample scrape failed.')
+      end
+    end
+
+    it 'fails when sample scrape raises', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      conn = instance_double(Faraday::Connection)
+      response = instance_double(Faraday::Response, status: 200, body: '{"version":"1.2.3"}')
+      allow(Faraday).to receive(:new).and_return(conn)
+      allow(conn).to receive(:get).with('/health').and_return(response)
+      allow(Html2rss::PageRecon::Diagnostics).to receive(:call)
+        .and_raise(StandardError, 'scrape timeout')
+
+      ClimateControl.modify(BOTASAURUS_SCRAPER_URL: 'http://127.0.0.1:4010') do
+        result = described_class.call(sample_url: 'https://example.com')
+
+        expect(result.ok).to be(false)
+        expect(result.checks.last.detail[:error]).to include('scrape timeout')
       end
     end
   end

--- a/spec/lib/html2rss/doctor/botasaurus_spec.rb
+++ b/spec/lib/html2rss/doctor/botasaurus_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'climate_control'
 
 RSpec.describe Html2rss::Doctor::Botasaurus do
   describe '.call' do

--- a/spec/lib/html2rss/html/article_extractor/heading_extractor_spec.rb
+++ b/spec/lib/html2rss/html/article_extractor/heading_extractor_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Html2rss::Html::ArticleExtractor::HeadingExtractor do
+  describe '.call' do
+    it 'prefers aria-label when no heading tags are present' do # rubocop:disable RSpec/ExampleLength
+      html = <<~HTML
+        <div class="card">
+          <a href="/story" aria-label="Breaking story headline">icon</a>
+        </div>
+      HTML
+      container = Nokogiri::HTML(html).at_css('.card')
+
+      heading = described_class.call(container, fallback_anchorless: true, selected_anchor: nil)
+
+      expect(heading['aria-label']).to eq('Breaking story headline')
+    end
+
+    it 'falls back to title attribute after aria-label candidates are empty' do # rubocop:disable RSpec/ExampleLength
+      html = <<~HTML
+        <div class="card">
+          <a href="/story" title="Story from title attribute">icon</a>
+        </div>
+      HTML
+      container = Nokogiri::HTML(html).at_css('.card')
+
+      heading = described_class.call(container, fallback_anchorless: true, selected_anchor: nil)
+
+      expect(heading['title']).to eq('Story from title attribute')
+    end
+  end
+end

--- a/spec/lib/html2rss/mcp/outcome_spec.rb
+++ b/spec/lib/html2rss/mcp/outcome_spec.rb
@@ -235,6 +235,11 @@ RSpec.describe Html2rss::MCP::Outcome do
       result = test_result(failure_kind: Html2rss::Test::FailureKind.coerce(:min_items))
       expect(described_class.test(result).next_step.name).to eq(:capture)
     end
+
+    it 'points at capture on quality failure' do
+      result = test_result(failure_kind: Html2rss::Test::FailureKind.coerce(:quality))
+      expect(described_class.test(result).next_step.name).to eq(:capture)
+    end
   end
 
   describe '.apply' do

--- a/spec/lib/html2rss/mcp/outcome_spec.rb
+++ b/spec/lib/html2rss/mcp/outcome_spec.rb
@@ -26,6 +26,71 @@ RSpec.describe Html2rss::MCP::Outcome do
       expect(described_class.instructions).to include('→ scrape').and include('→ capture → test → apply')
       expect(described_class.instructions).not_to include('scrape_url')
     end
+
+    it 'embeds auto strategy guidance in scrape_webpage_prompt' do
+      prompt = described_class.scrape_webpage_prompt('https://example.com')
+
+      expect(prompt).to include('https://example.com', 'strategy auto', 'payload.items')
+    end
+
+    it 'embeds evidence-based enhance guidance in capture_feed_config_prompt' do
+      prompt = described_class.capture_feed_config_prompt('https://example.com')
+
+      expect(prompt).to include('suggested_channel_url', 'enhance defaults from admission evidence')
+    end
+
+    describe '.inspect_guidance' do
+      def report(**data)
+        Html2rss::PageRecon::Diagnostics::Report.new(
+          data: { articles_count: 0, alternate_feeds: [], **data }
+        )
+      end
+
+      it 'returns default inspect guidance when articles are present' do
+        populated = Html2rss::PageRecon::Diagnostics::Report.new(
+          data: { articles_count: 3, alternate_feeds: [] }
+        )
+
+        expect(described_class.inspect_guidance(populated))
+          .to eq(described_class::GUIDANCE.fetch(:inspect))
+      end
+
+      it 'guides blocked surfaces toward botasaurus' do
+        expect(described_class.inspect_guidance(report(blocked_surface: true)))
+          .to include('anti-bot interstitial')
+      end
+
+      it 'guides blocked_surface category toward botasaurus' do
+        expect(described_class.inspect_guidance(report(surface_category: 'blocked_surface')))
+          .to include('inspect --deep')
+      end
+
+      it 'guides js shells toward auto or --deep' do
+        expect(described_class.inspect_guidance(report(likely_js_shell: true)))
+          .to include('JS-rendered shell')
+      end
+
+      it 'guides empty static pages toward redirect verification' do
+        expect(described_class.inspect_guidance(report)).to include('redirect_summary.final_url')
+      end
+    end
+
+    describe '.recon_guidance' do
+      it 'appends scheme downgrade hint' do
+        result = instance_double(Html2rss::Recon::Result, scheme_downgrade: true)
+        next_step = Html2rss::MCP::Outcome::NextStep.capture
+
+        expect(described_class.recon_guidance(result, next_step))
+          .to include('HTTPS→HTTP downgrade', next_step.guidance)
+      end
+
+      it 'returns next_step guidance when scheme is not downgraded' do
+        result = instance_double(Html2rss::Recon::Result, scheme_downgrade: false)
+        next_step = Html2rss::MCP::Outcome::NextStep.capture
+
+        expect(described_class.recon_guidance(result, next_step)).to eq(next_step.guidance)
+      end
+    end
   end
 
   describe '.scrape' do

--- a/spec/lib/html2rss/mcp/server_spec.rb
+++ b/spec/lib/html2rss/mcp/server_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Html2rss::MCP::Server do
       expect(protocol_server.prompts.keys).to contain_exactly('scrape-webpage', 'capture-feed-config')
       expect(protocol_server.instructions).to include('Faraday → Botasaurus AutoFallback')
       expect(protocol_server.instructions).to include('html2rss://runtime', 'catalog_fingerprint')
-      expect(protocol_server.instructions).to include('Strive enhance: true')
+      expect(protocol_server.instructions).to include('Default enhance follows capture evidence')
       expect(protocol_server.instructions).to include('payload.item_count')
       expect(protocol_server.instructions).to include('test')
       expect(protocol_server.instructions).not_to include('_meta')
@@ -526,7 +526,8 @@ RSpec.describe Html2rss::MCP::Server do
 
         expect(Html2rss::PageRecon::Diagnostics).to have_received(:call).with(
           url: 'https://example.com',
-          strategy: :auto
+          strategy: :auto,
+          deep: false
         )
         expect(result.dig(:result, :isError)).to be(false)
         expect(envelope[:payload]).to include(strategy: 'faraday')
@@ -679,12 +680,12 @@ RSpec.describe Html2rss::MCP::Server do
       expect(text).not_to include('_meta')
     end
 
-    it 'embeds catalog rewrite and enhance: true on capture-feed-config', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+    it 'embeds catalog rewrite and evidence-based enhance on capture-feed-config', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
       prompt = protocol_server.prompts['capture-feed-config']
       result = prompt.template({ url: 'https://example.com' }, server_context: nil)
       text = result.to_h.dig(:messages, 0, :content, :text)
 
-      expect(text).to include('Strive to keep enhance: true').and include('directory.topics')
+      expect(text).to include('enhance defaults from admission evidence').and include('directory.topics')
       expect(text).to include('payload.yaml').and include('payload.item_count')
       expect(text).not_to include('_meta')
     end

--- a/spec/lib/html2rss/mcp/server_spec.rb
+++ b/spec/lib/html2rss/mcp/server_spec.rb
@@ -288,7 +288,8 @@ RSpec.describe Html2rss::MCP::Server do
         expect(Html2rss).to have_received(:test).with(
           valid_config,
           min_items: 1,
-          strategy: :auto
+          strategy: :auto,
+          strict_quality: false
         )
         expect(result.dig(:result, :isError)).to be(false)
         expect(envelope).to include(ok: true, next_step: 'apply')
@@ -313,6 +314,44 @@ RSpec.describe Html2rss::MCP::Server do
           metrics: hash_including(item_count: 2, unique_url_count: 1)
         )
         expect(envelope[:guidance]).to include('quality_report warnings: duplicate_urls')
+      end
+
+      it 'forwards strict_quality to Html2rss.test', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+        allow(Html2rss).to receive(:test).and_return(test_result(success: true))
+
+        call_tool.call('test', { config: valid_config, min_items: 1, strict_quality: true })
+
+        expect(Html2rss).to have_received(:test).with(
+          valid_config,
+          min_items: 1,
+          strict_quality: true
+        )
+      end
+
+      it 'routes quality failure next_step to capture', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+        quality_report = Html2rss::Test::QualityReport.new(
+          warnings: [:duplicate_urls],
+          metrics: { item_count: 2, unique_url_count: 1, junk_title_count: 0, short_title_count: 0,
+                     low_word_count: 0 },
+          native_feed: nil,
+          defer_reason: nil
+        )
+        allow(Html2rss).to receive(:test).and_return(
+          test_result(
+            success: false,
+            failure_kind: Html2rss::Test::FailureKind.coerce(:quality),
+            error_message: 'Feed quality check failed (duplicate_urls)',
+            quality_report:
+          )
+        )
+
+        result = call_tool.call('test', { config: valid_config, strict_quality: true })
+        envelope = JSON.parse(result.dig(:result, :content, 0, :text), symbolize_names: true)
+
+        expect(result.dig(:result, :isError)).to be(true)
+        expect(envelope).to include(ok: false, next_step: 'capture')
+        expect(envelope[:payload]).to include(failure_kind: 'quality')
+        expect(envelope[:guidance]).to include('quality_report')
       end
 
       it 'preserves config strategy when MCP omits strategy argument', :aggregate_failures do # rubocop:disable RSpec/ExampleLength

--- a/spec/lib/html2rss/page_recon/diagnostics_spec.rb
+++ b/spec/lib/html2rss/page_recon/diagnostics_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Html2rss::PageRecon::Diagnostics do
   end
 
   before do
-    allow(Html2rss::PageRecon).to receive(:probe).and_return(probe)
+    allow(Html2rss::PageRecon).to receive(:probe) { probe }
   end
 
   it 'reports strategy, scrapers, and SST segment stats', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
@@ -132,7 +132,7 @@ RSpec.describe Html2rss::PageRecon::Diagnostics do
 
   context 'when a blocked interstitial is detected' do
     let(:response_body) { '<html><body>Checking your browser before accessing</body></html>' }
-    let(:page_recon_result) do
+    let(:blocked_recon) do
       Html2rss::PageRecon::Result.new(
         requested_url: 'https://example.com/blog',
         final_url: 'https://example.com/blog',
@@ -147,6 +147,14 @@ RSpec.describe Html2rss::PageRecon::Diagnostics do
         content_type: 'text/html',
         blocked_surface: 'cloudflare',
         sst: nil
+      )
+    end
+    let(:probe) do
+      Html2rss::PageRecon::Probe.new(
+        session: instance_double(Html2rss::RequestSession),
+        response:,
+        result: blocked_recon,
+        strategy: probe_strategy
       )
     end
 

--- a/spec/lib/html2rss/page_recon/diagnostics_spec.rb
+++ b/spec/lib/html2rss/page_recon/diagnostics_spec.rb
@@ -37,6 +37,14 @@ RSpec.describe Html2rss::PageRecon::Diagnostics do
     expect(report).to be_a(described_class::Report)
     expect(result[:strategy]).to eq(:faraday)
     expect(result[:html_response]).to be(true)
+    expect(result[:html_present]).to be(true)
+    expect(result[:likely_js_shell]).to be(false)
+    expect(result[:redirect_summary]).to include(
+      requested_url: 'https://example.com/blog',
+      final_url: 'https://example.com/blog',
+      status: 200,
+      scheme_downgrade: false
+    )
     expect(result[:sst]).to include(:node_count, :segment_stats)
   end
 
@@ -97,6 +105,69 @@ RSpec.describe Html2rss::PageRecon::Diagnostics do
         [{ href: 'https://example.com/feed.xml', mime_type: 'application/rss+xml' }]
       )
       expect(result[:alternate_feeds].map { |feed| feed[:href] }).not_to include('/feed')
+    end
+  end
+
+  context 'when HTML is present but no articles match' do
+    let(:response_body) do
+      <<~HTML
+        <!DOCTYPE html>
+        <html><head><title>Shell</title></head>
+        <body><div id="root">#{'x' * 9_000}</div></body></html>
+      HTML
+    end
+
+    before do
+      allow(Html2rss::AutoSource::Scraper).to receive(:classify_no_scraper_surface).and_return(:app_shell)
+    end
+
+    it 'flags likely_js_shell', :aggregate_failures do
+      result = described_class.call(url: 'https://example.com/blog', strategy: :auto).to_wire_h
+
+      expect(result[:html_present]).to be(true)
+      expect(result[:articles_count]).to eq(0)
+      expect(result[:likely_js_shell]).to be(true)
+    end
+  end
+
+  context 'when a blocked interstitial is detected' do
+    let(:response_body) { '<html><body>Checking your browser before accessing</body></html>' }
+    let(:page_recon_result) do
+      Html2rss::PageRecon::Result.new(
+        requested_url: 'https://example.com/blog',
+        final_url: 'https://example.com/blog',
+        status: 200,
+        scheme_downgrade: false,
+        alternate_feeds: [],
+        surface_category: :blocked_surface,
+        articles_count: 0,
+        admission_drops: {},
+        segment_stats: nil,
+        html_response: true,
+        content_type: 'text/html',
+        blocked_surface: 'cloudflare',
+        sst: nil
+      )
+    end
+
+    it 'does not classify blocked pages as js shells', :aggregate_failures do
+      result = described_class.call(url: 'https://example.com/blog', strategy: :auto).to_wire_h
+
+      expect(result[:surface_category]).to eq(:blocked_surface)
+      expect(result[:likely_js_shell]).to be(false)
+    end
+  end
+
+  describe '.call with deep: true' do
+    it 'uses botasaurus when configured and strategy is auto', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      allow(Html2rss::MCP::Runtime).to receive(:botasaurus_configured?).and_return(true)
+      allow(Html2rss::PageRecon).to receive(:probe).and_return(probe)
+
+      described_class.call(url: 'https://example.com/blog', strategy: :auto, deep: true)
+
+      expect(Html2rss::PageRecon).to have_received(:probe).with(
+        'https://example.com/blog', hash_including(strategy: :botasaurus)
+      )
     end
   end
 

--- a/spec/lib/html2rss/recon_spec.rb
+++ b/spec/lib/html2rss/recon_spec.rb
@@ -149,6 +149,12 @@ RSpec.describe Html2rss::Recon do
         result = described_class.call('https://example.com/news')
         expect(result.drop?).to be(true)
       end
+
+      it 'includes a Botasaurus retry hint in notes', :aggregate_failures do
+        result = described_class.call('https://example.com/news')
+        expect(result.notes).to include('scheme_downgrade')
+        expect(result.notes.join(' ')).to include('botasaurus_retry')
+      end
     end
 
     context 'when probe raises an error' do

--- a/spec/lib/html2rss/test/failure_kind_spec.rb
+++ b/spec/lib/html2rss/test/failure_kind_spec.rb
@@ -9,5 +9,6 @@ RSpec.describe Html2rss::Test::FailureKind do
     expect(described_class.coerce(:schema).schema?).to be(true)
     expect(described_class.coerce(:execution).execution?).to be(true)
     expect(described_class.coerce(:min_items).min_items?).to be(true)
+    expect(described_class.coerce(:quality).quality?).to be(true)
   end
 end

--- a/spec/lib/html2rss/test_spec.rb
+++ b/spec/lib/html2rss/test_spec.rb
@@ -111,6 +111,70 @@ RSpec.describe Html2rss::Test do
         expect(result.rss).to be_nil
       end
 
+      it 'keeps warn-only quality_report when strict_quality is false despite duplicate URLs', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+        duplicate_items = [
+          instance_double(RSS::Rss::Channel::Item, title: 'Story One Title Here', link: 'https://example.com/same',
+                                                    pubDate: nil),
+          instance_double(RSS::Rss::Channel::Item, title: 'Story Two Title Here', link: 'https://example.com/same',
+                                                    pubDate: nil)
+        ]
+        allow(fake_rss).to receive(:items).and_return(duplicate_items)
+
+        result = described_class.call(valid_config, min_items: 1, strict_quality: false)
+
+        expect(result.success).to be(true)
+        expect(result.quality_report.warnings).to include(:duplicate_urls)
+        expect(result.failure_kind).to be_nil
+      end
+
+      it 'fails with :quality when strict_quality and duplicate URLs', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+        duplicate_items = [
+          instance_double(RSS::Rss::Channel::Item, title: 'Story One Title Here', link: 'https://example.com/same',
+                                                    pubDate: nil),
+          instance_double(RSS::Rss::Channel::Item, title: 'Story Two Title Here', link: 'https://example.com/same',
+                                                    pubDate: nil)
+        ]
+        allow(fake_rss).to receive(:items).and_return(duplicate_items)
+
+        result = described_class.call(valid_config, min_items: 1, strict_quality: true)
+
+        expect(result.success).to be(false)
+        expect(result.failure_kind).to eq(Html2rss::Test::FailureKind.coerce(:quality))
+        expect(result.error_message).to include('duplicate_urls')
+        expect(result.rss).to be_nil
+        expect(result.quality_report.warnings).to include(:duplicate_urls)
+      end
+
+      it 'fails with :quality when strict_quality and more than half the titles are junk', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+        junk_items = [
+          instance_double(RSS::Rss::Channel::Item, title: 'Read More', link: 'https://example.com/a', pubDate: nil),
+          instance_double(RSS::Rss::Channel::Item, title: 'Learn More', link: 'https://example.com/b', pubDate: nil),
+          instance_double(RSS::Rss::Channel::Item, title: 'Valid Article Title Here', link: 'https://example.com/c',
+                                                    pubDate: nil)
+        ]
+        allow(fake_rss).to receive(:items).and_return(junk_items)
+
+        result = described_class.call(valid_config, min_items: 1, strict_quality: true)
+
+        expect(result.success).to be(false)
+        expect(result.failure_kind).to eq(Html2rss::Test::FailureKind.coerce(:quality))
+        expect(result.error_message).to include('generic_titles')
+      end
+
+      it 'prefers :min_items over :quality when both would fail', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+        duplicate_items = [
+          instance_double(RSS::Rss::Channel::Item, title: 'Story One Title Here', link: 'https://example.com/same',
+                                                    pubDate: nil),
+          instance_double(RSS::Rss::Channel::Item, title: 'Story Two Title Here', link: 'https://example.com/same',
+                                                    pubDate: nil)
+        ]
+        allow(fake_rss).to receive(:items).and_return(duplicate_items)
+
+        result = described_class.call(valid_config, min_items: 5, strict_quality: true)
+
+        expect(result.failure_kind).to eq(Html2rss::Test::FailureKind.coerce(:min_items))
+      end
+
       it 'handles file path input' do
         result = described_class.call('spec/fixtures/single.test.yml')
         expect(result.valid_schema?).to be(true)

--- a/spec/lib/html2rss/test_spec.rb
+++ b/spec/lib/html2rss/test_spec.rb
@@ -46,11 +46,17 @@ RSpec.describe Html2rss::Test do
   end
 
   let(:fake_feed_result) do
+    status = instance_double(
+      Html2rss::Status,
+      selected_strategy: :faraday,
+      entry_url: 'https://example.com/news',
+      scrape_url: 'https://example.com/news'
+    )
     instance_double(
       Html2rss::FeedResult,
       to_rss: fake_rss,
       channel_title: 'Example',
-      status: instance_double(Html2rss::Status, selected_strategy: :faraday)
+      status:
     )
   end
 
@@ -91,6 +97,15 @@ RSpec.describe Html2rss::Test do
         )
       end
 
+      it 'warns on url_mismatch when scrape URL differs from channel.url', :aggregate_failures do
+        allow(fake_feed_result.status).to receive(:scrape_url).and_return('https://example.com/blog/list')
+
+        result = described_class.call(valid_config, min_items: 1)
+
+        expect(result.quality_report.warnings).to include(:url_mismatch)
+        expect(result.quality_report.metrics[:url_mismatch]).to be(true)
+      end
+
       it 'advises when a native feed is discovered at channel.url', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
         native = Html2rss::Url.from_absolute('https://example.com/feed.xml')
         allow(Html2rss::Syndication::Discovery).to receive(:best_feed_url).and_return(native)
@@ -114,9 +129,9 @@ RSpec.describe Html2rss::Test do
       it 'keeps warn-only quality_report when strict_quality is false despite duplicate URLs', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
         duplicate_items = [
           instance_double(RSS::Rss::Channel::Item, title: 'Story One Title Here', link: 'https://example.com/same',
-                                                    pubDate: nil),
+                                                   pubDate: nil),
           instance_double(RSS::Rss::Channel::Item, title: 'Story Two Title Here', link: 'https://example.com/same',
-                                                    pubDate: nil)
+                                                   pubDate: nil)
         ]
         allow(fake_rss).to receive(:items).and_return(duplicate_items)
 
@@ -130,9 +145,9 @@ RSpec.describe Html2rss::Test do
       it 'fails with :quality when strict_quality and duplicate URLs', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
         duplicate_items = [
           instance_double(RSS::Rss::Channel::Item, title: 'Story One Title Here', link: 'https://example.com/same',
-                                                    pubDate: nil),
+                                                   pubDate: nil),
           instance_double(RSS::Rss::Channel::Item, title: 'Story Two Title Here', link: 'https://example.com/same',
-                                                    pubDate: nil)
+                                                   pubDate: nil)
         ]
         allow(fake_rss).to receive(:items).and_return(duplicate_items)
 
@@ -150,7 +165,7 @@ RSpec.describe Html2rss::Test do
           instance_double(RSS::Rss::Channel::Item, title: 'Read More', link: 'https://example.com/a', pubDate: nil),
           instance_double(RSS::Rss::Channel::Item, title: 'Learn More', link: 'https://example.com/b', pubDate: nil),
           instance_double(RSS::Rss::Channel::Item, title: 'Valid Article Title Here', link: 'https://example.com/c',
-                                                    pubDate: nil)
+                                                   pubDate: nil)
         ]
         allow(fake_rss).to receive(:items).and_return(junk_items)
 
@@ -164,9 +179,9 @@ RSpec.describe Html2rss::Test do
       it 'prefers :min_items over :quality when both would fail', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
         duplicate_items = [
           instance_double(RSS::Rss::Channel::Item, title: 'Story One Title Here', link: 'https://example.com/same',
-                                                    pubDate: nil),
+                                                   pubDate: nil),
           instance_double(RSS::Rss::Channel::Item, title: 'Story Two Title Here', link: 'https://example.com/same',
-                                                    pubDate: nil)
+                                                   pubDate: nil)
         ]
         allow(fake_rss).to receive(:items).and_return(duplicate_items)
 

--- a/spec/lib/html2rss_spec.rb
+++ b/spec/lib/html2rss_spec.rb
@@ -476,10 +476,14 @@ RSpec.describe Html2rss do
   end
 
   describe '.inspect' do
-    it 'delegates to PageRecon::Diagnostics.call' do
-      allow(Html2rss::PageRecon::Diagnostics).to receive(:call).with(url: 'https://example.com', strategy: :auto)
+    it 'delegates to PageRecon::Diagnostics.call' do # rubocop:disable RSpec/ExampleLength
+      allow(Html2rss::PageRecon::Diagnostics).to receive(:call).with(
+        url: 'https://example.com', strategy: :auto, deep: false
+      )
       described_class.inspect('https://example.com')
-      expect(Html2rss::PageRecon::Diagnostics).to have_received(:call).with(url: 'https://example.com', strategy: :auto)
+      expect(Html2rss::PageRecon::Diagnostics).to have_received(:call).with(
+        url: 'https://example.com', strategy: :auto, deep: false
+      )
     end
   end
 
@@ -492,10 +496,14 @@ RSpec.describe Html2rss do
   end
 
   describe '.test' do
-    it 'delegates to Test.call' do
-      allow(Html2rss::Test).to receive(:call).with('config.yml', nil, min_items: 1, params: {}, strategy: nil)
+    it 'delegates to Test.call' do # rubocop:disable RSpec/ExampleLength
+      allow(Html2rss::Test).to receive(:call).with(
+        'config.yml', nil, min_items: 1, params: {}, strategy: nil, strict_quality: false
+      )
       described_class.test('config.yml')
-      expect(Html2rss::Test).to have_received(:call).with('config.yml', nil, min_items: 1, params: {}, strategy: nil)
+      expect(Html2rss::Test).to have_received(:call).with(
+        'config.yml', nil, min_items: 1, params: {}, strategy: nil, strict_quality: false
+      )
     end
   end
 


### PR DESCRIPTION
## What changed

- **test:** optional `strict_quality` / `--strict-quality` adds `:quality` failure (duplicate URLs, >50% junk titles, short titles); default stays warn-only from #494; `url_mismatch` on `quality_report`
- **inspect:** `html_present`, `likely_js_shell`, `redirect_summary` on diagnostics wire; playbook distinguishes blocked vs JS shell vs empty extract; CLI/MCP `inspect --deep` (budgeted Botasaurus hop)
- **capture:** evidence-based `enhance: false` when admission drops ≥ 3; `suggested_channel_url` hint; `aria-label` / `[title]` title fallbacks in `heading_extractor`
- **recon:** scheme-downgrade note suggests Botasaurus retry
- **doctor:** CLI `html2rss doctor botasaurus` (env, `/health`, optional `--sample`)
- **MCP:** playbook copy aligned with evidence-based enhance; `test` forwards `strict_quality`; rebased onto master (#497 `catalog_fingerprint`)
- **tests:** doctor health/sample-scrape failure paths and playbook `inspect_guidance` / `recon_guidance` coverage for SimpleCov per-file gate

Phase 1a (warn-only audit) already merged in #494.

## Why

Codifies html2rss-configs curator pitfalls into the gem golden path (inspect → recon → capture → test → apply) so curators spend less time on manual curl, Chrome MCP, and YAML repair loops. Strict quality is opt-in until configs CI adopts it (phase 6 deferred).

## Risk

- **Large diff** — seven commits across 23 files; defaults unchanged unless flags set (`strict_quality`, `--deep`, explicit `--enhance`)
- **Capture YAML** — drafts may emit `enhance: false` more often (intended; reduces chrome repair)
- **test strict mode** — may false-positive edge feeds; use warn-only first in configs batch
- **doctor** — ops-only CLI; not an MCP verb

## Review map

1. `spec/lib/html2rss/test_spec.rb` — strict `:quality` gates, warn-only default, `url_mismatch`
2. `spec/lib/html2rss/page_recon/diagnostics_spec.rb` — blocked vs `likely_js_shell`, `redirect_summary`, `--deep`
3. `spec/lib/html2rss/capture_spec.rb` + `heading_extractor_spec.rb` — chrome-drop enhance default, `suggested_channel_url`, title fallbacks
4. `spec/lib/html2rss/doctor/botasaurus_spec.rb` + `mcp/outcome_spec.rb` — doctor preflight branches and playbook guidance copy
5. `lib/html2rss/test.rb` — `strict_quality` wiring and `QualityReport` integration
6. `lib/html2rss/page_recon/diagnostics.rb` — js-shell / redirect heuristics and deep inspect path
7. `lib/html2rss/capture.rb` — `resolve_enhance` threshold and channel URL hint
8. `lib/html2rss/doctor/botasaurus.rb` + `cli.rb` — doctor preflight and `--deep` inspect flag
9. `lib/html2rss/mcp/outcome/playbook.rb` + `server_spec.rb` — guidance copy and catalog_fingerprint expectations

## Validation

- `make ready` — exit 0 at `060a563d` (1839 examples, 98.36% line coverage, RuboCop clean)
- Rebased onto `master` (conflict in `spec/lib/html2rss/mcp/server_spec.rb` resolved: `catalog_fingerprint` + evidence-based enhance)

## Deferred

- Phase 6: `html2rss-configs` `check_config` adoption (separate repo / follow-up PR)