### PR TITLE
chore(release): bump version to v0.29.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    html2rss (0.28.0)
+    html2rss (0.29.1)
       addressable (~> 2.7)
       brotli
       dry-validation
@@ -291,7 +291,7 @@ CHECKSUMS
   faraday-gzip (3.1.0) sha256=320783690be169f9b7ddde11598b77156951343753f66a9ab98b1f6694433ff8
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   hana (1.3.7) sha256=5425db42d651fea08859811c29d20446f16af196308162894db208cac5ce9b0d
-  html2rss (0.28.0)
+  html2rss (0.29.1)
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a

--- a/lib/html2rss/version.rb
+++ b/lib/html2rss/version.rb
@@ -2,6 +2,6 @@
 
 module Html2rss
   # Current application version.
-  VERSION = '0.28.0'
+  VERSION = '0.29.1'
   public_constant :VERSION
 end


### PR DESCRIPTION
Automated version bump to `v0.29.1`.

This PR contains the version update in `lib/html2rss/version.rb` and regenerated schema.

### 🚀 Next Steps
1. Verify that all CI checks pass.
2. Merge this Pull Request.
3. Go to the draft release on GitHub and publish it.