### PR TITLE
feat(mcp): publish runtime catalog identity for stale-client detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Curation CLI, MCP, gem facades, and agent playbook unify on seven user-facing ve
 
 **MCP `next_step` values** rename to match bare verbs (`inspect`, `recon`, `capture`, `validate`, `test`, `apply`, `scrape`, `done`, `read_runtime`).
 
+**MCP `html2rss://runtime` resource** now publishes `version`, `mcp_contract_version`, `catalog_fingerprint`, `tools`, and `botasaurus_configured` (was `botasaurus_configured` only). Bump `mcp_contract_version` when tool names or required inputs change; clients should refresh `tools/list` when `catalog_fingerprint` differs from cache.
+
 **CLI command renames:**
 
 | Before          | After             |

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Cursor / Claude Desktop `mcp.json` must put Botasaurus on the **MCP process** (n
 }
 ```
 
-Read `html2rss://runtime` for a boolean `botasaurus_configured` (the URL is never returned). Every tool result is a JSON envelope (`ok`, `next_step`, `guidance`, `payload`) in both the text body and `structuredContent`. Follow `next_step` / `guidance`; do not parse scrape text as a raw item array.
+Read `html2rss://runtime` for `version`, `mcp_contract_version`, `catalog_fingerprint`, `tools`, and `botasaurus_configured` (the scraper URL is never returned). Refresh `tools/list` when `catalog_fingerprint` differs from your cache. Every tool result is a JSON envelope (`ok`, `next_step`, `guidance`, `payload`) in both the text body and `structuredContent`. Follow `next_step` / `guidance`; do not parse scrape text as a raw item array.
 
 Module guide: [`lib/html2rss/mcp/README.md`](lib/html2rss/mcp/README.md).
 
@@ -158,7 +158,7 @@ Module guide: [`lib/html2rss/mcp/README.md`](lib/html2rss/mcp/README.md).
 | `html2rss://schema`     | Full JSON Schema for feed configurations                        |
 | `html2rss://extractors` | Registered extractor **names** (options live in schema `$defs`) |
 | `html2rss://strategies` | Published MCP strategies (`auto`, `faraday`, `botasaurus`)      |
-| `html2rss://runtime`    | `botasaurus_configured` boolean (never the scraper URL)         |
+| `html2rss://runtime`    | `version`, `mcp_contract_version`, `catalog_fingerprint`, `tools`, `botasaurus_configured` (never the scraper URL) |
 
 ### Prompts
 

--- a/lib/html2rss/mcp/README.md
+++ b/lib/html2rss/mcp/README.md
@@ -45,6 +45,7 @@ Every tool result is one JSON object (text body and `structuredContent`):
 | Concern                                       | Owner                                            |
 | --------------------------------------------- | ------------------------------------------------ |
 | Tool schemas, titles, strategy enum           | `MCP::Contract`                                  |
+| Catalog fingerprint + `mcp_contract_version` | `MCP::Contract` (+ `Runtime.snapshot` wire)      |
 | Envelope factories, `next_step` routing       | `MCP::Outcome`                                   |
 | Runtime instructions, guidance, prompt bodies | `Outcome::Playbook` (SSOT — `Server` delegates)  |
 | Diagnostic fetch + assess                     | `PageRecon::Diagnostics`                         |
@@ -61,7 +62,7 @@ Do not duplicate playbook prose in `server.rb`.
 | `html2rss://schema`     | Full JSON Schema for feed configurations                   |
 | `html2rss://extractors` | Registered extractor names                                 |
 | `html2rss://strategies` | Published MCP strategies (`auto`, `faraday`, `botasaurus`) |
-| `html2rss://runtime`    | `botasaurus_configured` boolean (never the scraper URL)    |
+| `html2rss://runtime`    | `version`, `mcp_contract_version`, `catalog_fingerprint`, `tools`, `botasaurus_configured` (never the scraper URL). Fingerprint covers tool names, required keys, and `oneOf` branches; bump `mcp_contract_version` for envelope semantics. |
 
 ## Prompts
 

--- a/lib/html2rss/mcp/contract.rb
+++ b/lib/html2rss/mcp/contract.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'digest'
+
 module Html2rss
   module MCP
     ##
@@ -8,6 +10,10 @@ module Html2rss
     module Contract # rubocop:disable Metrics/ModuleLength -- published listing constants stay co-located
       # Published MCP request strategies (excludes +local_file+).
       STRATEGIES = %w[auto faraday botasaurus].freeze
