### PR TITLE
feat(html): add case-insensitive `Probe` for scraper resilience

### DIFF
--- a/lib/html2rss/auto_source.rb
+++ b/lib/html2rss/auto_source.rb
@@ -221,7 +221,7 @@ module Html2rss
     end
 
     def run_scraper(instance)
-      instance.each.map { |item| article_from_scraper_item(item, instance) }
+      instance.map { |item| article_from_scraper_item(item, instance) }
     rescue *OPERATIONAL_ERRORS => error
       Log.warn("#{self.class}: #{instance.class} quarantined #{error.class}: #{error.message}")
       []

--- a/lib/html2rss/auto_source.rb
+++ b/lib/html2rss/auto_source.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'dry-validation'
+require 'json'
+require 'nokogiri'
 
 module Html2rss
   ##
@@ -19,6 +21,14 @@ module Html2rss
   class AutoSource # rubocop:disable Metrics/ClassLength -- defaults + tiered extract stay on the contributor entry type
     # Default max articles to keep (also the short-circuit floor across scraper tiers).
     DEFAULT_LIMIT = 25
+
+    # Operational scraper failures quarantined within a tier; programmer errors propagate.
+    OPERATIONAL_ERRORS = [
+      Html2rss::Error,
+      ArgumentError,
+      ::JSON::ParserError,
+      ::Nokogiri::SyntaxError
+    ].freeze
 
     # Default auto-source configuration shipped for scraper and cleanup behavior.
     DEFAULT_CONFIG = {
@@ -211,15 +221,20 @@ module Html2rss
     end
 
     def run_scraper(instance)
-      instance.each.map do |item|
-        case item
-        when Article
-          item
-        when Hash
-          Article.new(**item, scraper: instance.class)
-        else
-          raise TypeError, "#{instance.class} yielded #{item.class}; expected Article or Hash"
-        end
+      instance.each.map { |item| article_from_scraper_item(item, instance) }
+    rescue *OPERATIONAL_ERRORS => error
+      Log.warn("#{self.class}: #{instance.class} quarantined #{error.class}: #{error.message}")
+      []
+    end
+
+    def article_from_scraper_item(item, instance)
+      case item
+      when Article
+        item
+      when Hash
+        Article.new(**item, scraper: instance.class)
+      else
+        raise TypeError, "#{instance.class} yielded #{item.class}; expected Article or Hash"
       end
     end
 

--- a/lib/html2rss/auto_source/scraper.rb
+++ b/lib/html2rss/auto_source/scraper.rb
@@ -118,7 +118,7 @@ module Html2rss
       # @return [SST::Document, nil]
       def self.normalize_sst(parsed_body)
         SST::Normalizer.call(parsed_body)
-      rescue ArgumentError
+      rescue SST::Normalizer::EmptyTree
         nil
       end
 

--- a/lib/html2rss/auto_source/scraper/json_state/document_scanner.rb
+++ b/lib/html2rss/auto_source/scraper/json_state/document_scanner.rb
@@ -8,8 +8,6 @@ module Html2rss
       class JsonState
         # Scans DOM nodes for JSON payloads containing article data.
         module DocumentScanner # rubocop:disable Metrics/ModuleLength
-          # Selector for JSON-only script tags.
-          JSON_SCRIPT_SELECTOR = 'script[type="application/json"]'
           # Regex patterns for known global JavaScript state assignments.
           GLOBAL_ASSIGNMENT_PATTERNS = [
             /(?:window|self|globalThis)\.__NEXT_DATA__\s*=\s*/m,
@@ -44,7 +42,8 @@ module Html2rss
           # @param parsed_body [Nokogiri::HTML::Document] parsed HTML document
           # @return [Array<Hash, Array>] JSON documents extracted from JSON script tags
           def script_documents(parsed_body)
-            parsed_body.css(JSON_SCRIPT_SELECTOR).filter_map { parse_json(_1.text) }
+            ::Html2rss::Html::Probe.scripts(parsed_body, ::Html2rss::Html::Probe::APPLICATION_JSON)
+                                   .filter_map { parse_json(_1.text) }
           end
 
           # @param parsed_body [Nokogiri::HTML::Document] parsed HTML document

--- a/lib/html2rss/auto_source/scraper/meta_oembed.rb
+++ b/lib/html2rss/auto_source/scraper/meta_oembed.rb
@@ -13,9 +13,6 @@ module Html2rss
 
         # Selector for OpenGraph meta tags.
         OG_META_SELECTOR = 'meta[property^="og:"], meta[property^="article:"], meta[name^="twitter:"]'
-        # Selector for oEmbed JSON link tag.
-        OEMBED_LINK_SELECTOR = 'link[rel="alternate"][type="application/json+oembed"][href]'
-
         # Mapping of meta property names to article attribute keys.
         META_MAP = {
           'og:title' => :title,
@@ -40,7 +37,11 @@ module Html2rss
             return false unless parsed_body
 
             !parsed_body.at_css('meta[property="og:title"]').nil? ||
-              !parsed_body.at_css(OEMBED_LINK_SELECTOR).nil?
+              ::Html2rss::Html::Probe.alternate_links(
+                parsed_body,
+                rel: 'alternate',
+                mime: ::Html2rss::Html::Probe::APPLICATION_JSON_OEMBED
+              ).any?
           end
         end
 
@@ -109,7 +110,7 @@ module Html2rss
 
         # @return [Hash{Symbol => Object}] oEmbed fields hash
         def fetch_oembed_data
-          return {} unless request_session && (link_node = parsed_body.at_css(OEMBED_LINK_SELECTOR))
+          return {} unless request_session && (link_node = oembed_link_node)
           return {} unless (oembed_url = resolve_url(link_node['href']))
 
           response = request_session.follow_up(url: oembed_url, relation: :auto_source, origin_url: url)
@@ -117,6 +118,15 @@ module Html2rss
         rescue Html2rss::Error, RequestService::UnsupportedResponseContentType, JSON::ParserError => error
           Log.warn("#{self.class}: failed to fetch oEmbed payload (#{error.class}: #{error.message})")
           {}
+        end
+
+        # @return [Nokogiri::XML::Element, nil] oEmbed descriptor link node
+        def oembed_link_node
+          ::Html2rss::Html::Probe.alternate_links(
+            parsed_body,
+            rel: 'alternate',
+            mime: ::Html2rss::Html::Probe::APPLICATION_JSON_OEMBED
+          ).first
         end
 
         # @param response [Html2rss::RequestService::Response, nil] HTTP response

--- a/lib/html2rss/auto_source/scraper/microdata.rb
+++ b/lib/html2rss/auto_source/scraper/microdata.rb
@@ -39,15 +39,17 @@ module Html2rss
           # @param node [Nokogiri::XML::Element] itemscope candidate node
           # @return [String, nil] supported schema type name when present
           def supported_type_name(node)
-            normalized_types(node['itemtype']).find { SUPPORTED_TYPES.include?(_1) }
+            itemtype_type_names(node['itemtype']).find { SUPPORTED_TYPES.include?(_1) }
           end
 
           # @param itemtype [String, nil] raw itemtype attribute value
-          # @return [Array<String>] normalized schema type names
-          def normalized_types(itemtype)
-            itemtype.to_s.split.filter_map do |value|
-              type = value.split('/').last.to_s.split('#').last.to_s
-              type unless type.empty?
+          # @return [Array<String>] canonical schema type names
+          def itemtype_type_names(itemtype)
+            itemtype.to_s.split.flat_map do |value|
+              short = value.split('/').last.to_s.split('#').last.to_s
+              next [] if short.empty?
+
+              Schema.normalize_types(short).to_a
             end
           end
 
@@ -189,7 +191,7 @@ module Html2rss
             item = call(node)
             itemtype = node['itemtype']
             itemid = node['itemid']
-            item[:@type] = Microdata.normalized_types(itemtype).first if itemtype
+            item[:@type] = Microdata.itemtype_type_names(itemtype).first if itemtype
             item[:@id] = itemid if present?(itemid)
             item
           end

--- a/lib/html2rss/auto_source/scraper/microdata.rb
+++ b/lib/html2rss/auto_source/scraper/microdata.rb
@@ -45,11 +45,11 @@ module Html2rss
           # @param itemtype [String, nil] raw itemtype attribute value
           # @return [Array<String>] canonical schema type names
           def itemtype_type_names(itemtype)
-            itemtype.to_s.split.flat_map do |value|
+            itemtype.to_s.split.filter_map do |value|
               short = value.split('/').last.to_s.split('#').last.to_s
-              next [] if short.empty?
+              next if short.empty?
 
-              Schema.normalize_types(short).to_a
+              Schema.canonicalize_type(short)
             end
           end
 

--- a/lib/html2rss/auto_source/scraper/native_feed.rb
+++ b/lib/html2rss/auto_source/scraper/native_feed.rb
@@ -31,8 +31,11 @@ module Html2rss
 
           parsed_body.css('head link[rel~="alternate"][href]').any? do |node|
             href = node['href'].to_s
-            type = node['type'].to_s.downcase
-            type.include?('rss') || type.include?('atom') || href.match?(/rss|atom|feed|\.xml/i)
+            ::Html2rss::Html::Probe.mime_match?(
+              node['type'],
+              ::Html2rss::Html::Probe::APPLICATION_RSS_XML,
+              ::Html2rss::Html::Probe::APPLICATION_ATOM_XML
+            ) || href.match?(/rss|atom|feed|\.xml/i)
           end
         end
 

--- a/lib/html2rss/auto_source/scraper/schema.rb
+++ b/lib/html2rss/auto_source/scraper/schema.rb
@@ -169,15 +169,15 @@ module Html2rss
         ##
         # @yield [Hash] Each scraped article_hash
         # @return [Array<Hash>] the scraped article_hashes
-        def each(&)
+        def each
           return enum_for(:each) unless block_given?
 
-          schema_objects.filter_map do |schema_object|
+          schema_objects.each do |schema_object|
             next unless (klass = self.class.scraper_for_schema_object(schema_object))
             next unless (results = klass.new(schema_object, url:).call)
 
             if results.is_a?(Array)
-              results.each { |result| yield(result) } # rubocop:disable Style/ExplicitBlockArgument
+              results.each { yield(_1) }
             else
               yield(results)
             end

--- a/lib/html2rss/auto_source/scraper/schema.rb
+++ b/lib/html2rss/auto_source/scraper/schema.rb
@@ -111,10 +111,7 @@ module Html2rss
               object.each_with_object(Set.new) { |item, set| set.merge(normalize_types(item)) }
             when String, Symbol
               short = object.to_s.sub(SCHEMA_ORG_PREFIX_RE, '')
-              return Set.new if short.empty?
-
-              canonical = CANONICAL_BY_DOWNCASE.fetch(::Html2rss::Html::Probe.fold(short), short)
-              Set[canonical]
+              short.empty? ? Set.new : Set[CANONICAL_BY_DOWNCASE.fetch(::Html2rss::Html::Probe.fold(short), short)]
             else
               Set.new
             end

--- a/lib/html2rss/auto_source/scraper/schema.rb
+++ b/lib/html2rss/auto_source/scraper/schema.rb
@@ -40,6 +40,9 @@ module Html2rss
         # Prefer these keys when recursively walking unsupported container objects.
         COLLECTION_KEYS = %i[itemListElement blogPost mainEntity hasPart].freeze
 
+        # Shared empty type set for nil/unsupported wire forms (avoids per-call Set.new).
+        EMPTY_TYPES = Set.new.freeze
+
         # @return [Symbol] scraper config key
         def self.options_key = :schema
 
@@ -109,12 +112,24 @@ module Html2rss
             case object
             when Array
               object.each_with_object(Set.new) { |item, set| set.merge(normalize_types(item)) }
-            when String, Symbol
-              short = object.to_s.sub(SCHEMA_ORG_PREFIX_RE, '')
-              short.empty? ? Set.new : Set[CANONICAL_BY_DOWNCASE.fetch(::Html2rss::Html::Probe.fold(short), short)]
             else
-              Set.new
+              name = canonicalize_type(object)
+              name ? Set[name] : EMPTY_TYPES
             end
+          end
+
+          # Canonical short Schema.org type name for a scalar wire form.
+          #
+          # @param object [String, Symbol, nil] raw `@type` / itemtype token
+          # @return [String, nil]
+          # @api private
+          def canonicalize_type(object)
+            return unless object.is_a?(String) || object.is_a?(Symbol)
+
+            short = object.to_s.sub(SCHEMA_ORG_PREFIX_RE, '')
+            return if short.empty?
+
+            CANONICAL_BY_DOWNCASE.fetch(::Html2rss::Html::Probe.fold(short), short)
           end
 
           private

--- a/lib/html2rss/auto_source/scraper/schema.rb
+++ b/lib/html2rss/auto_source/scraper/schema.rb
@@ -15,9 +15,6 @@ module Html2rss
       class Schema
         include Enumerable
 
-        # Selector for JSON-LD script tags containing Schema.org objects.
-        TAG_SELECTOR = 'script[type="application/ld+json"]'
-
         # Pre-compiled regex for supported schema types (short name or schema.org URL; string or array @type).
         # Allows preceding entries in a JSON @type array (e.g. ["WebPage","NewsArticle"]).
         SUPPORTED_TYPES_RE = begin
@@ -44,7 +41,8 @@ module Html2rss
           # @param parsed_body [Nokogiri::HTML::Document] parsed HTML document
           # @return [Boolean] whether the page includes supported schema types
           def articles?(parsed_body)
-            parsed_body.css(TAG_SELECTOR).any? { |script| supported_schema_type?(script) }
+            ::Html2rss::Html::Probe.scripts(parsed_body, ::Html2rss::Html::Probe::APPLICATION_LD_JSON)
+                                   .any? { |script| supported_schema_type?(script) }
           end
 
           # @param script [Nokogiri::XML::Element] schema JSON-LD script tag
@@ -168,9 +166,8 @@ module Html2rss
         private
 
         def schema_objects
-          @parsed_body.css(TAG_SELECTOR).flat_map do |tag|
-            Schema.from(tag)
-          end
+          ::Html2rss::Html::Probe.scripts(@parsed_body, ::Html2rss::Html::Probe::APPLICATION_LD_JSON)
+                                 .flat_map { |tag| Schema.from(tag) }
         end
 
         attr_reader :parsed_body, :url

--- a/lib/html2rss/auto_source/scraper/schema.rb
+++ b/lib/html2rss/auto_source/scraper/schema.rb
@@ -15,24 +15,30 @@ module Html2rss
       class Schema
         include Enumerable
 
-        # Pre-compiled regex for supported schema types (short name or schema.org URL; string or array @type).
-        # Allows preceding entries in a JSON @type array (e.g. ["WebPage","NewsArticle"]).
-        SUPPORTED_TYPES_RE = begin
-          types = Thing::SUPPORTED_TYPES | ItemList::SUPPORTED_TYPES
-          type_re = Regexp.union(types.to_a)
-          %r{"@type"\s*:\s*(?:\[\s*(?:"[^"]*"\s*,\s*)*)?"(?:https?://schema\.org/)?(?:#{type_re.source})"}
-        end.freeze
-
         # Matches a leading schema.org URL prefix on @type values (http or https).
         SCHEMA_ORG_PREFIX_RE = %r{\Ahttps?://schema\.org/}i
-
-        # Prefer these keys when recursively walking unsupported container objects.
-        COLLECTION_KEYS = %i[itemListElement blogPost mainEntity hasPart].freeze
 
         # Container types that must never be emitted as feed items (walk children only).
         DENIED_CONTAINER_TYPES = Set[
           'ItemList', 'Blog', 'BreadcrumbList', 'WebPage', 'CollectionPage'
         ].freeze
+
+        # Canonical Schema.org type names keyed by folded wire forms (case-insensitive lookup).
+        CANONICAL_BY_DOWNCASE = begin
+          canonical_types = Thing::SUPPORTED_TYPES | ItemList::SUPPORTED_TYPES | DENIED_CONTAINER_TYPES | Set['Product']
+          canonical_types.to_h { |type| [::Html2rss::Html::Probe.fold(type), type] }.freeze
+        end.freeze
+
+        # Pre-compiled regex for supported schema types (short name or schema.org URL; string or array @type).
+        # Allows preceding entries in a JSON @type array (e.g. ["WebPage","NewsArticle"]).
+        SUPPORTED_TYPES_RE = begin
+          types = Thing::SUPPORTED_TYPES | ItemList::SUPPORTED_TYPES
+          type_re = Regexp.union(types.to_a)
+          %r{(?i)"@type"\s*:\s*(?:\[\s*(?:"[^"]*"\s*,\s*)*)?"(?:https?://schema\.org/)?(?:#{type_re.source})"}
+        end.freeze
+
+        # Prefer these keys when recursively walking unsupported container objects.
+        COLLECTION_KEYS = %i[itemListElement blogPost mainEntity hasPart].freeze
 
         # @return [Symbol] scraper config key
         def self.options_key = :schema
@@ -105,7 +111,10 @@ module Html2rss
               object.each_with_object(Set.new) { |item, set| set.merge(normalize_types(item)) }
             when String, Symbol
               short = object.to_s.sub(SCHEMA_ORG_PREFIX_RE, '')
-              short.empty? ? Set.new : Set[short]
+              return Set.new if short.empty?
+
+              canonical = CANONICAL_BY_DOWNCASE.fetch(::Html2rss::Html::Probe.fold(short), short)
+              Set[canonical]
             else
               Set.new
             end

--- a/lib/html2rss/auto_source/segmenter/cluster.rb
+++ b/lib/html2rss/auto_source/segmenter/cluster.rb
@@ -64,7 +64,7 @@ module Html2rss
         def normalize_class(class_names)
           return '' if class_names.empty?
 
-          class_names.sort.join(' ')
+          class_names.map { ::Html2rss::Html::Probe.fold(_1) }.sort.join(' ')
         end
         module_function :normalize_class
         private_class_method :normalize_class

--- a/lib/html2rss/html/article_extractor.rb
+++ b/lib/html2rss/html/article_extractor.rb
@@ -130,11 +130,11 @@ module Html2rss
       end
 
       def heading_or_anchor_item?
-        heading_item? || article_tag.name.to_s == 'a'
+        heading_item? || Probe.tag(article_tag) == 'a'
       end
 
       def heading_item?
-        Navigator::HEADING_TAGS.include?(article_tag.name.to_s)
+        Navigator::HEADING_TAGS.include?(Probe.tag(article_tag))
       end
 
       def heading_or_anchor_miss?(title, lines, published_at)

--- a/lib/html2rss/html/article_extractor.rb
+++ b/lib/html2rss/html/article_extractor.rb
@@ -130,11 +130,8 @@ module Html2rss
       end
 
       def heading_or_anchor_item?
-        heading_item? || Probe.tag(article_tag) == 'a'
-      end
-
-      def heading_item?
-        Navigator::HEADING_TAGS.include?(Probe.tag(article_tag))
+        tag = Probe.tag(article_tag)
+        Navigator::HEADING_TAGS.include?(tag) || tag == 'a'
       end
 
       def heading_or_anchor_miss?(title, lines, published_at)

--- a/lib/html2rss/html/article_extractor/heading_extractor.rb
+++ b/lib/html2rss/html/article_extractor/heading_extractor.rb
@@ -30,12 +30,12 @@ module Html2rss
           private
 
           def select_best_heading(tags)
-            min_tag_name = tags.map(&:name).min
+            min_tag_name = tags.map { Probe.tag(_1) }.min
             best_tag = nil
             max_size = -1
 
             tags.each do |tag|
-              next if tag.name != min_tag_name
+              next if Probe.tag(tag) != min_tag_name
 
               size = Navigator::TextExtractor.call(tag)&.size.to_i
               (best_tag = tag) && (max_size = size) if size > max_size

--- a/lib/html2rss/html/article_extractor/heading_extractor.rb
+++ b/lib/html2rss/html/article_extractor/heading_extractor.rb
@@ -30,18 +30,11 @@ module Html2rss
           private
 
           def select_best_heading(tags)
-            min_tag_name = tags.map { Probe.tag(_1) }.min
-            best_tag = nil
-            max_size = -1
-
-            tags.each do |tag|
-              next if Probe.tag(tag) != min_tag_name
-
-              size = Navigator::TextExtractor.call(tag)&.size.to_i
-              (best_tag = tag) && (max_size = size) if size > max_size
-            end
-
-            best_tag
+            tagged = tags.map { |tag| [Probe.tag(tag), tag] }
+            min_tag_name = tagged.map(&:first).min
+            tagged.select { |name, _tag| name == min_tag_name }
+                  .max_by { |_name, tag| Navigator::TextExtractor.call(tag)&.size.to_i }
+                  &.last
           end
 
           def fallback_heading(article_tag)

--- a/lib/html2rss/html/feed_link.rb
+++ b/lib/html2rss/html/feed_link.rb
@@ -25,8 +25,10 @@ module Html2rss
         end
 
         def feed_mime_type(type)
-          media_type = type.to_s.split(';', 2).first.strip.downcase
-          media_type if media_type in 'application/rss+xml' | 'application/atom+xml'
+          return Probe::APPLICATION_RSS_XML if Probe.mime_match?(type, Probe::APPLICATION_RSS_XML)
+          return Probe::APPLICATION_ATOM_XML if Probe.mime_match?(type, Probe::APPLICATION_ATOM_XML)
+
+          nil
         end
       end
     end

--- a/lib/html2rss/html/navigator.rb
+++ b/lib/html2rss/html/navigator.rb
@@ -48,7 +48,7 @@ module Html2rss
         # @param article_tag [Nokogiri::XML::Node] article-like container to search within
         # @return [Nokogiri::XML::Node, nil] first eligible descendant anchor
         def main_anchor_for(article_tag)
-          return article_tag if article_tag.name == 'a' && article_tag.matches?(MAIN_ANCHOR_SELECTOR)
+          return article_tag if Probe.tag(article_tag) == 'a' && article_tag.matches?(MAIN_ANCHOR_SELECTOR)
 
           article_tag.at_css(MAIN_ANCHOR_SELECTOR)
         end
@@ -71,7 +71,7 @@ module Html2rss
               break
             end
 
-            if IGNORED_CONTAINER_TAGS.include?(curr.name)
+            if IGNORED_CONTAINER_TAGS.include?(Probe.tag(curr))
               is_ignored = true
               break
             end
@@ -93,7 +93,7 @@ module Html2rss
         # @param condition [Proc] The condition to be met.
         # @return [Nokogiri::XML::Node, nil] The first parent that satisfies the condition.
         def parent_until_condition(node, condition)
-          while node && !node.document? && node.name != 'html'
+          while node && !node.document? && Probe.tag(node) != 'html'
             return node if condition.call(node)
 
             node = node.parent
@@ -109,7 +109,7 @@ module Html2rss
           return false unless node
           return false if node.respond_to?(:document?) && node.document?
 
-          !CARD_WALK_STOP_TAGS.include?(node.name.to_s)
+          !CARD_WALK_STOP_TAGS.include?(Probe.tag(node))
         end
 
         ##
@@ -137,7 +137,7 @@ module Html2rss
         # @param tag_name [String] tag name to find in ancestors
         # @return [Nokogiri::XML::Node, nil] matching ancestor node
         def find_tag_in_ancestors(current_tag, tag_name)
-          return current_tag if current_tag.name == tag_name
+          return current_tag if Probe.tag(current_tag) == Probe.fold(tag_name)
 
           current_tag.ancestors(tag_name).first
         end

--- a/lib/html2rss/html/navigator.rb
+++ b/lib/html2rss/html/navigator.rb
@@ -11,9 +11,6 @@ module Html2rss
       # Element tags that indicate ignored DOM chrome when found in a container path.
       IGNORED_CONTAINER_TAGS = %w[nav footer header svg script style].to_set.freeze
 
-      # Layout roots and chrome tags excluded from class-clustering candidate nodes.
-      CLUSTER_EXCLUDED_TAGS = Set['html', 'body', 'nav', 'footer', 'header', 'svg', 'script', 'style'].freeze
-
       # Ancestor tags that usually indicate navigation/utility regions inside a content container.
       UTILITY_LANDMARK_TAGS = %w[nav aside footer menu].to_set.freeze
 
@@ -52,38 +49,6 @@ module Html2rss
 
           article_tag.at_css(MAIN_ANCHOR_SELECTOR)
         end
-
-        ##
-        # @param node [Nokogiri::XML::Node]
-        # @param cache [Hash, nil] identity cache used to store results (must use compare_by_identity)
-        # @return [Boolean] true when the node belongs to ignored DOM chrome
-        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
-        def ignored_container_path?(node, cache = nil)
-          return cache[node] if cache&.key?(node)
-
-          curr = node
-          visited = []
-          is_ignored = false
-
-          while curr.respond_to?(:parent) && curr
-            if cache&.key?(curr)
-              is_ignored = cache[curr]
-              break
-            end
-
-            if IGNORED_CONTAINER_TAGS.include?(Probe.tag(curr))
-              is_ignored = true
-              break
-            end
-
-            visited << curr
-            curr = curr.parent
-          end
-          visited.each { |n| cache[n] = is_ignored } if cache
-
-          is_ignored
-        end
-        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
         ##
         # Returns the first parent that satisfies the condition.

--- a/lib/html2rss/html/probe.rb
+++ b/lib/html2rss/html/probe.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Html2rss
+  module Html
+    ##
+    # Case-insensitive DOM wire matching for MIME types, tag names, and link relations.
+    module Probe
+      APPLICATION_LD_JSON = 'application/ld+json'
+      APPLICATION_JSON = 'application/json'
+      APPLICATION_JSON_OEMBED = 'application/json+oembed'
+      APPLICATION_RSS_XML = 'application/rss+xml'
+      APPLICATION_ATOM_XML = 'application/atom+xml'
+
+      FOLDED_APPLICATION_LD_JSON = APPLICATION_LD_JSON.freeze
+      FOLDED_APPLICATION_JSON = APPLICATION_JSON.freeze
+      FOLDED_APPLICATION_JSON_OEMBED = APPLICATION_JSON_OEMBED.freeze
+      FOLDED_APPLICATION_RSS_XML = APPLICATION_RSS_XML.freeze
+      FOLDED_APPLICATION_ATOM_XML = APPLICATION_ATOM_XML.freeze
+
+      module_function
+
+      ##
+      # @param string [String, Symbol, #to_s] wire value
+      # @return [String] folded comparison key
+      def fold(string)
+        string.to_s.downcase
+      end
+
+      ##
+      # @param node [Nokogiri::XML::Node]
+      # @return [String] folded element name
+      def tag(node)
+        fold(node.name)
+      end
+
+      ##
+      # @param type [String, Symbol, #to_s, nil] MIME type attribute value
+      # @return [String] media type without parameters, folded
+      def mime_base(type)
+        fold(type.to_s.split(';', 2).first.to_s.strip)
+      end
+
+      ##
+      # @param actual [String, Symbol, #to_s, nil] observed MIME type
+      # @param expected [Array<String>] canonical MIME types to match
+      # @return [Boolean]
+      def mime_match?(actual, *expected)
+        base = mime_base(actual)
+        expected.any? { |candidate| base == mime_base(candidate) }
+      end
+
+      ##
+      # @param doc [Nokogiri::XML::Node]
+      # @param mime_types [Array<String>] optional MIME filters (folded once per call)
+      # @return [Array<Nokogiri::XML::Element>]
+      def scripts(doc, *mime_types)
+        folded = mime_types.map { |mime| mime_base(mime) }.freeze unless mime_types.empty?
+
+        doc.css('script').reject do |script|
+          folded && !folded.include?(mime_base(script['type']))
+        end
+      end
+
+      ##
+      # @param doc [Nokogiri::XML::Node]
+      # @param rel [String] link rel token
+      # @param mime [String, nil] optional MIME filter
+      # @return [Array<Nokogiri::XML::Element>]
+      def alternate_links(doc, rel:, mime: nil)
+        nodes = doc.css(%(link[rel~="#{rel}"][href]))
+        return nodes if mime.nil?
+
+        nodes.select { |node| mime_match?(node['type'], mime) }
+      end
+    end
+  end
+end

--- a/lib/html2rss/html/probe.rb
+++ b/lib/html2rss/html/probe.rb
@@ -30,6 +30,7 @@ module Html2rss
       # @return [String] folded element name
       def tag(node)
         name = node.name
+        return fold(name) unless name.is_a?(String)
         return name if name.ascii_only? && !name.match?(/[A-Z]/)
 
         fold(name)

--- a/lib/html2rss/html/probe.rb
+++ b/lib/html2rss/html/probe.rb
@@ -29,14 +29,20 @@ module Html2rss
       # @param node [Nokogiri::XML::Node]
       # @return [String] folded element name
       def tag(node)
-        fold(node.name)
+        name = node.name
+        return name if name.ascii_only? && !name.match?(/[A-Z]/)
+
+        fold(name)
       end
 
       ##
       # @param type [String, Symbol, #to_s, nil] MIME type attribute value
       # @return [String] media type without parameters, folded
       def mime_base(type)
-        fold(type.to_s.split(';', 2).first.to_s.strip)
+        raw = type.to_s
+        return fold(raw) unless raw.include?(';') || raw.match?(/\A\s|\s\z/)
+
+        fold(raw.split(';', 2).first.to_s.strip)
       end
 
       ##
@@ -45,7 +51,7 @@ module Html2rss
       # @return [Boolean]
       def mime_match?(actual, *expected)
         base = mime_base(actual)
-        expected.any? { |candidate| base == mime_base(candidate) }
+        expected.any? { |candidate| base == candidate || base == mime_base(candidate) }
       end
 
       ##
@@ -53,11 +59,10 @@ module Html2rss
       # @param mime_types [Array<String>] optional MIME filters (folded once per call)
       # @return [Array<Nokogiri::XML::Element>]
       def scripts(doc, *mime_types)
-        folded = mime_types.map { |mime| mime_base(mime) }.freeze unless mime_types.empty?
+        return doc.css('script') if mime_types.empty?
 
-        doc.css('script').reject do |script|
-          folded && !folded.include?(mime_base(script['type']))
-        end
+        allowed = mime_types.to_set { |mime| mime_base(mime) }
+        doc.css('script').select { |script| allowed.include?(mime_base(script['type'])) }
       end
 
       ##

--- a/lib/html2rss/html/probe.rb
+++ b/lib/html2rss/html/probe.rb
@@ -5,17 +5,16 @@ module Html2rss
     ##
     # Case-insensitive DOM wire matching for MIME types, tag names, and link relations.
     module Probe
+      # Canonical MIME type strings for script and alternate link matching.
       APPLICATION_LD_JSON = 'application/ld+json'
+      # @see #mime_match?
       APPLICATION_JSON = 'application/json'
+      # @see #mime_match?
       APPLICATION_JSON_OEMBED = 'application/json+oembed'
+      # @see #mime_match?
       APPLICATION_RSS_XML = 'application/rss+xml'
+      # @see #mime_match?
       APPLICATION_ATOM_XML = 'application/atom+xml'
-
-      FOLDED_APPLICATION_LD_JSON = APPLICATION_LD_JSON.freeze
-      FOLDED_APPLICATION_JSON = APPLICATION_JSON.freeze
-      FOLDED_APPLICATION_JSON_OEMBED = APPLICATION_JSON_OEMBED.freeze
-      FOLDED_APPLICATION_RSS_XML = APPLICATION_RSS_XML.freeze
-      FOLDED_APPLICATION_ATOM_XML = APPLICATION_ATOM_XML.freeze
 
       module_function
 

--- a/lib/html2rss/link_destination/path_classifier.rb
+++ b/lib/html2rss/link_destination/path_classifier.rb
@@ -99,7 +99,7 @@ module Html2rss
       def shallow?
         segment_count = segments.size
 
-        segment_count <= 1 || (segment_count == 2 && high_confidence_junk_segment?(segments.last))
+        segment_count <= 1 || (segment_count == 2 && high_confidence_junk_at?(segment_count - 1))
       end
 
       # @return [Boolean] true when the final path segment looks like a post slug
@@ -111,15 +111,15 @@ module Html2rss
 
       # @return [Boolean] true when every path segment is utility chrome
       def utility_only_route?
-        segments.all? { |segment| high_confidence_junk_segment?(segment) }
+        (0...segments.size).all? { |i| high_confidence_junk_at?(i) }
       end
 
       # @return [Boolean] true when the route is shallow and contains high-confidence noise
       def shallow_high_confidence_route?
         vanity_segments = SEGMENT_SETS.fetch(:vanity)
 
-        shallow? && segments.any? do |segment|
-          high_confidence_junk_segment?(segment) || vanity_segments.include?(folded_segment(segment))
+        shallow? && (0...segments.size).any? do |i|
+          high_confidence_junk_at?(i) || vanity_segments.include?(@lexicon[i])
         end
       end
 
@@ -149,11 +149,11 @@ module Html2rss
       private
 
       def leading_high_confidence_junk?
-        segments.any? && high_confidence_junk_segment?(segments.first)
+        segments.any? && high_confidence_junk_at?(0)
       end
 
       def any_high_confidence_junk_segment?
-        segments.any? { |segment| high_confidence_junk_segment?(segment) }
+        (0...segments.size).any? { |i| high_confidence_junk_at?(i) }
       end
 
       def yearish_content_context?
@@ -179,12 +179,12 @@ module Html2rss
       def all_junk?(limit)
         return false if limit <= 0
 
-        (0...limit).all? { |i| high_confidence_junk_segment?(segments[i]) }
+        (0...limit).all? { |i| high_confidence_junk_at?(i) }
       end
 
-      def high_confidence_junk_segment?(segment)
-        SEGMENT_SETS.fetch(:high_confidence_junk).include?(folded_segment(segment)) ||
-          host_shaped_segment?(segment)
+      def high_confidence_junk_at?(index)
+        SEGMENT_SETS.fetch(:high_confidence_junk).include?(@lexicon[index]) ||
+          host_shaped_segment?(segments[index])
       end
 
       def host_shaped_segment?(segment)
@@ -199,10 +199,9 @@ module Html2rss
         context_segments = SEGMENT_SETS.fetch(:deep_post_context)
 
         (0...limit).any? do |i|
-          segment = segments[i]
-          content_segments.include?(folded_segment(segment)) ||
-            segment.match?(PathClassifier::YEARISH_SEGMENT) ||
-            context_segments.include?(folded_segment(segment))
+          content_segments.include?(@lexicon[i]) ||
+            segments[i].match?(PathClassifier::YEARISH_SEGMENT) ||
+            context_segments.include?(@lexicon[i])
         end
       end
 
@@ -211,17 +210,13 @@ module Html2rss
       end
 
       def excluded_last_segment?
-        last = segments.last
-        high_confidence_junk_segment?(last) || SEGMENT_SETS[:vanity].include?(folded_segment(last))
+        last_i = segments.size - 1
+        high_confidence_junk_at?(last_i) || SEGMENT_SETS[:vanity].include?(@lexicon[last_i])
       end
 
       def slug_last_segment?
         last = segments.last
         last.match?(YEARISH_SEGMENT) || last.match?(POST_SLUG_SEGMENT)
-      end
-
-      def folded_segment(segment)
-        ::Html2rss::Html::Probe.fold(segment)
       end
     end
   end

--- a/lib/html2rss/link_destination/path_classifier.rb
+++ b/lib/html2rss/link_destination/path_classifier.rb
@@ -71,27 +71,28 @@ module Html2rss
       # @param segments [Array<String>] normalized URL path segments
       def initialize(segments)
         @segments = segments
+        @lexicon = segments.map { ::Html2rss::Html::Probe.fold(_1) }.freeze
       end
 
       # @return [Boolean] true when the route has article-like path evidence
       def content_path?
         @content_path ||= !leading_high_confidence_junk? &&
-                          (SEGMENT_SETS[:content].intersect?(segments) || yearish_content_context?)
+                          (SEGMENT_SETS[:content].intersect?(@lexicon) || yearish_content_context?)
       end
 
       # @return [Boolean] true when the route includes utility/navigation evidence
       def utility_path?
-        @utility_path ||= SEGMENT_SETS[:utility].intersect?(segments)
+        @utility_path ||= SEGMENT_SETS[:utility].intersect?(@lexicon)
       end
 
       # @return [Boolean] true when the route points at conversion or account chrome
       def vanity_path?
-        @vanity_path ||= SEGMENT_SETS[:vanity].intersect?(segments)
+        @vanity_path ||= SEGMENT_SETS[:vanity].intersect?(@lexicon)
       end
 
       # @return [Boolean] true when the route points at taxonomy/listing chrome
       def taxonomy_path?
-        @taxonomy_path ||= SEGMENT_SETS[:taxonomy].intersect?(segments)
+        @taxonomy_path ||= SEGMENT_SETS[:taxonomy].intersect?(@lexicon)
       end
 
       # @return [Boolean] true when the route is too shallow to strongly indicate an article
@@ -118,7 +119,7 @@ module Html2rss
         vanity_segments = SEGMENT_SETS.fetch(:vanity)
 
         shallow? && segments.any? do |segment|
-          high_confidence_junk_segment?(segment) || vanity_segments.include?(segment)
+          high_confidence_junk_segment?(segment) || vanity_segments.include?(folded_segment(segment))
         end
       end
 
@@ -182,7 +183,8 @@ module Html2rss
       end
 
       def high_confidence_junk_segment?(segment)
-        SEGMENT_SETS.fetch(:high_confidence_junk).include?(segment) || host_shaped_segment?(segment)
+        SEGMENT_SETS.fetch(:high_confidence_junk).include?(folded_segment(segment)) ||
+          host_shaped_segment?(segment)
       end
 
       def host_shaped_segment?(segment)
@@ -198,9 +200,9 @@ module Html2rss
 
         (0...limit).any? do |i|
           segment = segments[i]
-          content_segments.include?(segment) ||
+          content_segments.include?(folded_segment(segment)) ||
             segment.match?(PathClassifier::YEARISH_SEGMENT) ||
-            context_segments.include?(segment)
+            context_segments.include?(folded_segment(segment))
         end
       end
 
@@ -210,12 +212,16 @@ module Html2rss
 
       def excluded_last_segment?
         last = segments.last
-        high_confidence_junk_segment?(last) || SEGMENT_SETS[:vanity].include?(last)
+        high_confidence_junk_segment?(last) || SEGMENT_SETS[:vanity].include?(folded_segment(last))
       end
 
       def slug_last_segment?
         last = segments.last
         last.match?(YEARISH_SEGMENT) || last.match?(POST_SLUG_SEGMENT)
+      end
+
+      def folded_segment(segment)
+        ::Html2rss::Html::Probe.fold(segment)
       end
     end
   end

--- a/lib/html2rss/sst/normalizer.rb
+++ b/lib/html2rss/sst/normalizer.rb
@@ -138,6 +138,7 @@ module Html2rss
       # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       def normalize_element(nk_node, parent:, depth:, path:, chrome:)
         return unless nk_node.respond_to?(:name)
+        return unless nk_node.element?
         return if nk_node.text? || nk_node.comment? || nk_node.cdata?
 
         tag = nk_node.name.to_s.downcase

--- a/lib/html2rss/sst/normalizer.rb
+++ b/lib/html2rss/sst/normalizer.rb
@@ -8,6 +8,9 @@ module Html2rss
     # Sole Nokogiri consumer on the heuristic auto-source path. Builds an
     # immutable SST::Document with parent/depth/chrome indices.
     class Normalizer # rubocop:disable Metrics/ClassLength
+      # Raised when no SST nodes survive normalization for the chosen root.
+      class EmptyTree < ArgumentError; end
+
       # Hard ceiling for SST node allocations; beyond this we degrade.
       MAX_NODES = 5_000
 
@@ -89,15 +92,48 @@ module Html2rss
       ##
       # @return [Document]
       def call
-        root_nk = @parsed_body.respond_to?(:root) ? (@parsed_body.at_css('html') || @parsed_body.root) : @parsed_body
+        root_nk = resolve_root_nk
         root = normalize_element(root_nk, parent: nil, depth: 0, path: '', chrome: false)
-        raise ArgumentError, 'SST Normalizer produced an empty tree' unless root
+        raise EmptyTree, 'SST Normalizer produced an empty tree' unless root
 
         index = Index.new(root:, parents: @parents, depths: @depths, ignored_chrome: @ignored_chrome)
         Document.build(root:, index:, degraded: @degraded, node_count: @node_count)
       end
 
       private
+
+      # @return [Nokogiri::XML::Node]
+      # rubocop:disable Metrics/MethodLength -- explicit root discovery fallback chain
+      def resolve_root_nk
+        parsed = @parsed_body
+
+        if parsed.respond_to?(:at_css)
+          html = parsed.at_css('html')
+          return html if html
+
+          body = parsed.at_css('body')
+          if body
+            Html2rss::Log.warn('sst.normalizer root fallback: body')
+            return body
+          end
+        end
+
+        if parsed.respond_to?(:element_children)
+          first = parsed.element_children.find { |child| element_root?(child) }
+          if first
+            Html2rss::Log.warn('sst.normalizer root fallback: first element child')
+            return first
+          end
+        end
+
+        Html2rss::Log.warn('sst.normalizer root fallback: self')
+        parsed
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      def element_root?(node)
+        node.element? && !STRIPPED_TAGS.include?(Html2rss::Html::Probe.tag(node))
+      end
 
       # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       def normalize_element(nk_node, parent:, depth:, path:, chrome:)

--- a/lib/html2rss/sst/normalizer.rb
+++ b/lib/html2rss/sst/normalizer.rb
@@ -53,6 +53,12 @@ module Html2rss
         )
       /xi
 
+      # Typed Attrs fields excluded from the leftover raw hash.
+      TYPED_ATTR_NAMES = %w[href src id class datetime itemprop style srcset type].to_set.freeze
+
+      # String form of Tags::IGNORED_CONTAINER_NAMES for chrome checks without to_sym.
+      IGNORED_CONTAINER_TAGS = Tags::IGNORED_CONTAINER_NAMES.to_set(&:to_s).freeze
+
       class << self
         ##
         # @param input [String, Nokogiri::HTML::Document, Nokogiri::XML::Node]
@@ -139,11 +145,9 @@ module Html2rss
       def normalize_element(nk_node, parent:, depth:, path:, chrome:)
         return unless nk_node.respond_to?(:name)
         return unless nk_node.element?
-        return if nk_node.text? || nk_node.comment? || nk_node.cdata?
 
-        tag = nk_node.name.to_s.downcase
+        tag = Html2rss::Html::Probe.tag(nk_node)
         return if STRIPPED_TAGS.include?(tag)
-        return if @degraded && !SEMANTIC_DEGRADE_TAGS.include?(tag)
 
         if @node_count >= MAX_NODES && !@degraded
           @degraded = true
@@ -156,9 +160,9 @@ module Html2rss
         tag_path = path.empty? ? "/#{tag}" : "#{path}/#{tag}"
         attrs = extract_attrs(nk_node)
         own_text = direct_text(nk_node)
-        chrome_here = chrome || Tags::IGNORED_CONTAINER_NAMES.include?(tag.to_sym)
+        chrome_here = chrome || IGNORED_CONTAINER_TAGS.include?(tag)
 
-        children = nk_node.children.filter_map do |child|
+        children = nk_node.element_children.filter_map do |child|
           normalize_element(child, parent: :pending, depth: depth + 1, path: tag_path, chrome: chrome_here)
         end.freeze
 
@@ -190,10 +194,9 @@ module Html2rss
       end
 
       def raw_attrs(nk_node)
-        typed = %w[href src id class datetime itemprop style srcset type].to_set
         nk_node.attribute_nodes.each_with_object({}) do |attr, raw|
           name = attr.name.to_s
-          next if typed.include?(name)
+          next if TYPED_ATTR_NAMES.include?(name)
           next unless name.match?(RAW_ATTR_KEEP)
 
           raw[name] = attr.value.to_s

--- a/spec/lib/html2rss/auto_source/scraper/meta_oembed_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper/meta_oembed_spec.rb
@@ -28,6 +28,16 @@ RSpec.describe Html2rss::AutoSource::Scraper::MetaOembed do
       it { expect(described_class.articles?(parsed_body)).to be true }
     end
 
+    context 'when oEmbed link tag uses uppercase MIME type' do
+      let(:parsed_body) do
+        Nokogiri::HTML(
+          '<html><head><link rel="alternate" type="APPLICATION/JSON+OEMBED" href="/oembed.json"></head></html>'
+        )
+      end
+
+      it { expect(described_class.articles?(parsed_body)).to be true }
+    end
+
     context 'when neither og:title nor oEmbed link tag is present' do
       let(:parsed_body) do
         Nokogiri::HTML('<html><head><title>Just Title</title></head></html>')

--- a/spec/lib/html2rss/auto_source/scraper/microdata_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper/microdata_spec.rb
@@ -25,6 +25,19 @@ RSpec.describe Html2rss::AutoSource::Scraper::Microdata do
       it { is_expected.to be(true) }
     end
 
+    context 'with lowercase itemtype URL' do
+      let(:parsed_body) do
+        Nokogiri::HTML(<<~HTML)
+          <article itemscope itemtype="https://schema.org/newsarticle">
+            <h1 itemprop="headline">Lowercase type headline</h1>
+            <a itemprop="url" href="/stories/lowercase-type">Read more</a>
+          </article>
+        HTML
+      end
+
+      it { is_expected.to be(true) }
+    end
+
     context 'with supported items nested inside another item property' do
       let(:parsed_body) do
         Nokogiri::HTML(<<~HTML)

--- a/spec/lib/html2rss/auto_source/scraper/schema_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper/schema_spec.rb
@@ -113,6 +113,22 @@ RSpec.describe Html2rss::AutoSource::Scraper::Schema do
 
       it { is_expected.to be_truthy }
     end
+
+    context 'with lowercase @type' do
+      let(:parsed_body) do
+        Nokogiri::HTML('<script type="application/ld+json">{"@type":"newsarticle"}</script>')
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'with mixed-case schema.org URL @type' do
+      let(:parsed_body) do
+        Nokogiri::HTML('<script type="application/ld+json">{"@type":"https://schema.org/NEWSARTICLE"}</script>')
+      end
+
+      it { is_expected.to be_truthy }
+    end
   end
 
   describe '.self.from(object)' do
@@ -406,6 +422,14 @@ RSpec.describe Html2rss::AutoSource::Scraper::Schema do
       end
     end
 
+    context 'with a lowercase Thing type' do
+      let(:object) { simple_article.call(type: 'article') }
+
+      it 'returns Thing class' do
+        expect(described_class.scraper_for_schema_object(object)).to eq(Html2rss::AutoSource::Scraper::Schema::Thing)
+      end
+    end
+
     context 'with an ItemList type' do
       let(:object) { simple_article.call(type: 'ItemList') }
 
@@ -458,6 +482,12 @@ RSpec.describe Html2rss::AutoSource::Scraper::Schema do
     it 'flattens array @type values' do
       expect(described_class.normalize_types(['https://schema.org/Article', 'NewsArticle']))
         .to eq(Set['Article', 'NewsArticle'])
+    end
+
+    it 'canonicalizes case-insensitive wire forms to PascalCase', :aggregate_failures do
+      expect(described_class.normalize_types('newsarticle')).to eq(Set['NewsArticle'])
+      expect(described_class.normalize_types('NEWSARTICLE')).to eq(Set['NewsArticle'])
+      expect(described_class.normalize_types('https://schema.org/article')).to eq(Set['Article'])
     end
   end
 

--- a/spec/lib/html2rss/auto_source/scraper/schema_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper/schema_spec.rb
@@ -68,6 +68,14 @@ RSpec.describe Html2rss::AutoSource::Scraper::Schema do
       it { is_expected.to be_truthy }
     end
 
+    context 'with uppercase JSON-LD MIME type' do
+      let(:parsed_body) do
+        Nokogiri::HTML("<script type=\"APPLICATION/LD+JSON\">#{news_article_schema_object.to_json}</script>")
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
     context 'with an empty body' do
       let(:parsed_body) { Nokogiri::HTML.fragment('') }
 

--- a/spec/lib/html2rss/auto_source/scraper_spec.rb
+++ b/spec/lib/html2rss/auto_source/scraper_spec.rb
@@ -168,6 +168,16 @@ RSpec.describe Html2rss::AutoSource::Scraper do
     let(:document) { described_class.normalize_sst(parsed_body) }
     let(:link_resolver) { Html2rss::Scoring::LinkResolver.new(url) }
 
+    it 'returns nil when normalization yields an empty tree' do
+      allow(Html2rss::SST::Normalizer).to receive(:call).and_raise(Html2rss::SST::Normalizer::EmptyTree, 'empty')
+
+      expect(described_class.normalize_sst(parsed_body)).to be_nil
+    end
+
+    it 'propagates non-empty-tree ArgumentError' do
+      expect { described_class.normalize_sst(nil) }.to raise_error(ArgumentError, /input is required/)
+    end
+
     it 'reuses the provided SST::Document without re-normalizing' do # rubocop:disable RSpec/ExampleLength
       shared_document = document
       allow(Html2rss::SST::Normalizer).to receive(:call)

--- a/spec/lib/html2rss/auto_source/segmenter_spec.rb
+++ b/spec/lib/html2rss/auto_source/segmenter_spec.rb
@@ -119,5 +119,35 @@ RSpec.describe Html2rss::AutoSource::Segmenter do
       expect(segments.first.root_node.attrs.class_names).to include('card-item')
       expect(segments.map(&:strategy).uniq).to eq([:cluster])
     end
+
+    it 'groups mixed-case class tokens into one cluster', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      html = <<~HTML
+        <html><body>
+          <div class="PostCard p-4">
+            <span class="card-title font-bold">Release v1.0</span>
+            <p class="card-body">Description text for release one goes here.</p>
+          </div>
+          <div class="postcard p-4">
+            <span class="card-title font-bold">Release v2.0</span>
+            <p class="card-body">Description text for release two goes here.</p>
+          </div>
+          <div class="PostCard p-4">
+            <span class="card-title font-bold">Release v3.0</span>
+            <p class="card-body">Description text for release three goes here.</p>
+          </div>
+        </body></html>
+      HTML
+
+      segments = described_class.call(
+        document_for(html),
+        base_url: 'https://example.com',
+        strategy: :cluster,
+        minimum_selector_frequency: 3
+      )
+
+      expect(segments.size).to eq(3)
+      expect(segments.first.root_node.attrs.class_names).to include('PostCard').or include('postcard')
+      expect(segments.map(&:strategy).uniq).to eq([:cluster])
+    end
   end
 end

--- a/spec/lib/html2rss/auto_source_spec.rb
+++ b/spec/lib/html2rss/auto_source_spec.rb
@@ -416,6 +416,91 @@ RSpec.describe Html2rss::AutoSource do
       end
     end
 
+    context 'when a scraper raises an operational error' do
+      let(:body) do
+        ld = {
+          '@context' => 'https://schema.org',
+          '@type' => 'NewsArticle',
+          'headline' => 'Schema Story Extra Words Here',
+          'url' => 'https://example.com/schema-1'
+        }
+        <<~HTML
+          <html><body>
+            <script type="application/ld+json">#{ld.to_json}</script>
+            <article>
+              <h2><a href="/story-one">Semantic Story One Extra Words</a></h2>
+              <p>Teaser content for the first semantic story.</p>
+            </article>
+          </body></html>
+        HTML
+      end
+      let(:config) do
+        described_class::DEFAULT_CONFIG.merge(
+          scraper: described_class::DEFAULT_CONFIG[:scraper].transform_values { |cfg| cfg.merge(enabled: false) }
+                                                            .merge(
+                                                              schema: { enabled: true },
+                                                              semantic_html: {
+                                                                enabled: true,
+                                                                fallback_anchorless: true
+                                                              }
+                                                            )
+        )
+      end
+
+      before do
+        allow(Html2rss::Log).to receive(:warn)
+        allow(Html2rss::AutoSource::Scraper).to receive(:build_instance).and_wrap_original do |method, scraper_class, *args, **kwargs| # rubocop:disable Layout/LineLength
+          instance = method.call(scraper_class, *args, **kwargs)
+          next instance unless scraper_class == Html2rss::AutoSource::Scraper::Schema && instance
+
+          allow(instance).to receive(:each).and_raise(ArgumentError, 'bad structured payload')
+          instance
+        end
+      end
+
+      it 'quarantines ArgumentError and continues the tier', :aggregate_failures do
+        expect(articles.size).to eq(1)
+        expect(articles.first.scraper).to eq(Html2rss::AutoSource::Scraper::SemanticHtml)
+        expect(Html2rss::Log).to have_received(:warn).with(/quarantined ArgumentError/)
+      end
+    end
+
+    context 'when a scraper raises an unexpected error' do
+      let(:body) do
+        ld = {
+          '@context' => 'https://schema.org',
+          '@type' => 'NewsArticle',
+          'headline' => 'Schema Story Extra Words Here',
+          'url' => 'https://example.com/schema-1'
+        }
+        <<~HTML
+          <html><body>
+            <script type="application/ld+json">#{ld.to_json}</script>
+          </body></html>
+        HTML
+      end
+      let(:config) do
+        described_class::DEFAULT_CONFIG.merge(
+          scraper: described_class::DEFAULT_CONFIG[:scraper].transform_values { |cfg| cfg.merge(enabled: false) }
+                                                            .merge(schema: { enabled: true })
+        )
+      end
+
+      before do
+        allow(Html2rss::AutoSource::Scraper).to receive(:build_instance).and_wrap_original do |method, scraper_class, *args, **kwargs| # rubocop:disable Layout/LineLength
+          instance = method.call(scraper_class, *args, **kwargs)
+          next instance unless scraper_class == Html2rss::AutoSource::Scraper::Schema && instance
+
+          allow(instance).to receive(:each).and_raise(StandardError, 'boom')
+          instance
+        end
+      end
+
+      it 'propagates StandardError instead of quarantining it' do
+        expect { articles }.to raise_error(StandardError, 'boom')
+      end
+    end
+
     context 'when the listing is wrapping a.card links (ISS Africa shape)' do
       let(:url) { Html2rss::Url.from_absolute('https://issafrica.org/iss-today') }
       let(:body) do

--- a/spec/lib/html2rss/html/article_extractor/heading_extractor_spec.rb
+++ b/spec/lib/html2rss/html/article_extractor/heading_extractor_spec.rb
@@ -4,6 +4,36 @@ require 'spec_helper'
 
 RSpec.describe Html2rss::Html::ArticleExtractor::HeadingExtractor do
   describe '.call' do
+    it 'prefers the numerically lowest heading tag (h1 over h2/h3)' do # rubocop:disable RSpec/ExampleLength
+      html = <<~HTML
+        <div class="card">
+          <h3>Tertiary</h3>
+          <h2>Secondary</h2>
+          <h1>Primary title</h1>
+        </div>
+      HTML
+      container = Nokogiri::HTML(html).at_css('.card')
+
+      heading = described_class.call(container, fallback_anchorless: false, selected_anchor: nil)
+
+      expect(heading.name).to eq('h1')
+    end
+
+    it 'among equal heading levels prefers the longest text' do # rubocop:disable RSpec/ExampleLength
+      html = <<~HTML
+        <div class="card">
+          <h2>Short</h2>
+          <h2>This is the longer heading text</h2>
+          <h3>Lower level ignored</h3>
+        </div>
+      HTML
+      container = Nokogiri::HTML(html).at_css('.card')
+
+      heading = described_class.call(container, fallback_anchorless: false, selected_anchor: nil)
+
+      expect(heading.text).to eq('This is the longer heading text')
+    end
+
     it 'prefers aria-label when no heading tags are present' do # rubocop:disable RSpec/ExampleLength
       html = <<~HTML
         <div class="card">

--- a/spec/lib/html2rss/html/feed_link_spec.rb
+++ b/spec/lib/html2rss/html/feed_link_spec.rb
@@ -38,5 +38,23 @@ RSpec.describe Html2rss::Html::FeedLink do
     it 'keeps head RSS/Atom alternates and ignores oembed, body links, and /feed guesses' do
       expect(feed_links).to eq(expected)
     end
+
+    context 'with uppercase MIME types' do
+      let(:html) do
+        <<~HTML
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <link rel="alternate" type="APPLICATION/RSS+XML" href="https://example.com/feed.xml">
+            <link rel="alternate" type="Application/Atom+xml" href="/atom.xml">
+          </head>
+          </html>
+        HTML
+      end
+
+      it 'normalizes feed MIME types case-insensitively' do
+        expect(feed_links).to eq(expected)
+      end
+    end
   end
 end

--- a/spec/lib/html2rss/html/navigator_spec.rb
+++ b/spec/lib/html2rss/html/navigator_spec.rb
@@ -207,6 +207,13 @@ RSpec.describe Html2rss::Html::Navigator do
       expect(described_class.ignored_container_path?(document.at_css('#foot'))).to be(true)
     end
 
+    it 'treats uppercase NAV as ignored chrome', :aggregate_failures do
+      document = Nokogiri::HTML('<html><body><NAV><a id="nav-link" href="/home">Home</a></NAV></body></html>')
+
+      expect(described_class.ignored_container_path?(document.at_css('#nav-link'))).to be(true)
+      expect(described_class.usable_card_parent?(document.at_css('NAV'))).to be(false)
+    end
+
     it 'returns false for content nodes and memoizes via identity cache', :aggregate_failures do
       cache = {}.compare_by_identity
       node = document.at_css('#story')

--- a/spec/lib/html2rss/html/navigator_spec.rb
+++ b/spec/lib/html2rss/html/navigator_spec.rb
@@ -79,6 +79,12 @@ RSpec.describe Html2rss::Html::Navigator do
       expect(described_class.usable_card_parent?(document.at_css('nav'))).to be(false)
       expect(described_class.usable_card_parent?(document.at_css('body'))).to be(false)
     end
+
+    it 'treats uppercase NAV as a card-walk stop' do
+      document = Nokogiri::HTML('<html><body><NAV><a href="/home">Home</a></NAV></body></html>')
+
+      expect(described_class.usable_card_parent?(document.at_css('NAV'))).to be(false)
+    end
   end
 
   describe '.find_closest_selector_upwards' do
@@ -188,39 +194,6 @@ RSpec.describe Html2rss::Html::Navigator do
       child = document.at_css('#child')
       expect(described_class.descendant_of?(document.at_css('#parent'), child)).to be(false)
       expect(described_class.descendant_of?(document.at_css('#other'), child)).to be(false)
-    end
-  end
-
-  describe '.ignored_container_path?' do
-    let(:document) do
-      Nokogiri::HTML(<<~HTML)
-        <html><body>
-          <nav><a id="nav-link" href="/home">Home</a></nav>
-          <main><article><a id="story" href="/story">Story</a></article></main>
-          <footer><span id="foot">x</span></footer>
-        </body></html>
-      HTML
-    end
-
-    it 'returns true for nodes under nav/footer chrome', :aggregate_failures do
-      expect(described_class.ignored_container_path?(document.at_css('#nav-link'))).to be(true)
-      expect(described_class.ignored_container_path?(document.at_css('#foot'))).to be(true)
-    end
-
-    it 'treats uppercase NAV as ignored chrome', :aggregate_failures do
-      document = Nokogiri::HTML('<html><body><NAV><a id="nav-link" href="/home">Home</a></NAV></body></html>')
-
-      expect(described_class.ignored_container_path?(document.at_css('#nav-link'))).to be(true)
-      expect(described_class.usable_card_parent?(document.at_css('NAV'))).to be(false)
-    end
-
-    it 'returns false for content nodes and memoizes via identity cache', :aggregate_failures do
-      cache = {}.compare_by_identity
-      node = document.at_css('#story')
-
-      expect(described_class.ignored_container_path?(node, cache)).to be(false)
-      expect(described_class.ignored_container_path?(node, cache)).to be(false)
-      expect(cache).to include(node)
     end
   end
 end

--- a/spec/lib/html2rss/html/probe_spec.rb
+++ b/spec/lib/html2rss/html/probe_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'nokogiri'
+
+RSpec.describe Html2rss::Html::Probe do
+  describe '.fold' do
+    it 'downcases wire strings' do
+      expect(described_class.fold('APPLICATION/LD+JSON')).to eq('application/ld+json')
+    end
+  end
+
+  describe '.tag' do
+    it 'returns the folded element name' do
+      node = Nokogiri::HTML('<DIV></DIV>').at_css('div')
+
+      expect(described_class.tag(node)).to eq('div')
+    end
+  end
+
+  describe '.mime_base' do
+    it 'strips parameters and folds MIME types' do
+      expect(described_class.mime_base('Application/Atom+xml; charset=utf-8')).to eq('application/atom+xml')
+    end
+  end
+
+  describe '.mime_match?' do
+    it 'matches canonical MIME types regardless of case' do
+      expect(described_class.mime_match?('APPLICATION/RSS+XML', 'application/rss+xml')).to be(true)
+    end
+
+    it 'matches MIME types with parameters' do
+      expect(described_class.mime_match?('application/atom+xml; charset=utf-8', 'application/atom+xml')).to be(true)
+    end
+
+    it 'rejects unrelated MIME types' do
+      expect(described_class.mime_match?('text/html', 'application/rss+xml')).to be(false)
+    end
+  end
+
+  describe '.scripts' do
+    let(:document) do
+      Nokogiri::HTML(<<~HTML)
+        <html>
+          <head>
+            <script type="text/javascript">console.log('skip')</script>
+            <script type="APPLICATION/LD+JSON">{"@type":"NewsArticle"}</script>
+            <script type="application/json">{"state":true}</script>
+          </head>
+        </html>
+      HTML
+    end
+
+    it 'returns scripts whose MIME type matches case-insensitively' do
+      scripts = described_class.scripts(document, described_class::APPLICATION_LD_JSON)
+
+      expect(scripts.map { |node| node['type'] }).to eq(['APPLICATION/LD+JSON'])
+    end
+
+    it 'returns all scripts when no MIME filter is given' do
+      expect(described_class.scripts(document).size).to eq(3)
+    end
+  end
+
+  describe '.alternate_links' do
+    let(:document) do
+      Nokogiri::HTML(<<~HTML)
+        <html>
+          <head>
+            <link rel="alternate" type="APPLICATION/JSON+OEMBED" href="/oembed.json">
+            <link rel="alternate" type="application/rss+xml" href="/feed.xml">
+            <link rel="canonical" href="https://example.com/">
+          </head>
+        </html>
+      HTML
+    end
+
+    it 'filters alternate links by rel and MIME type' do
+      links = described_class.alternate_links(document, rel: 'alternate',
+                                                        mime: described_class::APPLICATION_JSON_OEMBED)
+
+      expect(links.map { |node| node['href'] }).to eq(['/oembed.json'])
+    end
+
+    it 'returns all rel matches when mime is omitted' do
+      links = described_class.alternate_links(document, rel: 'alternate')
+
+      expect(links.map { |node| node['href'] }).to contain_exactly('/oembed.json', '/feed.xml')
+    end
+  end
+end

--- a/spec/lib/html2rss/html/probe_spec.rb
+++ b/spec/lib/html2rss/html/probe_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe Html2rss::Html::Probe do
 
       expect(described_class.tag(node)).to eq('div')
     end
+
+    it 'folds Symbol names from SST nodes' do
+      node = Struct.new(:name).new(:Header)
+
+      expect(described_class.tag(node)).to eq('header')
+    end
   end
 
   describe '.mime_base' do

--- a/spec/lib/html2rss/link_destination/path_classifier_spec.rb
+++ b/spec/lib/html2rss/link_destination/path_classifier_spec.rb
@@ -92,5 +92,13 @@ RSpec.describe Html2rss::LinkDestination::PathClassifier do
       expect(classifier.utility_path?).to be(false)
       expect(classifier.junk_path?).to be(false)
     end
+
+    it 'treats /News/ segments as content regardless of case', :aggregate_failures do
+      classifier = classifier_for('News', '2026', 'platform-launch-notes')
+
+      expect(classifier.content_path?).to be(true)
+      expect(classifier.utility_path?).to be(false)
+      expect(classifier.junk_path?).to be(false)
+    end
   end
 end

--- a/spec/lib/html2rss/sst/normalizer_spec.rb
+++ b/spec/lib/html2rss/sst/normalizer_spec.rb
@@ -35,6 +35,27 @@ RSpec.describe Html2rss::SST::Normalizer do
       expect(described_class.call(node).root.find { |n| n.name == :article }).not_to be_nil
     end
 
+    it 'normalizes HTML fragments from the first element child', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      fragment = Nokogiri::HTML.fragment('<article><a href="/p">Post</a></article>')
+      allow(Html2rss::Log).to receive(:warn)
+
+      doc = described_class.call(fragment)
+
+      expect(doc.root.name).to eq(:article)
+      expect(doc.root.find { |n| n.name == :a }).not_to be_nil
+      expect(Html2rss::Log).to have_received(:warn).with(/first element child/)
+    end
+
+    it 'normalizes script-only body nodes from the body root', :aggregate_failures do
+      body = Nokogiri::HTML('<html><body><script>evil()</script></body></html>').at_css('body')
+      allow(Html2rss::Log).to receive(:warn)
+
+      doc = described_class.call(body)
+
+      expect(doc.root.name).to eq(:body)
+      expect(Html2rss::Log).to have_received(:warn).with(/root fallback: self/)
+    end
+
     it 'degrades when MAX_NODES is breached', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
       stub_const('Html2rss::SST::Normalizer::MAX_NODES', 3)
       allow(Html2rss::Log).to receive(:warn)


### PR DESCRIPTION
## What changed

- Added `Html::Probe` as the single owner for case-insensitive DOM wire matching (MIME types, tag names, link relations); migrated schema, microdata, meta_oembed, native_feed, json_state, feed_link, and navigator call sites.
- Schema `@type` normalization uses frozen `CANONICAL_BY_DOWNCASE` plus scalar `canonicalize_type` / `EMPTY_TYPES`; Microdata itemtype path avoids `Set → to_a`.
- `PathClassifier` folds once into `@lexicon` and predicates index that array (no re-fold); cluster segmenter folds at comparison boundaries only.
- Auto-source quarantines operational scraper errors within a tier; `run_scraper` uses `instance.map`; Schema `#each` no longer builds a `filter_map` intermediate.
- SST normalizer: root discovery for fragments/minimal HTML, `EmptyTree`, skip non-elements, walk `element_children`, hoist typed-attr / ignored-container Sets.
- Cached `Probe.tag` in heading selection paths; deleted unused `Navigator#ignored_container_path?` and `CLUSTER_EXCLUDED_TAGS`; `Probe.tag` accepts Symbol node names (SST).

## Why

Sites emit mixed-case MIME types, schema.org `@type` prefixes, and path segments that defeat exact-match scrapers. Probe centralizes folding at decision boundaries. Operational quarantine keeps one bad scraper from aborting the whole tier. Follow-on work cut hot-path allocations introduced by that case-folding without changing the case-insensitive contracts.

## Benchmarks

Allocation probe (`GC.stat[:total_allocated_objects]`, N=500, same fixtures / Ruby via `mise`):

| Hot path | Before /call | After /call | Δ |
| --- | ---: | ---: | ---: |
| Probe `scripts` + `mime_match?` | 505.0 | 210.0 | **−58%** |
| PathClassifier predicates | 9.0 | 7.0 | −22% |
| Schema `normalize_types` | 22.0 | 21.0 | −5% |
| SST Normalizer (`page_1` fixture) | 57496.0 | 50887.0 | **−11%** |

## Risk

- Low — hardening is additive (case-insensitivity, quarantine, root fallback); exact-case inputs still match.
- SST root fallback warns on non-standard trees; empty documents raise `EmptyTree` (rescued on Html scraper probe paths).
- Schema canonicalization may admit previously unmatched mixed-case `@type` values — intended.
- Internal API shrink: removed unused Navigator helpers (no CLI/MCP contract change).

## Review map

1. `spec/lib/html2rss/html/probe_spec.rb` — case-insensitive MIME/tag/scripts contract
2. `spec/lib/html2rss/auto_source_spec.rb` — operational quarantine within a tier
3. `lib/html2rss/html/probe.rb` — fold/tag/mime fast paths and script filtering
4. `lib/html2rss/link_destination/path_classifier.rb` — `@lexicon` reuse (no `folded_segment`)
5. `lib/html2rss/auto_source/scraper/schema.rb` — canonicalize + `#each` without double collect
6. `lib/html2rss/sst/normalizer.rb` — root fallback, element walk, degrade guard
7. `lib/html2rss/auto_source.rb` — `OPERATIONAL_ERRORS` quarantine + `map`

## Validation

- `make ready` — pass (RuboCop, yard-lint, schema sync, shellcheck, full RSpec; 1867 examples, 0 failures)