+
+      # Bump when tool names, required inputs, or envelope semantics change (independent of gem +VERSION+).
+      MCP_CONTRACT_VERSION = 2
+      public_constant :MCP_CONTRACT_VERSION
 
       # Raised when apply/validate config uses an unpublished MCP request adapter.
       class UnpublishedRequestError < ArgumentError; end
@@ -195,7 +201,34 @@ module Html2rss
         test: 'Test'
       }.freeze
 
+      # @api private
+      CATALOG_ENTRY_LINE = lambda do |entry|
+        schema = entry.fetch(:input_schema)
+        required = Array(schema[:required]).sort.join(',')
+        one_of = Array(schema[:oneOf]).map { |branch| Array(branch[:required]).sort.join('+') }.sort.join('|')
+        [entry.fetch(:name), required, one_of].reject(&:empty?).join(':')
+      end.freeze
+
       class << self
+        ##
+        # Canonical MCP tool names in alphabetical order (same set as +tools/list+).
+        #
+        # @return [Array<String>]
+        def catalog_tools
+          Server::Tools::TOOLS.map { |entry| entry.fetch(:name) }.sort
+        end
+
+        ##
+        # Stable fingerprint of published tools, required keys, and +oneOf+ branches.
+        # Clients compare against a cached +tools/list+ to detect stale catalogs.
+        # Bump {MCP_CONTRACT_VERSION} for envelope or breaking wire semantics only.
+        #
+        # @return [String] 16-char hex digest prefix
+        def catalog_fingerprint
+          lines = Server::Tools::TOOLS.sort_by { |entry| entry.fetch(:name) }.map(&CATALOG_ENTRY_LINE)
+          Digest::SHA256.hexdigest(lines.join("\n")).slice(0, 16)
+        end
+
         ##
         # Envelope JSON Schema. Built lazily so Zeitwerk can load Contract before Outcome.
         #

--- a/lib/html2rss/mcp/outcome/playbook.rb
+++ b/lib/html2rss/mcp/outcome/playbook.rb
@@ -19,8 +19,9 @@ module Html2rss
           scrape: 'Call scrape for articles now. strategy auto already runs Faraday then Botasaurus ' \
                   'and promotes native RSS/Atom when present.',
           capture: 'Call capture for a reusable YAML draft, then follow next_step.',
-          read_runtime: 'Read html2rss://runtime. Set BOTASAURUS_SCRAPER_URL on the MCP process ' \
-                        'if botasaurus_configured is false.',
+          read_runtime: 'Read html2rss://runtime. Compare mcp_contract_version and catalog_fingerprint ' \
+                        'to your cached tools/list before retrying unknown tools. ' \
+                        'Set BOTASAURUS_SCRAPER_URL on the MCP process if botasaurus_configured is false.',
           test: 'Call test next (schema + live extraction). Confirm payload.item_count, ' \
                 'failure_kind, and payload.quality_report warnings before shipping.'
         }.freeze
@@ -44,9 +45,11 @@ module Html2rss
               3. Weak scrape/capture or recon (final URL, status, https→http, rel=alternate feeds)? → inspect (or batch_inspect). When alternates warrant it, inspect next_step is recon.
               4. Have a config already? → validate (must succeed) → test → apply
               5. Schema / extractors / strategies / runtime → resources html2rss://schema|extractors|strategies|runtime
+                 - runtime publishes version, mcp_contract_version, catalog_fingerprint, tools, botasaurus_configured.
+                 - Refresh tools/list when catalog_fingerprint differs from your cache.
 
               Prefer capture for durable config; scrape / batch_scrape for one-shot extraction.
-              Follow envelope next_step and guidance. Botasaurus needs BOTASAURUS_SCRAPER_URL in this process env (boolean at html2rss://runtime; the URL is never returned).
+              Follow envelope next_step and guidance. Botasaurus needs BOTASAURUS_SCRAPER_URL in this process env (read html2rss://runtime; the URL is never returned).
             TEXT
           end
 

--- a/lib/html2rss/mcp/runtime.rb
+++ b/lib/html2rss/mcp/runtime.rb
@@ -5,12 +5,33 @@ module Html2rss
     ##
     # Runtime facts for the MCP process (env configuration, wire coercion).
     module Runtime
+      # Published +html2rss://runtime+ resource (never leaks secrets).
+      Snapshot = Data.define(
+        :version,
+        :mcp_contract_version,
+        :catalog_fingerprint,
+        :tools,
+        :botasaurus_configured
+      )
+
       module_function
 
       ##
       # @return [Boolean] whether Botasaurus transport is configured in this process
       def botasaurus_configured?
         !ENV['BOTASAURUS_SCRAPER_URL'].to_s.strip.empty?
+      end
+
+      ##
+      # @return [Snapshot] runtime capabilities and catalog identity for MCP clients
+      def snapshot
+        Snapshot.new(
+          version: Html2rss::VERSION,
+          mcp_contract_version: Contract::MCP_CONTRACT_VERSION,
+          catalog_fingerprint: Contract.catalog_fingerprint,
+          tools: Contract.catalog_tools,
+          botasaurus_configured: botasaurus_configured?
+        )
       end
 
       ##

--- a/lib/html2rss/mcp/server.rb
+++ b/lib/html2rss/mcp/server.rb
@@ -57,11 +57,11 @@ module Html2rss
         {
           uri: 'html2rss://runtime',
           name: 'Runtime capabilities',
-          description: 'Whether optional transports are configured in this MCP process (never leaks secrets)',
+          description: 'Gem version, MCP contract version, catalog fingerprint, tool names, and Botasaurus config',
           mime_type: 'application/json',
           body: lambda {
             [{ uri: 'html2rss://runtime', mimeType: 'application/json',
-               text: JSON.pretty_generate(botasaurus_configured: Runtime.botasaurus_configured?) }]
+               text: JSON.pretty_generate(Runtime.snapshot.to_h) }]
           }
         }
       ].freeze

--- a/spec/lib/html2rss/mcp/contract_spec.rb
+++ b/spec/lib/html2rss/mcp/contract_spec.rb
@@ -79,6 +79,51 @@ RSpec.describe Html2rss::MCP::Contract do
     end
   end
 
+  describe 'MCP_CONTRACT_VERSION' do
+    it 'is independent of the gem version constant', :aggregate_failures do
+      expect(described_class::MCP_CONTRACT_VERSION).to be_a(Integer)
+      expect(described_class::MCP_CONTRACT_VERSION).to eq(2)
+    end
+  end
+
+  describe '.catalog_tools' do
+    it 'lists canonical tool names in stable order' do
+      expect(described_class.catalog_tools).to eq(
+        %w[apply batch_inspect batch_recon batch_scrape capture inspect recon scrape test validate]
+      )
+    end
+  end
+
+  describe '.catalog_fingerprint' do
+    it 'is a stable 16-char hex digest for the published registry', :aggregate_failures do
+      fingerprint = described_class.catalog_fingerprint
+      expect(fingerprint).to match(/\A[0-9a-f]{16}\z/)
+      expect(described_class.catalog_fingerprint).to eq(fingerprint)
+    end
+
+    it 'changes when the published tool set changes' do
+      baseline = described_class.catalog_fingerprint
+      extra_tool = { name: 'future_tool', kind: :url, input_schema: { required: %w[url] } }
+      stub_const('Html2rss::MCP::Server::Tools::TOOLS', Html2rss::MCP::Server::Tools::TOOLS + [extra_tool])
+
+      expect(described_class.catalog_fingerprint).not_to eq(baseline)
+    end
+
+    it 'changes when a tool oneOf branch changes' do # rubocop:disable RSpec/ExampleLength -- mutation setup encodes fingerprint sensitivity
+      baseline = described_class.catalog_fingerprint
+      mutated = Html2rss::MCP::Server::Tools::TOOLS.map do |entry|
+        next entry unless entry.fetch(:name) == 'validate'
+
+        schema = Html2rss::HashUtil.deep_dup(entry.fetch(:input_schema))
+        schema[:oneOf] = [{ required: %w[config yaml] }]
+        entry.merge(input_schema: schema)
+      end
+      stub_const('Html2rss::MCP::Server::Tools::TOOLS', mutated)
+
+      expect(described_class.catalog_fingerprint).not_to eq(baseline)
+    end
+  end
+
   describe '.output_schema' do
     it 'validates an Outcome wire hash' do
       wire = Html2rss::MCP::Outcome.apply(rss: '<rss/>', item_count: 1).to_h

--- a/spec/lib/html2rss/mcp/runtime_spec.rb
+++ b/spec/lib/html2rss/mcp/runtime_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Html2rss::MCP::Runtime do
+  describe '.snapshot' do
+    subject(:wire) { described_class.snapshot.to_h }
+
+    it 'publishes gem version, contract version, catalog identity, and botasaurus flag', :aggregate_failures do # rubocop:disable RSpec/ExampleLength -- runtime wire is one contract
+      expect(wire).to include(
+        version: Html2rss::VERSION,
+        mcp_contract_version: Html2rss::MCP::Contract::MCP_CONTRACT_VERSION,
+        catalog_fingerprint: Html2rss::MCP::Contract.catalog_fingerprint,
+        tools: Html2rss::MCP::Contract.catalog_tools,
+        botasaurus_configured: false
+      )
+    end
+
+    it 'returns a typed Snapshot' do
+      expect(described_class.snapshot).to be_a(described_class::Snapshot)
+    end
+  end
+end

--- a/spec/lib/html2rss/mcp/server_spec.rb
+++ b/spec/lib/html2rss/mcp/server_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Html2rss::MCP::Server do
       )
       expect(protocol_server.prompts.keys).to contain_exactly('scrape-webpage', 'capture-feed-config')
       expect(protocol_server.instructions).to include('Faraday → Botasaurus AutoFallback')
-      expect(protocol_server.instructions).to include('html2rss://runtime')
+      expect(protocol_server.instructions).to include('html2rss://runtime', 'catalog_fingerprint')
       expect(protocol_server.instructions).to include('Strive enhance: true')
       expect(protocol_server.instructions).to include('payload.item_count')
       expect(protocol_server.instructions).to include('test')
@@ -595,12 +595,19 @@ RSpec.describe Html2rss::MCP::Server do
       expect(names).not_to include('local_file')
     end
 
-    it 'reports botasaurus_configured without leaking the URL', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+    it 'reports runtime catalog identity without leaking secrets', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
       ClimateControl.modify(BOTASAURUS_SCRAPER_URL: 'http://127.0.0.1:4010/secret-token') do
         result = read_resource.call('html2rss://runtime')
         text = result.dig(:result, :contents, 0, :text)
+        wire = JSON.parse(text)
 
-        expect(JSON.parse(text)).to eq('botasaurus_configured' => true)
+        expect(wire).to eq(
+          'version' => Html2rss::VERSION,
+          'mcp_contract_version' => Html2rss::MCP::Contract::MCP_CONTRACT_VERSION,
+          'catalog_fingerprint' => Html2rss::MCP::Contract.catalog_fingerprint,
+          'tools' => Html2rss::MCP::Contract.catalog_tools,
+          'botasaurus_configured' => true
+        )
         expect(text).not_to include('127.0.0.1')
         expect(text).not_to include('secret-token')
       end


### PR DESCRIPTION
## What changed

- `html2rss://runtime` now returns `version`, `mcp_contract_version`, `catalog_fingerprint`, `tools`, and `botasaurus_configured` (was `botasaurus_configured` only).
- `Contract::MCP_CONTRACT_VERSION` (2) tracks envelope/breaking wire semantics; `catalog_fingerprint` hashes tool names, required keys, and `oneOf` branches.
- `Runtime::Snapshot` (`Data.define`) owns the wire shape; `Server` resource delegates to `Runtime.snapshot`.
- Playbook `read_runtime` guidance and decision tree tell agents to refresh `tools/list` when `catalog_fingerprint` differs.
- Docs synced in `README.md`, `lib/html2rss/mcp/README.md`, `CHANGELOG.md`.

## Why

After the bare-verb MCP rename, clients with cached `tools/list` catalogs (Cursor host instructions, hardcoded tool names) fail silently on unknown tools. Publishing catalog identity on the runtime resource gives a cheap, secret-safe refresh signal without suffix aliases or deprecation shims.

## Risk

- Low — additive runtime resource fields; no tool aliases or behavior changes.
- Clients that only read `botasaurus_configured` still work; new fields are optional to consume.
- Bump `mcp_contract_version` when envelope semantics change; fingerprint changes when tool registry shape changes.

## Review map

Review map: whole PR is small — start at `lib/html2rss/mcp/contract.rb` (fingerprint + contract version), then `lib/html2rss/mcp/runtime.rb`.

## Validation

- `make quick` (RuboCop on touched files + targeted MCP specs) — exit 0, 67 examples