### PR TITLE
refactor(request_service): modernize HTTPX transport and purify strategy architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Most people looking for a first working feed should start with `html2rss-web`, r
 Detailed usage guides, reference docs, and the feed directory live on the project website:
 
 - [Ruby gem documentation](https://html2rss.github.io/ruby-gem)
-- [Request strategies](https://html2rss.github.io/ruby-gem/reference/strategy) (`auto` = `faraday` → `botasaurus`; or pin concrete strategies)
+- [Request strategies](https://html2rss.github.io/ruby-gem/reference/strategy) (`auto` = `default` → `botasaurus`; or pin concrete strategies)
 - [Selectors & pagination](https://html2rss.github.io/ruby-gem/reference/selectors#paginated-feeds)
 - [Web application](https://html2rss.github.io/web-application)
 - [Feed directory](https://html2rss.github.io/feed-directory)
@@ -26,7 +26,7 @@ Cloud development: [Open in GitHub Codespaces](https://github.com/codespaces/new
 ## Architecture
 
 1. **Config** — loads and validates configuration (YAML/hash); schema via `html2rss schema` / `schema/html2rss-config.schema.json`
-2. **RequestService** — fetches pages (`faraday`, `botasaurus`, or `local_file`)
+2. **RequestService** — fetches pages (`default` (HTTPX), `botasaurus`, or `local_file`)
 3. **Selectors** — extracts content via CSS selectors with extractors/post-processors
 4. **AutoSource** — auto-detects content (Schema.org, JSON state, semantic HTML, structural patterns)
 5. **FeedBuilder** — assembles Article objects and renders feeds (RSS 2.0 / JSON Feed 1.1)
@@ -157,7 +157,7 @@ Module guide: [`lib/html2rss/mcp/README.md`](lib/html2rss/mcp/README.md).
 | ----------------------- | --------------------------------------------------------------- |
 | `html2rss://schema`     | Full JSON Schema for feed configurations                        |
 | `html2rss://extractors` | Registered extractor **names** (options live in schema `$defs`) |
-| `html2rss://strategies` | Published MCP strategies (`auto`, `faraday`, `botasaurus`)      |
+| `html2rss://strategies` | Published MCP strategies (`auto`, `default`, `httpx`, `botasaurus`)      |
 | `html2rss://runtime`    | `version`, `mcp_contract_version`, `catalog_fingerprint`, `tools`, `botasaurus_configured` (never the scraper URL) |
 
 ### Prompts
@@ -183,11 +183,11 @@ Set `BOTASAURUS_SCRAPER_URL` to `http://127.0.0.1:4010` and use strategy `botasa
 
 | Strategy     | Description                                                                 |
 | ------------ | --------------------------------------------------------------------------- |
-| `auto`       | Tries `faraday`, falls back to `botasaurus` (default in gem/CLI/MCP scrape) |
-| `faraday`    | Plain HTTP requests via Faraday                                             |
+| `auto`       | Tries `default`, falls back to `botasaurus` (default in gem/CLI/MCP scrape) |
+| `default`    | Plain HTTP requests via HTTPX (alias: `httpx`; legacy: `faraday`)           |
 | `botasaurus` | Puppeteer-backed scraping for JavaScript pages                              |
 
-`inspect` keeps Faraday when `auto` for cheap diagnostics. Elsewhere, strategy can be set via CLI (`--strategy`), gem API keyword argument, or feed config `request.strategy`. See the [request strategies docs](https://html2rss.github.io/ruby-gem/reference/strategy) for more details.
+`inspect` keeps `default` when `auto` for cheap diagnostics. Elsewhere, strategy can be set via CLI (`--strategy`), gem API keyword argument, or feed config `strategy`. See the [request strategies docs](https://html2rss.github.io/ruby-gem/reference/strategy) for more details.
 
 ## License
 

--- a/lib/html2rss.rb
+++ b/lib/html2rss.rb
@@ -33,7 +33,7 @@ module Html2rss # rubocop:disable Metrics/ModuleLength
   # Golden path step 1 (optional); use {.recon} for verdict and native_feed.
   #
   # @param url [String] source page URL
-  # @param strategy [Symbol] request strategy (:auto, :faraday, :botasaurus)
+  # @param strategy [Symbol] request strategy (:auto, :default, :botasaurus)
   # @param deep [Boolean] when true and strategy is :auto, one Botasaurus hop if configured
   # @return [Html2rss::PageRecon::Diagnostics::Report]
   def self.inspect(url, strategy: :auto, deep: false, **)
@@ -45,7 +45,7 @@ module Html2rss # rubocop:disable Metrics/ModuleLength
   # Golden path step 2 (optional); adds verdict beyond {.inspect}.
   #
   # @param url [String, Html2rss::Url] source page URL
-  # @param strategy [Symbol] request strategy (:auto, :faraday, :botasaurus)
+  # @param strategy [Symbol] request strategy (:auto, :default, :botasaurus)
   # @return [Html2rss::Recon::Result]
   def self.recon(url, strategy: :auto, **)
     Recon.call(url, strategy:, **)
@@ -56,7 +56,7 @@ module Html2rss # rubocop:disable Metrics/ModuleLength
   # Golden path step 3.
   #
   # @param url [String] source page URL
-  # @param strategy [Symbol] request strategy (+:auto+, +:faraday+, +:botasaurus+)
+  # @param strategy [Symbol] request strategy (+:auto+, +:default+, +:botasaurus+)
   # @option options [String, nil] :items_selector optional CSS selector hint for items
   # @option options [Array<String>, nil] :topics optional directory topics override
   # @option options [String, nil] :title optional title override
@@ -140,7 +140,7 @@ module Html2rss # rubocop:disable Metrics/ModuleLength
   # Scrapes multiple URLs in parallel using auto-source article discovery.
   #
   # @param urls [Enumerable<String>] list of URLs to scrape
-  # @param strategy [Symbol] request strategy (:auto, :faraday, :botasaurus)
+  # @param strategy [Symbol] request strategy (:auto, :default, :botasaurus)
   # @param limit [Integer] max articles to keep per URL (default: 10)
   # @param concurrency [Integer] max worker threads (default: 5)
   # @return [Html2rss::Batch::BatchResult]
@@ -152,7 +152,7 @@ module Html2rss # rubocop:disable Metrics/ModuleLength
   # Inspects multiple URLs in parallel with per-URL error isolation.
   #
   # @param urls [Enumerable<String>] list of URLs to inspect
-  # @param strategy [Symbol] request strategy (:auto, :faraday, :botasaurus)
+  # @param strategy [Symbol] request strategy (:auto, :default, :botasaurus)
   # @param concurrency [Integer] max worker threads (default: 5)
   # @return [Html2rss::Batch::BatchResult]
   def self.batch_inspect(urls, strategy: :auto, concurrency: Batch::DEFAULT_CONCURRENCY)
@@ -163,7 +163,7 @@ module Html2rss # rubocop:disable Metrics/ModuleLength
   # Runs recon across multiple URLs in parallel with per-URL error isolation.
   #
   # @param urls [Enumerable<String>] list of URLs to recon
-  # @param strategy [Symbol] request strategy (:auto, :faraday, :botasaurus)
+  # @param strategy [Symbol] request strategy (:auto, :default, :botasaurus)
   # @param concurrency [Integer] max worker threads (default: 5)
   # @option options [String, nil] :cache_dir optional HTML cache directory
   # @return [Html2rss::Batch::BatchResult]

--- a/lib/html2rss/batch.rb
+++ b/lib/html2rss/batch.rb
@@ -77,7 +77,7 @@ module Html2rss
       # Scrapes multiple URLs in parallel with per-URL error isolation.
       #
       # @param urls [Enumerable<String>] list of URLs to scrape
-      # @param strategy [Symbol, String] request strategy (+:auto+, +:faraday+, +:botasaurus+)
+      # @param strategy [Symbol, String] request strategy (+:auto+, +:default+, +:botasaurus+)
       # @param limit [Integer] max articles to extract per URL
       # @param concurrency [Integer] number of worker threads (default 5, max 10)
       # @return [BatchResult]
@@ -89,7 +89,7 @@ module Html2rss
       # Inspects multiple URLs in parallel with per-URL error isolation.
       #
       # @param urls [Enumerable<String>] list of URLs to inspect
-      # @param strategy [Symbol, String] request strategy (+:auto+, +:faraday+, +:botasaurus+)
+      # @param strategy [Symbol, String] request strategy (+:auto+, +:default+, +:botasaurus+)
       # @param concurrency [Integer] number of worker threads (default 5, max 10)
       # @return [BatchResult]
       def batch_inspect(urls:, strategy: :auto, concurrency: DEFAULT_CONCURRENCY)
@@ -104,7 +104,7 @@ module Html2rss
       # Runs recon across multiple URLs in parallel with per-URL error isolation.
       #
       # @param urls [Enumerable<String>] list of URLs to recon
-      # @param strategy [Symbol, String] request strategy (+:auto+, +:faraday+, +:botasaurus+)
+      # @param strategy [Symbol, String] request strategy (+:auto+, +:default+, +:botasaurus+)
       # @param concurrency [Integer] number of worker threads (default 5, max 10)
       # @option options [String, nil] :cache_dir optional HTML cache directory
       # @return [BatchResult]

--- a/lib/html2rss/capture.rb
+++ b/lib/html2rss/capture.rb
@@ -75,7 +75,7 @@ module Html2rss
       # Analyzes a URL and builds a reusable feed config.
       #
       # @param url [String] source page URL
-      # @param strategy [Symbol] request strategy (+:auto+, +:faraday+, +:botasaurus+)
+      # @param strategy [Symbol] request strategy (+:auto+, +:default+, +:botasaurus+)
       # @option options [String, nil] :items_selector optional selector hint
       # @option options [Array<String>, nil] :topics optional directory topics override
       # @option options [String, nil] :title optional title override

--- a/lib/html2rss/capture/README.md
+++ b/lib/html2rss/capture/README.md
@@ -40,7 +40,7 @@ Html2rss.capture('https://example.com', strategy: :local_file, local_file_path: 
 Html2rss.capture('https://example.com', max_redirects: 8, max_requests: 4)
 ```
 
-`strategy: :auto` uses the same AutoFallback chain as scrape (`faraday` → `botasaurus`). When AutoFallback selects a concrete strategy (or you pin one), Capture **stamps** `strategy:` into the emitted config so later `Html2rss.apply(config)` replays the same transport.
+`strategy: :auto` uses the same AutoFallback chain as scrape (`default` → `botasaurus`). When AutoFallback selects a concrete strategy (or you pin one), Capture **stamps** `strategy:` into the emitted config so later `Html2rss.apply(config)` replays the same transport.
 
 ## CLI
 

--- a/lib/html2rss/config/request_headers.rb
+++ b/lib/html2rss/config/request_headers.rb
@@ -32,6 +32,9 @@ module Html2rss
         'User-Agent' => DEFAULT_USER_AGENT
       }.freeze
 
+      # Hop-by-hop headers forbidden in HTTP/2 requests (RFC 7540 §8.1.2.2 / RFC 9113 §8.2.1).
+      FORBIDDEN_H2_HEADERS = %w[connection keep-alive proxy-connection transfer-encoding upgrade].to_set.freeze
+
       class << self
         ##
         # :reek:ManualDispatch
@@ -74,7 +77,7 @@ module Html2rss
       ##
       # @return [Hash{String => String}] normalized HTTP headers
       def to_h
-        defaults = DEFAULT_HEADERS.dup
+        defaults = self.class.browser_defaults
         normalized = normalize_custom_headers(headers)
 
         accept_override = normalized.delete('Accept')
@@ -83,6 +86,7 @@ module Html2rss
         defaults['Accept'] = normalize_accept(accept_override)
         defaults['Accept-Language'] = build_accept_language
 
+        defaults.reject! { |key, _| FORBIDDEN_H2_HEADERS.include?(key.downcase) }
         defaults.compact
       end
 

--- a/lib/html2rss/feed_pipeline/README.md
+++ b/lib/html2rss/feed_pipeline/README.md
@@ -2,25 +2,25 @@
 
 `:auto` is the default request plan for feed builds (`auto_source`, `auto_json_feed`, Capture, and MCP `scrape` / `capture`). `FeedPipeline::StrategyPlan` resolves it; `FeedPipeline::AutoFallback` executes `AutoFallback::CHAIN`.
 
-Use `:auto` when you want Faraday first and a browser-backed hop only if that fetch fails or yields zero items. Pin a concrete strategy (`faraday`, `botasaurus`, `local_file`) when you need a single transport.
+Use `:auto` when you want `default` (HTTPX) first and a browser-backed hop only if that fetch fails or yields zero items. Pin a concrete strategy (`default`, `botasaurus`, `local_file`) when you need a single transport.
 
 ## Chain
 
 `AutoFallback::CHAIN` is:
 
-1. **Faraday** — plain HTTP (faster, cheaper).
-2. **Botasaurus** — attempted when Faraday raises a fallback-eligible error (for example `BlockedSurfaceDetected` or timeout) or extracts zero feed items.
+1. **Default (HTTPX)** — plain HTTP (faster, cheaper).
+2. **Botasaurus** — attempted when default raises a fallback-eligible error (for example `BlockedSurfaceDetected` or timeout) or extracts zero feed items.
 
-Before escalating Faraday → Botasaurus on a **weak** auto-source extract (empty / below floor / high-entropy / app-shell / unsupported — not blocked), `FeedResolution` may probe up to five same-origin listing or native-feed candidates and rewrite the effective scrape URL via {ScrapeTarget}. Botasaurus then uses the resolved URL. Direct RSS/Atom entry URLs are parsed via `Syndication::Parser` without HTML AutoSource.
+Before escalating default → Botasaurus on a **weak** auto-source extract (empty / below floor / high-entropy / app-shell / unsupported — not blocked), `FeedResolution` may probe up to five same-origin listing or native-feed candidates and rewrite the effective scrape URL via {ScrapeTarget}. Botasaurus then uses the resolved URL. Direct RSS/Atom entry URLs are parsed via `Syndication::Parser` without HTML AutoSource.
 
-There is no Browserless / Puppeteer-in-gem tier. Pin `botasaurus` when you want browser rendering without Faraday first. Botasaurus needs `BOTASAURUS_SCRAPER_URL`.
+There is no Browserless / Puppeteer-in-gem tier. Pin `botasaurus` when you want browser rendering without default first. Botasaurus needs `BOTASAURUS_SCRAPER_URL`.
 
 ## Surfaces
 
 | Surface                                  | `:auto` behavior                                                                                                                   |
 | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| Gem / CLI `apply`, MCP `scrape`, Capture | Full AutoFallback chain (`faraday` → `botasaurus`)                                                                                 |
-| MCP `inspect`                            | Cheap diagnostic: `StrategyPlan.concrete_for_diagnostic` maps `auto` to Faraday (pin `botasaurus` when you need browser rendering) |
+| Gem / CLI `apply`, MCP `scrape`, Capture | Full AutoFallback chain (`default` → `botasaurus`)                                                                                 |
+| MCP `inspect`                            | Cheap diagnostic: `StrategyPlan.concrete_for_diagnostic` maps `auto` to default (pin `botasaurus` when you need browser rendering) |
 
 ## Fallback vs abort
 
@@ -28,7 +28,7 @@ These typically hop to the next chain member (among other `StandardError`s `Auto
 
 - `Html2rss::RequestService::BlockedSurfaceDetected`
 - `Html2rss::RequestService::RequestTimedOut`
-- Faraday connection / timeout errors
+- HTTPX connection / timeout errors
 - Empty extraction results when a later chain member may succeed
 
 These abort immediately (`AutoFallback::NON_FALLBACK_ERRORS`): unknown strategy, invalid URL, unsupported scheme, budget exceeded, private network denied, cross-origin follow-up denied, response too large.

--- a/lib/html2rss/mcp/README.md
+++ b/lib/html2rss/mcp/README.md
@@ -20,7 +20,7 @@ Batch: `batch_inspect`, `batch_recon`, `batch_scrape`.
 
 ## Decision tree
 
-1. **Articles now (no saved config)?** → `scrape` (or `batch_scrape` for multiple URLs). `strategy: "auto"` runs Faraday → Botasaurus; do not retry with explicit `faraday` after `auto`.
+1. **Articles now (no saved config)?** → `scrape` (or `batch_scrape` for multiple URLs). `strategy: "auto"` runs default (HTTPX) → Botasaurus; do not retry with explicit `default` after `auto`.
 2. **Reusable feed YAML?** → `capture` → `test` → `apply`. `capture` returns YAML in `payload.yaml`. Strive `enhance: true` (false only when chrome leaks). `test` runs schema + live extraction; optional `compare_enhance` compares enhance off vs on. `apply` is the ship gate (`isError` on zero items). Both `test` and `apply` may include `quality_report.enhance_gains` when `selectors.items.enhance` is true.
 3. **Weak scrape/capture or recon?** → `inspect` (or `batch_inspect`). When alternates warrant it, follow `next_step` to `recon`.
 4. **Config already in hand?** → `validate` (schema only) → `test` → `apply`.
@@ -61,7 +61,7 @@ Do not duplicate playbook prose in `server.rb`.
 | ----------------------- | ---------------------------------------------------------- |
 | `html2rss://schema`     | Full JSON Schema for feed configurations                   |
 | `html2rss://extractors` | Registered extractor names                                 |
-| `html2rss://strategies` | Published MCP strategies (`auto`, `faraday`, `botasaurus`) |
+| `html2rss://strategies` | Published MCP strategies (`auto`, `default`, `httpx`, `botasaurus`) |
 | `html2rss://runtime`    | `version`, `mcp_contract_version`, `catalog_fingerprint`, `tools`, `botasaurus_configured` (never the scraper URL). Fingerprint covers tool names, required keys, and `oneOf` branches; bump `mcp_contract_version` for envelope semantics. |
 
 ## Prompts
@@ -73,7 +73,7 @@ Do not duplicate playbook prose in `server.rb`.
 
 ## Strategy note
 
-`scrape` / `capture` with `strategy: "auto"` run the full AutoFallback chain. `inspect` maps `auto` to Faraday for cheap diagnostics; pin `botasaurus` when you need browser rendering for inspect.
+`scrape` / `capture` with `strategy: "auto"` run the full AutoFallback chain. `inspect` maps `auto` to default (HTTPX) for cheap diagnostics; pin `botasaurus` when you need browser rendering for inspect.
 
 ## Inspect redirects
 

--- a/lib/html2rss/mcp/contract.rb
+++ b/lib/html2rss/mcp/contract.rb
@@ -9,7 +9,11 @@ module Html2rss
     # annotations, and the single compact JSON envelope response.
     module Contract # rubocop:disable Metrics/ModuleLength -- published listing constants stay co-located
       # Published MCP request strategies (excludes +local_file+).
-      STRATEGIES = %w[auto default httpx botasaurus faraday].freeze
+      STRATEGIES = %w[auto default httpx botasaurus].freeze
+      # Accepted migration strategies retained for backwards compatibility.
+      MIGRATION_STRATEGIES = %w[faraday].freeze
+      # Complete set of strategies accepted by {.assert_published_request!}.
+      ALL_ACCEPTED_STRATEGIES = (STRATEGIES + MIGRATION_STRATEGIES).freeze
 
       # Bump when tool names, required inputs, or envelope semantics change (independent of gem +VERSION+).
       MCP_CONTRACT_VERSION = 2
@@ -281,7 +285,7 @@ module Html2rss
         #   or +request.local_file_path+ is present
         def assert_published_request!(config)
           strategy = config[:strategy]
-          unless strategy.nil? || STRATEGIES.include?(strategy.to_s)
+          unless strategy.nil? || ALL_ACCEPTED_STRATEGIES.include?(strategy.to_s)
             raise UnpublishedRequestError,
                   "MCP does not accept strategy #{strategy} (published: #{STRATEGIES.join(', ')})"
           end

--- a/lib/html2rss/mcp/outcome/playbook.rb
+++ b/lib/html2rss/mcp/outcome/playbook.rb
@@ -36,7 +36,7 @@ module Html2rss
               html2rss MCP — decide which tool to call:
 
               1. Need articles now (no saved config)? → scrape (or batch_scrape for multiple)
-                 - strategy "auto" runs Faraday → Botasaurus AutoFallback. Do not retry with explicit faraday after auto.
+                 - strategy "auto" runs default (HTTPX) → Botasaurus AutoFallback. Do not retry with explicit default after auto.
                  - Empty scrape is still success (articles-now). Follow next_step / guidance (read_runtime if Botasaurus unset).
               2. Need a reusable feed YAML? → capture → test → apply
                  - capture returns YAML inside payload.yaml. Draft only: if destination is html2rss-configs, rewrite for directory.topics and explicit channel title/url. Default enhance follows capture evidence (false when admission_drops show chrome); override only when needed.
@@ -58,9 +58,9 @@ module Html2rss
           # @return [String]
           def scrape_webpage_prompt(url)
             <<~MSG.strip
-              Scrape #{url} with scrape (strategy auto). One call is enough — auto already runs Faraday then Botasaurus.
+              Scrape #{url} with scrape (strategy auto). One call is enough — auto already runs default then Botasaurus.
               Follow envelope next_step and guidance. Call inspect only if articles are empty/weak or you need diagnostics (final_url, status, scheme_downgrade, alternate_feeds). When inspect finds alternates, follow next_step to recon.
-              Do not retry scrape with explicit faraday after auto. Read html2rss://runtime if next_step is read_runtime.
+              Do not retry scrape with explicit default after auto. Read html2rss://runtime if next_step is read_runtime.
               Return payload.items (not a raw JSON array).
             MSG
           end
@@ -72,7 +72,7 @@ module Html2rss
             <<~MSG.strip
               Build a reusable html2rss feed config for #{url}:
               1) capture — YAML is payload.yaml. Check payload.articles_count, payload.has_selectors, and payload.suggested_channel_url. enhance defaults from admission evidence (false when chrome drops are high). When payload.native_feed is set, follow next_step (done — use the native feed).
-              2) Follow next_step. If weak or you need recon, inspect then recon when alternates warrant it. Auto already hops to Botasaurus; do not retry capture with botasaurus unless Faraday was blocked.
+              2) Follow next_step. If weak or you need recon, inspect then recon when alternates warrant it. Auto already hops to Botasaurus; do not retry capture with botasaurus unless default was blocked.
               3) test with yaml (or config hash) — schema + live extraction. On :schema failure, validate; on :execution/:min_items, recapture. Read payload.quality_report.enhance_gains when enhance is on; optional compare_enhance compares enhance off vs on without changing shipped RSS.
               4) apply — isError if zero items. Confirm payload.item_count and payload.quality_report (including enhance_gains) before shipping.
               If the destination is html2rss-configs, rewrite the draft for directory.topics and explicit channel title/url. Return YAML.
@@ -95,7 +95,7 @@ module Html2rss
             if data[:blocked_surface] || data[:surface_category].to_s == 'blocked_surface'
               return 'Blocked or anti-bot interstitial likely. Retry scrape with strategy botasaurus once ' \
                      '(or CLI inspect --deep when BOTASAURUS_SCRAPER_URL is set). ' \
-                     'Do not retry explicit faraday after auto.'
+                     'Do not retry explicit default after auto.'
             end
             if data[:likely_js_shell]
               return 'JS-rendered shell likely (html_present, zero articles). Use strategy auto or botasaurus; ' \

--- a/lib/html2rss/mcp/server.rb
+++ b/lib/html2rss/mcp/server.rb
@@ -10,7 +10,7 @@ module Html2rss
     # This module maps MCP kwargs to those APIs, then {Outcome} + {Contract} shape the envelope.
     #
     # Strategy note: MCP +auto+ passes through to FeedPipeline AutoFallback
-    # (faraday → botasaurus). Concrete strategies are used as-is.
+    # (default → botasaurus). Concrete strategies are used as-is.
     # Botasaurus requires +BOTASAURUS_SCRAPER_URL+.
     module Server # rubocop:disable Metrics/ModuleLength
       # MCP server display name.

--- a/lib/html2rss/mcp/server/tools.rb
+++ b/lib/html2rss/mcp/server/tools.rb
@@ -13,7 +13,7 @@ module Html2rss
             kind: :url,
             description: 'One-shot article extraction as JSON Feed items. ' \
                          'Use when you need articles now without a saved config. ' \
-                         'strategy "auto" triggers fallback chain (faraday → botasaurus) for JS-rendered sites.',
+                         'strategy "auto" triggers fallback chain (default → botasaurus) for JS-rendered sites.',
             input_schema: Contract::SCRAPE_INPUT_SCHEMA,
             handler: :scrape_outcome
           },

--- a/lib/html2rss/recon.rb
+++ b/lib/html2rss/recon.rb
@@ -111,7 +111,7 @@ module Html2rss
     # Runs reconnaissance on a single URL.
     #
     # @param url [String, Html2rss::Url] source page URL
-    # @param strategy [Symbol] request strategy (:auto, :faraday, :botasaurus)
+    # @param strategy [Symbol] request strategy (:auto, :default, :botasaurus)
     # @param cache_dir [String, nil] optional directory to cache raw HTML bodies
     # @param cache_mutex [Mutex, nil] optional mutex serializing cache writes
     # @option options [Integer, nil] :max_redirects optional maximum redirects

--- a/lib/html2rss/request_service.rb
+++ b/lib/html2rss/request_service.rb
@@ -1,18 +1,13 @@
 # frozen_string_literal: true
 
-require 'singleton'
-require 'forwardable'
-
 module Html2rss
   ##
   # Requests website URLs to retrieve their HTML for further processing.
-  # Provides concrete transport strategies (e.g. Faraday, Botasaurus).
+  # Provides concrete transport strategies (e.g. HttpxStrategy, BotasaurusStrategy).
   #
   # Feed-level +:auto+ is not registered here — {FeedPipeline::StrategyPlan} resolves
   # it to a concrete strategy (or {FeedPipeline::AutoFallback} chain) before execute.
   class RequestService
-    include Singleton
-
     # Raised when an unknown request strategy is requested.
     class UnknownStrategy < Html2rss::Error; end
     # Raised when a URL cannot be parsed or validated.
@@ -59,118 +54,60 @@ module Html2rss
     # Raised when Botasaurus responds but the scrape fails (upstream error, bad payload).
     class BotasaurusServiceError < Html2rss::Error; end
 
-    class << self
-      extend Forwardable
-
-      %i[default_strategy_name
-         default_strategy_name=
-         strategy_names
-         register_strategy
-         unregister_strategy
-         strategy_registered?
-         execute].each do |method|
-        def_delegator :instance, method
-      end
-    end
-
-    # Canonical strategy mappings for deprecated strategy names.
-    DEPRECATED_STRATEGIES = {
-      faraday: :default,
-      httpx: :default
+    # Map of supported strategy names to their implementation classes.
+    # @return [Hash{Symbol => Class<Strategy>}]
+    STRATEGIES = {
+      default: HttpxStrategy,
+      httpx: HttpxStrategy,
+      faraday: HttpxStrategy,
+      botasaurus: BotasaurusStrategy,
+      local_file: LocalFileStrategy
     }.freeze
-    private_constant :DEPRECATED_STRATEGIES
 
-    def initialize
-      @strategies = {
-        default: HttpxStrategy,
-        httpx: HttpxStrategy,
-        faraday: HttpxStrategy,
-        botasaurus: BotasaurusStrategy,
-        local_file: LocalFileStrategy
-      }
-      @default_strategy_name = :default
-    end
+    # Canonical default strategy symbol.
+    # @return [Symbol]
+    DEFAULT_STRATEGY_NAME = :default
 
-    # @return [Symbol] the default strategy name
-    attr_reader :default_strategy_name
+    class << self
+      # @return [Symbol] the default strategy name
+      def default_strategy_name = DEFAULT_STRATEGY_NAME
 
-    ##
-    # Sets the default strategy.
-    # @param strategy [Symbol] the name of the strategy
-    # @return [Symbol] the selected default strategy name
-    # @raise [UnknownStrategy] if the strategy is not registered
-    def default_strategy_name=(strategy)
-      raise UnknownStrategy unless strategy_registered?(strategy)
+      # @return [Array<String>] the names of the registered strategies
+      def strategy_names = STRATEGIES.keys.map(&:to_s)
 
-      warn_deprecated_strategy(strategy)
-      @default_strategy_name = strategy.to_sym
-    end
-
-    # @return [Array<String>] the names of the registered strategies
-    def strategy_names = @strategies.keys.map(&:to_s)
-
-    ##
-    # Registers a new strategy.
-    # @param name [Symbol] the name of the strategy
-    # @param strategy_class [Class] the class implementing the strategy
-    # @return [Class] the registered strategy class
-    # @raise [ArgumentError] if strategy_class is not a Class
-    def register_strategy(name, strategy_class)
-      unless strategy_class.is_a?(Class)
-        raise ArgumentError, "Expected a Class for strategy, got #{strategy_class.class}"
+      ##
+      # Checks if a strategy is registered.
+      # @param name [Symbol, String] the name of the strategy
+      # @return [Boolean] true if the strategy is registered, false otherwise.
+      def strategy_registered?(name)
+        STRATEGIES.key?(name.to_sym)
       end
 
-      @strategies[name.to_sym] = strategy_class
-    end
+      ##
+      # Executes the request using the specified strategy.
+      # @param ctx [Context] the context for the request.
+      # @param strategy [Symbol, String] the strategy to use (defaults to the default strategy).
+      # @return [Response] the response from the executed strategy.
+      # @raise [UnknownStrategy] if the strategy is not registered.
+      def execute(ctx, strategy: default_strategy_name)
+        strategy_sym = strategy.to_sym
+        strategy_class = STRATEGIES.fetch(strategy_sym) do
+          raise UnknownStrategy,
+                "The strategy '#{strategy}' is not known. Available strategies: #{strategy_names.join(', ')}"
+        end
 
-    ##
-    # Checks if a strategy is registered.
-    # @param name [Symbol] the name of the strategy
-    # @return [Boolean] true if the strategy is registered, false otherwise.
-    def strategy_registered?(name)
-      @strategies.key?(name.to_sym)
-    end
-
-    ##
-    # Unregisters a strategy.
-    # @param name [Symbol] the name of the strategy
-    # @return [Boolean] true if the strategy was unregistered, false otherwise.
-    # @raise [ArgumentError] if attempting to unregister the default strategy.
-    def unregister_strategy(name) # rubocop:disable Naming/PredicateMethod
-      name_sym = name.to_sym
-      raise ArgumentError, 'Cannot unregister the default strategy.' if name_sym == @default_strategy_name
-
-      !!@strategies.delete(name_sym)
-    end
-
-    ##
-    # Executes the request using the specified strategy.
-    # @param ctx [Context] the context for the request.
-    # @param strategy [Symbol] the strategy to use (defaults to the default strategy).
-    # @return [Response] the response from the executed strategy.
-    # @raise [ArgumentError] if the context is nil.
-    # @raise [UnknownStrategy] if the strategy is not registered.
-    def execute(ctx, strategy: default_strategy_name)
-      strategy_sym = strategy.to_sym
-      strategy_class = @strategies.fetch(strategy_sym) do
-        raise UnknownStrategy,
-              "The strategy '#{strategy}' is not known. Available strategies: #{strategy_names.join(', ')}"
+        warn_migration_strategy(strategy_sym) if strategy_sym == :faraday
+        strategy_class.new(ctx).execute
       end
 
-      warn_deprecated_strategy(strategy_sym)
-      strategy_class.new(ctx).execute
-    end
+      private
 
-    private
-
-    def warn_deprecated_strategy(strategy)
-      canonical = DEPRECATED_STRATEGIES[strategy.to_sym]
-      return unless canonical
-
-      message = "RequestService: strategy ':#{strategy}' is deprecated and will be removed in a future release. " \
-                "Use ':#{canonical}' instead."
-      warn(message, category: :deprecated)
-      Log.warn(message)
+      def warn_migration_strategy(strategy)
+        message = "RequestService: strategy ':#{strategy}' is deprecated for migration and will be removed " \
+                  "in a future release. Use ':default' instead."
+        warn(message, category: :deprecated)
+        Log.warn(message)
+      end
     end
   end
 end

--- a/lib/html2rss/request_service/botasaurus_strategy.rb
+++ b/lib/html2rss/request_service/botasaurus_strategy.rb
@@ -99,10 +99,7 @@ module Html2rss
       end
 
       def post_headers(request_id)
-        {
-          'Content-Type' => 'application/json',
-          REQUEST_ID_HEADER => request_id
-        }
+        { 'Content-Type' => 'application/json', REQUEST_ID_HEADER => request_id }
       end
 
       def attempt_timeout_seconds
@@ -126,6 +123,10 @@ module Html2rss
       def translate_connection_error(error)
         raise BotasaurusConnectionFailed, "Botasaurus connection failed: #{error.message}"
       end
+
+      def timeout_error?(error) = error.is_a?(HTTPX::TimeoutError) || super
+
+      def connection_error?(error) = error.is_a?(HTTPX::ConnectionError) || error.is_a?(HTTPX::TLSError) || super
     end
   end
 end

--- a/lib/html2rss/request_service/compressed_body.rb
+++ b/lib/html2rss/request_service/compressed_body.rb
@@ -49,20 +49,14 @@ module Html2rss
           return raw unless raw.start_with?(GZIP_MAGIC)
 
           uncompress_gzip(raw)
-        when 'deflate' then inflate_deflate(raw)
         when 'br' then try_brotli(raw, require_html: false)
+        when 'deflate' then inflate_deflate(raw)
         end
       rescue Zlib::Error, Brotli::Error, ArgumentError
         nil
       end
       module_function :inflate
       private_class_method :inflate
-
-      def uncompress_gzip(raw)
-        Zlib::GzipReader.wrap(StringIO.new(raw), encoding: 'ASCII-8BIT', &:read)
-      end
-      module_function :uncompress_gzip
-      private_class_method :uncompress_gzip
 
       def inflate_deflate(raw)
         inflater = nil
@@ -75,6 +69,14 @@ module Html2rss
       end
       module_function :inflate_deflate
       private_class_method :inflate_deflate
+
+      def uncompress_gzip(raw)
+        Zlib::GzipReader.wrap(StringIO.new(raw), encoding: 'ASCII-8BIT', &:read)
+      rescue Zlib::Error
+        nil
+      end
+      module_function :uncompress_gzip
+      private_class_method :uncompress_gzip
 
       def try_brotli(raw, require_html: true)
         inflated = Brotli.inflate(raw)

--- a/lib/html2rss/request_service/httpx_strategy.rb
+++ b/lib/html2rss/request_service/httpx_strategy.rb
@@ -4,6 +4,9 @@ require 'httpx'
 require 'httpx/plugins/follow_redirects'
 require 'httpx/plugins/callbacks'
 require 'httpx/plugins/ssrf_filter'
+require 'httpx/plugins/brotli'
+require 'httpx/plugins/fiber_concurrency'
+require 'httpx/plugins/retries'
 
 module Html2rss
   class RequestService
@@ -13,16 +16,17 @@ module Html2rss
     # and redirect handling without monkey-patching.
     # rubocop:disable-next Metrics/ClassLength -- terminal redirect retry colocated with HTTPX transport
     class HttpxStrategy < Strategy
-      # Hop-by-hop headers forbidden in HTTP/2 requests (RFC 7540 §8.1.2.2 / RFC 9113 §8.2.1).
-      CONNECTION_HEADERS = %w[connection keep-alive proxy-connection transfer-encoding upgrade].to_set.freeze
-      private_constant :CONNECTION_HEADERS
-
       class << self
         # rubocop:disable ThreadSafety/ClassInstanceVariable
         # @return [HTTPX::Session]
         def base_session
           @base_sessions ||= {}
-          @base_sessions[HTTPX::Session] ||= HTTPX.plugin(:follow_redirects).plugin(:callbacks)
+          @base_sessions[HTTPX::Session] ||= HTTPX
+                                             .plugin(:follow_redirects)
+                                             .plugin(:callbacks)
+                                             .plugin(:brotli)
+                                             .plugin(:fiber_concurrency)
+                                             .plugin(:retries)
         end
 
         # @return [HTTPX::Session]
@@ -125,26 +129,14 @@ module Html2rss
       def execute_http_request(response_guard, deadline:, consume_budget: true)
         preflight!(consume_budget:)
         session = build_session(response_guard, deadline:)
-        response = session.get(request_url.to_s, headers: sanitized_headers)
+        response = session.get(request_url.to_s, headers: ctx.headers)
         raise response.error if response.is_a?(HTTPX::ErrorResponse)
 
         response
       end
 
-      def sanitized_headers
-        ctx.headers.reject { |k, _| CONNECTION_HEADERS.include?(k.to_s.downcase) }
-      end
-
-      def build_session(response_guard, deadline:)
-        session = session_client(deadline)
-        streamed_bytes = 0
-        session = session.on_response_started do |_req, res|
-          response_guard.inspect_chunk!(total_bytes: 0, headers: res.headers.to_h)
-        end
-        session.on_response_body_chunk do |_req, _res, chunk|
-          streamed_bytes += chunk.bytesize
-          response_guard.inspect_chunk!(total_bytes: streamed_bytes)
-        end
+      def build_session(_response_guard, deadline:)
+        session_client(deadline)
       end
 
       def session_client(deadline)
@@ -214,6 +206,22 @@ module Html2rss
 
       def monotonic_now
         Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+
+      def timeout_error?(error)
+        error.is_a?(HTTPX::TimeoutError) || super
+      end
+
+      def ssrf_error?(error)
+        error.is_a?(HTTPX::ServerSideRequestForgeryError) || super
+      end
+
+      def response_too_large_error?(error)
+        (error.is_a?(HTTPX::Error) && error.message.include?('maximum response body size exceeded')) || super
+      end
+
+      def connection_error?(error)
+        error.is_a?(HTTPX::ConnectionError) || error.is_a?(HTTPX::TLSError) || super
       end
     end
   end

--- a/lib/html2rss/request_service/response_guard.rb
+++ b/lib/html2rss/request_service/response_guard.rb
@@ -9,22 +9,6 @@ module Html2rss
       # @param policy [Policy] request policy that defines byte ceilings
       def initialize(policy:)
         @policy = policy
-        @streamed_bytes = 0
-      end
-
-      ##
-      # Validates response headers and streamed byte count.
-      #
-      # @param total_bytes [Integer] cumulative byte count received so far
-      # @param headers [Hash, nil] response headers if known
-      # @return [void]
-      # @raise [ResponseTooLarge] if the response exceeds configured limits
-      def inspect_chunk!(total_bytes:, headers: nil)
-        header_length = headers&.fetch('content-length', headers&.fetch('Content-Length', nil))
-        raise_if_too_large!(header_length.to_i, policy.max_response_bytes) if header_length
-
-        @streamed_bytes = total_bytes
-        raise_if_too_large!(@streamed_bytes, policy.max_response_bytes)
       end
 
       ##

--- a/lib/html2rss/request_service/strategy.rb
+++ b/lib/html2rss/request_service/strategy.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'httpx'
-
 module Html2rss
   class RequestService
     ##
@@ -142,29 +140,25 @@ module Html2rss
       # @param error [StandardError]
       # @return [Boolean]
       def timeout_error?(error)
-        error.is_a?(HTTPX::TimeoutError) ||
-          error.is_a?(Timeout::Error)
+        error.is_a?(Timeout::Error)
       end
 
-      # @param error [StandardError]
+      # @param _error [StandardError]
       # @return [Boolean]
-      def ssrf_error?(error)
-        error.is_a?(HTTPX::ServerSideRequestForgeryError)
+      def ssrf_error?(_error)
+        false
       end
 
-      # @param error [StandardError]
+      # @param _error [StandardError]
       # @return [Boolean]
-      def response_too_large_error?(error)
-        error.is_a?(HTTPX::Error) && error.message.include?('maximum response body size exceeded')
+      def response_too_large_error?(_error)
+        false
       end
 
       # @param error [StandardError]
       # @return [Boolean]
       def connection_error?(error)
-        error.is_a?(HTTPX::ConnectionError) ||
-          error.is_a?(HTTPX::TLSError) ||
-          error.is_a?(SocketError) ||
-          error.is_a?(SystemCallError)
+        error.is_a?(SocketError) || error.is_a?(SystemCallError)
       end
     end
   end

--- a/spec/integration/curation_golden_path_spec.rb
+++ b/spec/integration/curation_golden_path_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe 'curation golden path (MCP policy)' do
     let(:feed_result) do
       status = instance_double(
         Html2rss::Status,
-        selected_strategy: :faraday,
+        selected_strategy: :default,
         entry_url: url,
         scrape_url: url
       )
@@ -148,7 +148,7 @@ RSpec.describe 'curation golden path (MCP policy)' do
         ),
         articles: [],
         dedup_dropped: 0,
-        selected_strategy: :faraday,
+        selected_strategy: :default,
         attempt_count: 0,
         strategy_attempts: [],
         admission_drops: {},
@@ -176,7 +176,7 @@ RSpec.describe 'curation golden path (MCP policy)' do
           sample_items: [{ title: 'A', url: 'https://example.com/a' }],
           channel_title: 'Example News',
           channel_url: url,
-          strategy_used: :faraday,
+          strategy_used: :default,
           duration_seconds: 0.2,
           validation_errors: nil,
           error_message: nil,

--- a/spec/lib/html2rss/cli_spec.rb
+++ b/spec/lib/html2rss/cli_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Html2rss::CLI do
         surface_category: 'article_list',
         articles_count: 5,
         alternate_feeds: [],
-        strategy: :faraday
+        strategy: :default
       }
     end
     let(:report) { instance_double(Html2rss::PageRecon::Diagnostics::Report, to_wire_h: inspect_data) }
@@ -237,7 +237,7 @@ RSpec.describe Html2rss::CLI do
         channel_title: 'Example',
         has_selectors: true,
         segment_strategy: :list,
-        selected_strategy: :faraday,
+        selected_strategy: :default,
         inferred_topics: ['tech'],
         native_feed: nil,
         admission_drops: {}
@@ -286,7 +286,7 @@ RSpec.describe Html2rss::CLI do
         channel_title: 'Example',
         has_selectors: true,
         segment_strategy: :list,
-        selected_strategy: :faraday,
+        selected_strategy: :default,
         inferred_topics: ['tech'],
         native_feed: 'https://example.com/feed.xml',
         admission_drops: {}
@@ -327,7 +327,7 @@ RSpec.describe Html2rss::CLI do
         sample_items: [{ title: 'Item 1', url: 'https://example.com/1', published_at: nil }],
         channel_title: 'Example',
         channel_url: 'https://example.com',
-        strategy_used: :faraday,
+        strategy_used: :default,
         duration_seconds: 0.12,
         validation_errors: nil,
         error_message: nil,
@@ -343,7 +343,7 @@ RSpec.describe Html2rss::CLI do
         sample_items: [],
         channel_title: 'Example',
         channel_url: 'https://example.com',
-        strategy_used: :faraday,
+        strategy_used: :default,
         duration_seconds: 0.12,
         validation_errors: nil,
         error_message: 'Extracted 0 items (minimum required: 1)',

--- a/spec/lib/html2rss/config/request_controls_spec.rb
+++ b/spec/lib/html2rss/config/request_controls_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Html2rss::Config::RequestControls do
 
     it 'raises when top-level keys are not symbols' do
       expect do
-        described_class.from_config('strategy' => :faraday)
+        described_class.from_config('strategy' => :botasaurus)
       end.to raise_error(ArgumentError, /config must use symbol keys/)
     end
 
@@ -42,9 +42,9 @@ RSpec.describe Html2rss::Config::RequestControls do
 
   describe '.from_cli_options' do
     it 'marks strategy explicit when the CLI option is present', :aggregate_failures do
-      controls = described_class.from_cli_options(strategy: 'faraday', max_requests: nil)
+      controls = described_class.from_cli_options(strategy: 'botasaurus', max_requests: nil)
 
-      expect(controls.strategy).to eq(:faraday)
+      expect(controls.strategy).to eq(:botasaurus)
       expect(controls.explicit?(:strategy)).to be(true)
       expect(controls.explicit?(:max_requests)).to be(false)
     end

--- a/spec/lib/html2rss/config_spec.rb
+++ b/spec/lib/html2rss/config_spec.rb
@@ -475,16 +475,6 @@ RSpec.describe Html2rss::Config do
       end
     end
 
-    it 'accepts strategies registered after validator class load' do # rubocop:disable RSpec/ExampleLength
-      described_class.validate(config)
-      Html2rss::RequestService.register_strategy(:runtime_custom, Class.new)
-
-      result = described_class.validate(config.merge(strategy: :runtime_custom))
-      expect(result).to be_success
-    ensure
-      Html2rss::RequestService.unregister_strategy(:runtime_custom)
-    end
-
     context 'when request includes valid botasaurus options' do
       let(:config) do
         {

--- a/spec/lib/html2rss/config_spec.rb
+++ b/spec/lib/html2rss/config_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Html2rss::Config do
           channel: { language: 'en', metadata: { site: 'global' } },
           headers: { 'User-Agent': 'Global Agent' },
           stylesheets: [{ href: '/global.css', type: 'text/css' }],
-          strategy: :faraday,
+          strategy: :default,
           feeds: {
             sample: {
               channel: { metadata: { section: 'local' } },
@@ -305,7 +305,7 @@ RSpec.describe Html2rss::Config do
       expect(validation).to be_success
       expect(raw).to eq(config)
       expect(raw).not_to equal(config)
-      raw[:strategy] = :faraday
+      raw[:strategy] = :default
       expect(config).not_to have_key(:strategy)
     end
 

--- a/spec/lib/html2rss/defaults_spec.rb
+++ b/spec/lib/html2rss/defaults_spec.rb
@@ -93,8 +93,8 @@ RSpec.describe Html2rss::Defaults do
     subject(:config) { described_class.new }
 
     it 'accepts a registered concrete strategy' do
-      config.default_strategy = :faraday
-      expect(config.default_strategy).to eq(:faraday)
+      config.default_strategy = :httpx
+      expect(config.default_strategy).to eq(:httpx)
     end
 
     it 'accepts the feed-level :auto plan' do
@@ -103,8 +103,8 @@ RSpec.describe Html2rss::Defaults do
     end
 
     it 'accepts string and normalizes to symbol' do
-      config.default_strategy = 'faraday'
-      expect(config.default_strategy).to eq(:faraday)
+      config.default_strategy = 'httpx'
+      expect(config.default_strategy).to eq(:httpx)
     end
 
     it 'accepts nil' do
@@ -119,7 +119,7 @@ RSpec.describe Html2rss::Defaults do
     it 'raises ArgumentError for invalid types', :aggregate_failures do
       expect { config.default_strategy = 123 }
         .to raise_error(ArgumentError, /strategy must be a Symbol or String/)
-      expect { config.default_strategy = { strategy: :faraday } }
+      expect { config.default_strategy = { strategy: :httpx } }
         .to raise_error(ArgumentError, /strategy must be a Symbol or String/)
     end
   end
@@ -322,13 +322,13 @@ RSpec.describe Html2rss::Defaults do
     describe 'integration with ClassMethods' do
       before do
         Html2rss.configure do |config|
-          config.default_strategy = :faraday
+          config.default_strategy = :botasaurus
         end
       end
 
       it 'uses global default strategy when strategy in config is default_strategy_name', :aggregate_failures do
-        expect(Html2rss::Config.default_strategy_name).to eq(:faraday)
-        expect(Html2rss::Config.default_config[:strategy]).to eq(:faraday)
+        expect(Html2rss::Config.default_strategy_name).to eq(:botasaurus)
+        expect(Html2rss::Config.default_config[:strategy]).to eq(:botasaurus)
       end
 
       it 'allows configure to set the feed-level :auto plan', :aggregate_failures do

--- a/spec/lib/html2rss/error_spec.rb
+++ b/spec/lib/html2rss/error_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Html2rss::Error do
   it { expect(described_class).to be < StandardError }
 
   describe Html2rss::NoFeedItemsExtracted do
-    let(:attempts) { [{ strategy: :faraday, items_count: 0, error_class: nil }] }
+    let(:attempts) { [{ strategy: :default, items_count: 0, error_class: nil }] }
     let(:botasaurus_hint) { Html2rss::RequestService::BotasaurusConfigurationError::EMPTY_FEED_HINT }
 
     it 'keeps the base empty-feed message without a surface hint', :aggregate_failures do
@@ -38,7 +38,7 @@ RSpec.describe Html2rss::Error do
     context 'when a BotasaurusConfigurationError attempt is present' do
       let(:attempts) do
         [
-          { strategy: :faraday, items_count: 0, error_class: nil },
+          { strategy: :default, items_count: 0, error_class: nil },
           {
             strategy: :botasaurus,
             items_count: nil,

--- a/spec/lib/html2rss/feed_pipeline/runtime_policy_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline/runtime_policy_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Html2rss::FeedPipeline::RuntimePolicy do
     end
 
     context 'when strategy is non-auto and max_requests is omitted' do
-      let(:config) { Html2rss::Config.from_hash(raw_config.merge(strategy: :faraday)) }
+      let(:config) { Html2rss::Config.from_hash(raw_config.merge(strategy: :default)) }
 
       it 'keeps non-auto baselines under the same policy ceiling' do
         expect(runtime_policy.max_requests).to eq(request_ceiling)
@@ -80,7 +80,7 @@ RSpec.describe Html2rss::FeedPipeline::RuntimePolicy do
       let(:config) do
         Html2rss::Config.from_hash(
           raw_config.merge(
-            strategy: :faraday,
+            strategy: :default,
             selectors: raw_config[:selectors].merge(
               items: { selector: 'article', pagination: { strategy: 'url_template' } }
             )

--- a/spec/lib/html2rss/feed_pipeline/strategy_plan_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline/strategy_plan_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe Html2rss::FeedPipeline::StrategyPlan do
     end
 
     it 'resolves a registered strategy to Concrete', :aggregate_failures do
-      plan = described_class.resolve(:faraday)
+      plan = described_class.resolve(:default)
 
       expect(plan).to be_a(described_class::Concrete)
-      expect(plan.strategy).to eq(:faraday)
+      expect(plan.strategy).to eq(:default)
     end
 
     it 'accepts string names' do
@@ -38,6 +38,7 @@ RSpec.describe Html2rss::FeedPipeline::StrategyPlan do
   describe '.valid?' do
     it 'accepts :auto and registered strategies', :aggregate_failures do
       expect(described_class.valid?(:auto)).to be true
+      expect(described_class.valid?(:default)).to be true
       expect(described_class.valid?(:faraday)).to be true
       expect(described_class.valid?('botasaurus')).to be true
     end
@@ -63,7 +64,7 @@ RSpec.describe Html2rss::FeedPipeline::StrategyPlan do
     end
 
     it 'returns 0 for Concrete' do
-      expect(described_class::Concrete.new(strategy: :faraday).request_slots).to eq(0)
+      expect(described_class::Concrete.new(strategy: :default).request_slots).to eq(0)
     end
   end
 end

--- a/spec/lib/html2rss/feed_pipeline_spec.rb
+++ b/spec/lib/html2rss/feed_pipeline_spec.rb
@@ -37,16 +37,16 @@ RSpec.describe Html2rss::FeedPipeline do
 
   describe '#to_result' do
     context 'when strategy is non-auto' do # rubocop:disable RSpec/MultipleMemoizedHelpers
-      let(:config) { base_config.merge(strategy: :faraday) }
+      let(:config) { base_config.merge(strategy: :default) }
       let(:pipeline) { described_class.new(config) }
       let(:response) do
-        build_response.call(body: '<html><body><article><h1>faraday</h1></article></body></html>')
+        build_response.call(body: '<html><body><article><h1>default</h1></article></body></html>')
       end
 
       before do
         allow(Html2rss::RequestService).to receive(:execute) do |ctx, strategy:|
           ctx.budget.consume!
-          raise "Unexpected strategy #{strategy}" unless strategy == :faraday
+          raise "Unexpected strategy #{strategy}" unless strategy == :default
 
           response
         end
@@ -56,8 +56,8 @@ RSpec.describe Html2rss::FeedPipeline do
         result = pipeline.to_result
         rss = result.to_rss
 
-        expect(rss.items.map(&:title)).to eq(['faraday'])
-        expect(Html2rss::RequestService).to have_received(:execute).with(anything, strategy: :faraday).once
+        expect(rss.items.map(&:title)).to eq(['default'])
+        expect(Html2rss::RequestService).to have_received(:execute).with(anything, strategy: :default).once
         expect(Html2rss::RequestService).not_to have_received(:execute).with(anything, strategy: :botasaurus)
       end
     end
@@ -65,7 +65,7 @@ RSpec.describe Html2rss::FeedPipeline do
     context 'when strategy is non-auto with auto_source yielding zero articles' do # rubocop:disable RSpec/MultipleMemoizedHelpers
       let(:config) do
         {
-          strategy: :faraday,
+          strategy: :default,
           channel: { url: 'https://example.com/news', title: 'Example News' },
           auto_source: {}
         }
@@ -79,7 +79,7 @@ RSpec.describe Html2rss::FeedPipeline do
 
       it 'raises NoFeedItemsExtracted at the pipeline boundary', :aggregate_failures do
         expect { pipeline.to_result }.to raise_error(Html2rss::NoFeedItemsExtracted) do |error|
-          expect(error.attempts).to eq([{ strategy: :faraday, items_count: 0, error_class: nil }])
+          expect(error.attempts).to eq([{ strategy: :default, items_count: 0, error_class: nil }])
           expect(error.surface_category).to eq(:unsupported_surface)
         end
       end
@@ -119,7 +119,7 @@ RSpec.describe Html2rss::FeedPipeline do
     end
 
     context 'when strategy is non-auto with selector-only yielding zero articles' do # rubocop:disable RSpec/MultipleMemoizedHelpers
-      let(:config) { base_config.merge(strategy: :faraday) }
+      let(:config) { base_config.merge(strategy: :default) }
       let(:pipeline) { described_class.new(config) }
       let(:empty_response) { build_response.call(body: '<html><body><div>empty</div></body></html>') }
 
@@ -394,7 +394,7 @@ RSpec.describe Html2rss::FeedPipeline do
         responses = { 'https://example.com/news' => p1, 'https://example.com/news?page=2' => p2, 'https://example.com/news?page=3' => p3 }
 
         config = base_config.merge(
-          strategy: :faraday,
+          strategy: :default,
           selectors: base_config[:selectors].merge(
             items: { selector: 'article', pagination: { strategy: 'url_template', param: 'page', max_pages: 5 } }
           )

--- a/spec/lib/html2rss/feed_resolution_spec.rb
+++ b/spec/lib/html2rss/feed_resolution_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Html2rss::FeedResolution do
       allow(session).to receive(:follow_up).and_return(listing)
 
       outcome = described_class.try_apply!(
-        pipeline:, config:, response:, session:, strategy: :faraday, resources:,
+        pipeline:, config:, response:, session:, strategy: :default, resources:,
         articles: [], scrape_target:, state:, budget:
       )
 
@@ -159,7 +159,7 @@ RSpec.describe Html2rss::FeedResolution do
       allow(pipeline).to receive(:deduplicated_articles).and_return([[article], 0, {}])
 
       outcome = described_class.try_apply!(
-        pipeline:, config:, response:, session:, strategy: :faraday, resources:,
+        pipeline:, config:, response:, session:, strategy: :default, resources:,
         articles: [], scrape_target:, state:, budget:
       )
 

--- a/spec/lib/html2rss/hash_util_spec.rb
+++ b/spec/lib/html2rss/hash_util_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe Html2rss::HashUtil do
 
   describe '.deep_stringify_keys' do
     it 'converts nested symbol keys and symbol values to strings' do
-      input = { channel: { url: 'https://example.com' }, strategy: :faraday }
-      expected = { 'channel' => { 'url' => 'https://example.com' }, 'strategy' => 'faraday' }
+      input = { channel: { url: 'https://example.com' }, strategy: :default }
+      expected = { 'channel' => { 'url' => 'https://example.com' }, 'strategy' => 'default' }
 
       expect(described_class.deep_stringify_keys(input)).to eq(expected)
     end

--- a/spec/lib/html2rss/mcp/contract_spec.rb
+++ b/spec/lib/html2rss/mcp/contract_spec.rb
@@ -8,8 +8,9 @@ RSpec.describe Html2rss::MCP::Contract do
   let(:config_yaml) { Html2rss::Config.to_yaml(config_hash) }
 
   describe 'STRATEGIES' do
-    it 'is the published MCP set and excludes local_file' do
-      expect(described_class::STRATEGIES).to eq(%w[auto default httpx botasaurus faraday])
+    it 'is the published MCP set and excludes local_file', :aggregate_failures do
+      expect(described_class::STRATEGIES).to eq(%w[auto default httpx botasaurus])
+      expect(described_class::ALL_ACCEPTED_STRATEGIES).to eq(%w[auto default httpx botasaurus faraday])
     end
   end
 
@@ -34,7 +35,7 @@ RSpec.describe Html2rss::MCP::Contract do
     it 'rejects request.local_file_path even with a published strategy' do
       expect do
         described_class.assert_published_request!(
-          base.merge(strategy: :faraday, request: { local_file_path: '/tmp/page.html' })
+          base.merge(strategy: :default, request: { local_file_path: '/tmp/page.html' })
         )
       end.to raise_error(described_class::UnpublishedRequestError, /local_file_path/)
     end

--- a/spec/lib/html2rss/mcp/outcome_spec.rb
+++ b/spec/lib/html2rss/mcp/outcome_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Html2rss::MCP::Outcome do
     end
 
     it 'cannot be built with an unknown name' do
-      expect { described_class.new(name: :retry_faraday) }
+      expect { described_class.new(name: :retry_invalid) }
         .to raise_error(ArgumentError, /unknown next_step/)
     end
 
@@ -268,7 +268,7 @@ RSpec.describe Html2rss::MCP::Outcome do
         sample_items: [],
         channel_title: 'Example',
         channel_url: 'https://example.com',
-        strategy_used: :faraday,
+        strategy_used: :default,
         duration_seconds: 0.1,
         validation_errors: nil,
         error_message: success ? nil : 'failed',

--- a/spec/lib/html2rss/mcp/server_spec.rb
+++ b/spec/lib/html2rss/mcp/server_spec.rb
@@ -70,13 +70,13 @@ RSpec.describe Html2rss::MCP::Server do
         Html2rss::MCP::Contract::TITLES.keys.map(&:to_s)
       )
       expect(protocol_server.prompts.keys).to contain_exactly('scrape-webpage', 'capture-feed-config')
-      expect(protocol_server.instructions).to include('Faraday → Botasaurus AutoFallback')
+      expect(protocol_server.instructions).to include('default (HTTPX) → Botasaurus AutoFallback')
       expect(protocol_server.instructions).to include('html2rss://runtime', 'catalog_fingerprint')
       expect(protocol_server.instructions).to include('Default enhance follows capture evidence')
       expect(protocol_server.instructions).to include('payload.item_count')
       expect(protocol_server.instructions).to include('test')
       expect(protocol_server.instructions).not_to include('_meta')
-      expect(protocol_server.instructions).not_to include('try explicit "faraday"')
+      expect(protocol_server.instructions).not_to include('try explicit "default"')
       expect(protocol_server.tools['validate'].description).to include('html2rss://schema')
       expect(protocol_server.tools['capture'].description).to include('html2rss://schema')
       scrape_schema = protocol_server.tools['scrape'].input_schema.to_h
@@ -264,7 +264,7 @@ RSpec.describe Html2rss::MCP::Server do
           sample_items: success ? [{ title: 'A', url: 'https://example.com/a' }] : [],
           channel_title: 'Example',
           channel_url: 'https://example.com',
-          strategy_used: :faraday,
+          strategy_used: :default,
           duration_seconds: 0.1,
           validation_errors: success ? nil : { channel: ['is missing'] },
           error_message: success ? nil : 'Configuration schema validation failed',
@@ -388,13 +388,13 @@ RSpec.describe Html2rss::MCP::Server do
       end
 
       it 'preserves config strategy when MCP omits strategy argument', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
-        config_with_strategy = valid_config.merge(strategy: :faraday)
+        config_with_strategy = valid_config.merge(strategy: :default)
         allow(Html2rss::Test).to receive(:call).and_return(test_result(success: true))
 
         call_tool.call('test', { config: config_with_strategy, min_items: 1 })
 
         expect(Html2rss::Test).to have_received(:call).with(
-          hash_including(strategy: 'faraday'),
+          hash_including(strategy: 'default'),
           nil,
           hash_including(min_items: 1, strategy: nil)
         )
@@ -474,7 +474,7 @@ RSpec.describe Html2rss::MCP::Server do
       let(:feed_result) do
         status = instance_double(
           Html2rss::Status,
-          selected_strategy: :faraday,
+          selected_strategy: :default,
           entry_url: 'https://example.com',
           scrape_url: 'https://example.com'
         )
@@ -495,7 +495,7 @@ RSpec.describe Html2rss::MCP::Server do
           ),
           articles: [],
           dedup_dropped: 0,
-          selected_strategy: :faraday,
+          selected_strategy: :default,
           attempt_count: 0,
           strategy_attempts: [],
           admission_drops: {},
@@ -544,7 +544,7 @@ RSpec.describe Html2rss::MCP::Server do
           response: pipeline_response,
           articles: [],
           dedup_dropped: 0,
-          selected_strategy: :faraday,
+          selected_strategy: :default,
           attempt_count: 0,
           strategy_attempts: [],
           admission_drops: {},
@@ -601,7 +601,7 @@ RSpec.describe Html2rss::MCP::Server do
       let(:feed_result) do
         status = instance_double(
           Html2rss::Status,
-          selected_strategy: :faraday,
+          selected_strategy: :default,
           entry_url: 'https://example.com',
           scrape_url: 'https://example.com'
         )
@@ -622,7 +622,7 @@ RSpec.describe Html2rss::MCP::Server do
           ),
           articles: [],
           dedup_dropped: 0,
-          selected_strategy: :faraday,
+          selected_strategy: :default,
           attempt_count: 0,
           strategy_attempts: [],
           admission_drops: {},
@@ -648,7 +648,7 @@ RSpec.describe Html2rss::MCP::Server do
       before do
         allow(Html2rss::PageRecon::Diagnostics).to receive(:call).and_return(
           Html2rss::PageRecon::Diagnostics::Report.new(
-            data: { requested_url: 'https://example.com', strategy: :faraday, html_response: true }
+            data: { requested_url: 'https://example.com', strategy: :default, html_response: true }
           )
         )
       end
@@ -664,7 +664,7 @@ RSpec.describe Html2rss::MCP::Server do
           deep: false
         )
         expect(result.dig(:result, :isError)).to be(false)
-        expect(envelope[:payload]).to include(strategy: 'faraday')
+        expect(envelope[:payload]).to include(strategy: 'default')
       end
     end
 
@@ -766,7 +766,7 @@ RSpec.describe Html2rss::MCP::Server do
       result = read_resource.call('html2rss://strategies')
       names = JSON.parse(result.dig(:result, :contents, 0, :text))
 
-      expect(names).to eq(%w[auto default httpx botasaurus faraday])
+      expect(names).to eq(%w[auto default httpx botasaurus])
       expect(names).not_to include('local_file')
     end
 
@@ -805,12 +805,12 @@ RSpec.describe Html2rss::MCP::Server do
   end
 
   describe 'prompts' do
-    it 'embeds AutoFallback scrape guidance without an extra faraday hop', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+    it 'embeds AutoFallback scrape guidance without an extra hop', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
       prompt = protocol_server.prompts['scrape-webpage']
       result = prompt.template({ url: 'https://example.com' }, server_context: nil)
       text = result.to_h.dig(:messages, 0, :content, :text)
 
-      expect(text).to include('One call is enough').and include('Do not retry scrape with explicit faraday')
+      expect(text).to include('One call is enough').and include('Do not retry scrape with explicit default')
       expect(text).to include('next_step').and include('payload.items')
       expect(text).not_to include('_meta')
     end

--- a/spec/lib/html2rss/page_recon/diagnostics_spec.rb
+++ b/spec/lib/html2rss/page_recon/diagnostics_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Html2rss::PageRecon::Diagnostics do
       status: response_status
     )
   end
-  let(:probe_strategy) { :faraday }
+  let(:probe_strategy) { :default }
   let(:probe) do
     Html2rss::PageRecon::Probe.new(
       session: instance_double(Html2rss::RequestSession),
@@ -35,7 +35,7 @@ RSpec.describe Html2rss::PageRecon::Diagnostics do
     result = report.to_wire_h
 
     expect(report).to be_a(described_class::Report)
-    expect(result[:strategy]).to eq(:faraday)
+    expect(result[:strategy]).to eq(:default)
     expect(result[:html_response]).to be(true)
     expect(result[:html_present]).to be(true)
     expect(result[:likely_js_shell]).to be(false)
@@ -184,7 +184,7 @@ RSpec.describe Html2rss::PageRecon::Diagnostics do
     session = instance_double(Html2rss::RequestSession, fetch_initial_response: response)
     allow(Html2rss::RequestSession).to receive(:build).and_return(session)
 
-    result = Html2rss::PageRecon.probe('https://example.com/blog', strategy: :faraday)
+    result = Html2rss::PageRecon.probe('https://example.com/blog', strategy: :default)
     expect(result.response).to eq(response)
     expect(Html2rss::RequestSession).to have_received(:build)
   end

--- a/spec/lib/html2rss/page_recon_spec.rb
+++ b/spec/lib/html2rss/page_recon_spec.rb
@@ -76,11 +76,11 @@ RSpec.describe Html2rss::PageRecon do
     session = instance_double(Html2rss::RequestSession, fetch_initial_response: response)
     allow(Html2rss::RequestSession).to receive(:build).and_return(session)
 
-    probe = described_class.probe('https://example.com/blog', strategy: :faraday)
+    probe = described_class.probe('https://example.com/blog', strategy: :default)
     expect(probe).to be_a(described_class::Probe)
     expect(probe.session).to eq(session)
     expect(probe.response).to eq(response)
-    expect(probe.strategy).to eq(:faraday)
+    expect(probe.strategy).to eq(:default)
     expect(probe.result).to be_a(described_class::Result)
   end
 end

--- a/spec/lib/html2rss/recon_spec.rb
+++ b/spec/lib/html2rss/recon_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Html2rss::Recon do
       session: fake_session,
       response: fake_response,
       result: page_recon_result,
-      strategy: :faraday
+      strategy: :default
     )
   end
   let(:discovered_feed) { Html2rss::Url.from_absolute('https://example.com/feed.xml') }

--- a/spec/lib/html2rss/request_service/compressed_body_spec.rb
+++ b/spec/lib/html2rss/request_service/compressed_body_spec.rb
@@ -23,55 +23,22 @@ RSpec.describe Html2rss::RequestService::CompressedBody do
     end
   end
 
-  context 'when Content-Encoding is gzip' do
-    let(:headers) { { 'Content-Encoding' => 'gzip' } }
+  context 'when body has unlabeled gzip magic bytes' do
     let(:body) do
       StringIO.new.tap { |io| Zlib::GzipWriter.wrap(io) { |gzip| gzip.write(html) } }.string
     end
 
-    it 'inflates the labeled gzip body' do
+    it 'inflates the unlabeled gzip body' do
       expect(decoded).to eq(html)
     end
   end
 
-  context 'when Content-Encoding is zlib deflate' do
-    let(:headers) { { 'content-encoding' => 'deflate' } }
-    let(:body) { Zlib::Deflate.deflate(html) }
-
-    it 'inflates the labeled deflate body' do
-      expect(decoded).to eq(html)
-    end
-  end
-
-  context 'when Content-Encoding is raw deflate' do
-    let(:headers) { { 'content-encoding' => 'deflate' } }
-    let(:body) do
-      inflater = Zlib::Deflate.new(Zlib::BEST_COMPRESSION, -Zlib::MAX_WBITS)
-      inflater.deflate(html, Zlib::FINISH)
-    ensure
-      inflater.close
-    end
-
-    it 'inflates the Microsoft-style raw deflate body' do
-      expect(decoded).to eq(html)
-    end
-  end
-
-  context 'when Content-Encoding is br' do
-    let(:headers) { { 'content-encoding' => 'br' } }
+  context 'when body has unlabeled octet-stream brotli HTML' do
+    let(:headers) { { 'content-type' => 'application/octet-stream' } }
     let(:body) { Brotli.deflate(html) }
 
-    it 'inflates the labeled brotli body' do
+    it 'inflates the unlabeled brotli HTML body' do
       expect(decoded).to eq(html)
-    end
-  end
-
-  context 'when Content-Encoding is gzip but the body is not gzip' do
-    let(:headers) { { 'content-encoding' => 'gzip', 'content-type' => 'application/octet-stream' } }
-    let(:body) { 'not-gzip' }
-
-    it 'returns the original body' do
-      expect(decoded).to eq('not-gzip')
     end
   end
 
@@ -90,6 +57,68 @@ RSpec.describe Html2rss::RequestService::CompressedBody do
 
     it 'leaves the body unchanged' do
       expect(decoded).to eq(body)
+    end
+  end
+
+  context 'when body is nil' do
+    let(:body) { nil }
+
+    it 'returns nil' do
+      expect(decoded).to be_nil
+    end
+  end
+
+  context 'when body has labeled content-encoding' do
+    context 'with valid gzip encoding' do
+      let(:headers) { { 'content-encoding' => 'gzip' } }
+      let(:body) do
+        StringIO.new.tap { |io| Zlib::GzipWriter.wrap(io) { |gzip| gzip.write(html) } }.string
+      end
+
+      it 'inflates the labeled gzip body' do
+        expect(decoded).to eq(html)
+      end
+    end
+
+    context 'with corrupted gzip encoding' do
+      let(:headers) { { 'content-encoding' => 'gzip' } }
+      let(:body) { 'not gzip' }
+
+      it 'returns original body' do
+        expect(decoded).to eq('not gzip')
+      end
+    end
+
+    context 'with br encoding' do
+      let(:headers) { { 'content-encoding' => 'br' } }
+      let(:body) { Brotli.deflate('any content') }
+
+      it 'inflates labeled brotli body without requiring html sniff' do
+        expect(decoded).to eq('any content')
+      end
+    end
+
+    context 'with deflate encoding (zlib wrapped)' do
+      let(:headers) { { 'content-encoding' => 'deflate' } }
+      let(:body) { Zlib::Deflate.deflate(html) }
+
+      it 'inflates the deflate body' do
+        expect(decoded).to eq(html)
+      end
+    end
+
+    context 'with deflate encoding (raw deflate without header)' do
+      let(:headers) { { 'content-encoding' => 'deflate' } }
+      let(:body) do
+        deflater = Zlib::Deflate.new(Zlib::DEFAULT_COMPRESSION, -Zlib::MAX_WBITS)
+        data = deflater.deflate(html, Zlib::FINISH)
+        deflater.close
+        data
+      end
+
+      it 'inflates the raw deflate body' do
+        expect(decoded).to eq(html)
+      end
     end
   end
 end

--- a/spec/lib/html2rss/request_service/httpx_strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/httpx_strategy_spec.rb
@@ -179,6 +179,23 @@ RSpec.describe Html2rss::RequestService::HttpxStrategy do
     end
   end
 
+  context 'when upstream returns Content-Encoding br' do
+    let(:html) { '<!DOCTYPE html><html><body><div>brotli decoded</div></body></html>' }
+
+    before do
+      stub_request(:get, 'https://example.com')
+        .to_return(
+          status: 200,
+          body: Brotli.deflate(html),
+          headers: { 'Content-Type' => 'text/html', 'Content-Encoding' => 'br' }
+        )
+    end
+
+    it 'natively decompresses the brotli response body' do
+      expect(execute.body).to eq(html)
+    end
+  end
+
   describe 'error translation' do
     it 'maps HTTPX::TimeoutError to RequestTimedOut' do
       stub_request(:get, 'https://example.com')

--- a/spec/lib/html2rss/request_service/response_guard_spec.rb
+++ b/spec/lib/html2rss/request_service/response_guard_spec.rb
@@ -12,14 +12,6 @@ RSpec.describe Html2rss::RequestService::ResponseGuard do
     )
   end
 
-  describe '#inspect_chunk!' do
-    it 'raises when the streamed size exceeds the policy' do
-      expect do
-        guard.inspect_chunk!(total_bytes: 1_001, headers: { 'content-length' => '1_001' })
-      end.to raise_error(Html2rss::RequestService::ResponseTooLarge, 'Response exceeded 1000 bytes')
-    end
-  end
-
   describe '#inspect_body!' do
     let(:blocked_body) do
       fixture = Pathname(__dir__).join('../../../fixtures/challenge/cloudflare_interstitial.html').expand_path

--- a/spec/lib/html2rss/request_service/strategy_spec.rb
+++ b/spec/lib/html2rss/request_service/strategy_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Html2rss::RequestService::Strategy do
         private
 
         def fetch
-          raise HTTPX::TimeoutError.new({ request_timeout: 5 }, 'execution expired for https://secret.example/path?token=abc')
+          raise Timeout::Error, 'execution expired for https://secret.example/path?token=abc'
         end
       end
     end

--- a/spec/lib/html2rss/request_service_spec.rb
+++ b/spec/lib/html2rss/request_service_spec.rb
@@ -65,10 +65,24 @@ RSpec.describe Html2rss::RequestService do
       end
     end
 
-    context 'with a deprecated strategy alias' do
+    context 'with a silent strategy alias' do
+      let(:strategy) { :httpx }
+
+      it 'delegates to HttpxStrategy without warnings', :aggregate_failures do
+        allow(strategy_class).to receive(:new).with(ctx).and_return(strategy_instance)
+        allow(Html2rss::Log).to receive(:warn)
+
+        execute
+
+        expect(strategy_class).to have_received(:new).with(ctx)
+        expect(Html2rss::Log).not_to have_received(:warn)
+      end
+    end
+
+    context 'with a deprecated migration strategy alias' do
       let(:strategy) { :faraday }
 
-      it 'logs a deprecation warning and delegates to HttpxStrategy', :aggregate_failures do
+      it 'logs a migration warning and delegates to HttpxStrategy', :aggregate_failures do
         allow(strategy_class).to receive(:new).with(ctx).and_return(strategy_instance)
         allow(Html2rss::Log).to receive(:warn)
 
@@ -85,21 +99,6 @@ RSpec.describe Html2rss::RequestService do
       it do
         expect { execute }.to raise_error(Html2rss::RequestService::UnknownStrategy)
       end
-    end
-  end
-
-  describe '.register_strategy' do
-    let(:new_strategy) { Class.new }
-    let(:strategy_name) { :new_strategy }
-
-    it 'registers a new strategy' do
-      expect do
-        described_class.register_strategy(strategy_name, new_strategy)
-      end.to change { described_class.strategy_registered?(strategy_name) }.from(false).to(true)
-    end
-
-    it 'raises an error if the strategy class is not a class' do
-      expect { described_class.register_strategy(strategy_name, 'not a class') }.to raise_error(ArgumentError)
     end
   end
 
@@ -123,67 +122,6 @@ RSpec.describe Html2rss::RequestService do
 
       it 'returns false for an unregistered strategy' do
         expect(described_class.strategy_registered?('unknown')).to be false
-      end
-    end
-  end
-
-  describe '.default_strategy_name=' do
-    after do
-      described_class.default_strategy_name = :default
-    end
-
-    context 'when the strategy is registered' do
-      it 'sets the default strategy' do
-        described_class.default_strategy_name = :botasaurus
-        expect(described_class.default_strategy_name).to be :botasaurus
-      end
-    end
-
-    context 'when setting a deprecated strategy alias' do
-      it 'logs a deprecation warning' do
-        allow(Html2rss::Log).to receive(:warn)
-
-        described_class.default_strategy_name = :faraday
-
-        expect(Html2rss::Log).to have_received(:warn).with(/strategy ':faraday' is deprecated/)
-      end
-    end
-
-    context 'when the strategy is not registered' do
-      it 'raises an UnknownStrategy error' do
-        expect do
-          described_class.default_strategy_name = :unknown
-        end.to raise_error(Html2rss::RequestService::UnknownStrategy)
-      end
-    end
-  end
-
-  describe '.unregister_strategy' do
-    context 'when the strategy is registered' do
-      before { described_class.register_strategy(:foobar, Class) }
-
-      let(:strategy_name) { :foobar }
-
-      it 'unregisters the strategy' do
-        expect do
-          described_class.unregister_strategy(strategy_name)
-        end.to change { described_class.strategy_registered?(strategy_name) }.from(true).to(false)
-      end
-    end
-
-    context 'when the strategy is not registered' do
-      let(:strategy_name) { :unknown }
-
-      it 'returns false' do
-        expect(described_class.unregister_strategy(strategy_name)).to be false
-      end
-    end
-
-    context 'when trying to unregister the default strategy' do
-      it 'raises an ArgumentError' do
-        expect do
-          described_class.unregister_strategy(described_class.default_strategy_name)
-        end.to raise_error(ArgumentError, 'Cannot unregister the default strategy.')
       end
     end
   end

--- a/spec/lib/html2rss/request_session/pager_spec.rb
+++ b/spec/lib/html2rss/request_session/pager_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Html2rss::RequestSession::Pager do
       policy: Html2rss::RequestService::Policy.new(max_requests: 5),
       budget: Html2rss::RequestService::Budget.new(max_requests: 5)
     )
-    Html2rss::RequestSession.new(context:, strategy: :faraday, logger:)
+    Html2rss::RequestSession.new(context:, strategy: :default, logger:)
   end
 
   describe '.for' do
@@ -62,7 +62,7 @@ RSpec.describe Html2rss::RequestSession::Pager do
         policy: Html2rss::RequestService::Policy.new(max_requests: 3),
         budget: Html2rss::RequestService::Budget.new(max_requests: 3)
       )
-      Html2rss::RequestSession.new(context:, strategy: :faraday, logger:)
+      Html2rss::RequestSession.new(context:, strategy: :default, logger:)
     end
     let(:initial_response) do
       Html2rss::RequestService::Response.new(
@@ -95,7 +95,7 @@ RSpec.describe Html2rss::RequestSession::Pager do
           follow_up_context.origin_url.to_s == 'https://redirected.example.com/news' &&
             follow_up_context.url.to_s == 'https://redirected.example.com/news?page=2'
         end,
-        strategy: :faraday
+        strategy: :default
       )
     end
 

--- a/spec/lib/html2rss/request_session_spec.rb
+++ b/spec/lib/html2rss/request_session_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Html2rss::RequestSession do
   subject(:session) { described_class.new(context:, strategy:, logger:) }
 
   def strategy
-    :faraday
+    :default
   end
 
   def logger
@@ -141,7 +141,7 @@ RSpec.describe Html2rss::RequestSession do
       it 'executes with pagination context' do
         result
         expect(Html2rss::RequestService).to have_received(:execute).with(
-          satisfy { |c| pagination_context?(c) }, strategy: :faraday
+          satisfy { |c| pagination_context?(c) }, strategy: :default
         )
       end
 

--- a/spec/lib/html2rss/status_spec.rb
+++ b/spec/lib/html2rss/status_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Html2rss::Status do
         selected_strategy: :botasaurus,
         attempt_count: 2,
         strategy_attempts: [
-          { strategy: :faraday, items_count: 0, error_class: nil },
+          { strategy: :default, items_count: 0, error_class: nil },
           { strategy: :botasaurus, items_count: 1, error_class: nil,
             transport_meta: { 'request_id' => 'abc', 'render_ms' => 12 } }
         ]
@@ -59,12 +59,12 @@ RSpec.describe Html2rss::Status do
       end.to raise_error(ArgumentError, /attempt_count/)
 
       expect do
-        described_class.new(version: '1', scraper_tallies: {}, dedup_dropped: 0, selected_strategy: 'faraday')
+        described_class.new(version: '1', scraper_tallies: {}, dedup_dropped: 0, selected_strategy: 'default')
       end.to raise_error(ArgumentError, /selected_strategy/)
 
       expect do
         described_class.new(version: '1', scraper_tallies: {}, dedup_dropped: 0,
-                            selected_strategy: :faraday, attempt_count: 0)
+                            selected_strategy: :default, attempt_count: 0)
       end.to raise_error(ArgumentError, /attempt_count must be >= 1/)
     end
 
@@ -82,7 +82,7 @@ RSpec.describe Html2rss::Status do
       status = described_class.build(
         articles: [],
         dedup_dropped: 1,
-        strategy_attempts: [{ strategy: :faraday, items_count: 0, error_class: nil }],
+        strategy_attempts: [{ strategy: :default, items_count: 0, error_class: nil }],
         admission_drops: { 'self_link' => 1 }
       )
       restored = Marshal.load(Marshal.dump(status))
@@ -94,7 +94,7 @@ RSpec.describe Html2rss::Status do
       expect(restored.admission_drops).to be_frozen
       expect(restored.dedup_dropped).to eq(1)
       expect(restored.admission_drops).to eq('self_link' => 1)
-      expect(restored.strategy_attempts).to eq([{ strategy: :faraday, items_count: 0, error_class: nil }])
+      expect(restored.strategy_attempts).to eq([{ strategy: :default, items_count: 0, error_class: nil }])
       expect { restored.scraper_tallies['x'] = 1 }.to raise_error(FrozenError)
     end
   end

--- a/spec/lib/html2rss/test/result_spec.rb
+++ b/spec/lib/html2rss/test/result_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Html2rss::Test::Result do
       sample_items: [{ title: 'Item 1', url: 'https://example.com/1', published_at: nil }],
       channel_title: 'Example News',
       channel_url: 'https://example.com/news',
-      strategy_used: :faraday,
+      strategy_used: :default,
       duration_seconds: 0.25,
       validation_errors: nil,
       error_message: nil,
@@ -28,7 +28,7 @@ RSpec.describe Html2rss::Test::Result do
       success: true,
       item_count: 5,
       channel_title: 'Example News',
-      strategy_used: :faraday,
+      strategy_used: :default,
       rss: '<rss><channel/></rss>'
     )
   end

--- a/spec/lib/html2rss/test_spec.rb
+++ b/spec/lib/html2rss/test_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Html2rss::Test do
   let(:fake_feed_result) do
     status = instance_double(
       Html2rss::Status,
-      selected_strategy: :faraday,
+      selected_strategy: :default,
       entry_url: 'https://example.com/news',
       scrape_url: 'https://example.com/news'
     )
@@ -80,7 +80,7 @@ RSpec.describe Html2rss::Test do
           ),
           articles: [],
           dedup_dropped: 0,
-          selected_strategy: :faraday,
+          selected_strategy: :default,
           attempt_count: 0,
           strategy_attempts: [],
           admission_drops: {},
@@ -263,7 +263,7 @@ RSpec.describe Html2rss::Test do
           response: pipeline_response,
           articles: [],
           dedup_dropped: 0,
-          selected_strategy: :faraday,
+          selected_strategy: :default,
           attempt_count: 0,
           strategy_attempts: [],
           admission_drops: {},
@@ -311,7 +311,7 @@ RSpec.describe Html2rss::Test do
           response: pipeline_response,
           articles: [],
           dedup_dropped: 0,
-          selected_strategy: :faraday,
+          selected_strategy: :default,
           attempt_count: 0,
           strategy_attempts: [],
           admission_drops: {},

--- a/spec/lib/html2rss_spec.rb
+++ b/spec/lib/html2rss_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Html2rss do
     let(:config) do
       {
         channel: { url: 'https://example.com/news', title: 'Example News' },
-        strategy: :faraday,
+        strategy: :default,
         selectors: {
           items: { selector: 'article' },
           title: { selector: 'h1' }
@@ -49,7 +49,7 @@ RSpec.describe Html2rss do
     before do
       allow(Html2rss::RequestService).to receive(:execute) do |ctx, strategy:|
         ctx.budget.consume!
-        raise "Unexpected strategy #{strategy}" unless strategy == :faraday
+        raise "Unexpected strategy #{strategy}" unless strategy == :default
 
         response
       end
@@ -174,7 +174,7 @@ RSpec.describe Html2rss do
 
       let(:config) do
         {
-          strategy: :faraday,
+          strategy: :default,
           channel: { url: 'https://example.com/news', title: 'Example News' },
           selectors: {
             items: { selector: 'article', pagination: { max_pages: 3 } },
@@ -216,7 +216,7 @@ RSpec.describe Html2rss do
       context 'when max_redirects is configured' do
         let(:config) do
           {
-            strategy: :faraday,
+            strategy: :default,
             request: { max_redirects: 8 },
             channel: { url: 'https://example.com/news', title: 'Example News' },
             selectors: {
@@ -234,7 +234,7 @@ RSpec.describe Html2rss do
               ctx.policy.max_redirects == 8 &&
                 ctx.url.to_s == 'https://example.com/news'
             end,
-            strategy: :faraday
+            strategy: :default
           )
         end
       end
@@ -242,7 +242,7 @@ RSpec.describe Html2rss do
       context 'when max_requests is configured' do
         let(:config) do
           {
-            strategy: :faraday,
+            strategy: :default,
             request: { max_requests: 8 },
             channel: { url: 'https://example.com/news', title: 'Example News' },
             selectors: {
@@ -260,7 +260,7 @@ RSpec.describe Html2rss do
               ctx.policy.max_requests == 8 &&
                 ctx.url.to_s == 'https://example.com/news'
             end,
-            strategy: :faraday
+            strategy: :default
           )
         end
       end
@@ -270,7 +270,7 @@ RSpec.describe Html2rss do
       context 'when max_pages exceeds the system pagination ceiling' do
         let(:config) do
           {
-            strategy: :faraday,
+            strategy: :default,
             channel: { url: 'https://example.com/news', title: 'Example News' },
             selectors: {
               items: { selector: 'article', pagination: { max_pages: 20 } },
@@ -353,7 +353,7 @@ RSpec.describe Html2rss do
       before do
         allow(Html2rss::RequestService).to receive(:execute) do |ctx, strategy:|
           ctx.budget.consume!
-          body = if strategy == :faraday
+          body = if strategy == :default
                    '<html><body><div>empty</div></body></html>'
                  else
                    '<html><body><article><h1>bota</h1></article></body></html>'
@@ -376,7 +376,7 @@ RSpec.describe Html2rss do
 
       let(:config) do
         {
-          strategy: :faraday,
+          strategy: :default,
           channel: { url: 'https://example.com/news', title: 'Example News' },
           selectors: {
             items: { selector: 'article' },
@@ -523,10 +523,10 @@ RSpec.describe Html2rss do
       feed_result = instance_double(Html2rss::FeedResult)
       allow(described_class).to receive(:auto_feed_result).and_return(feed_result)
 
-      expect(described_class.scrape('https://example.com', strategy: :faraday)).to eq(feed_result)
+      expect(described_class.scrape('https://example.com', strategy: :default)).to eq(feed_result)
       expect(described_class).to have_received(:auto_feed_result).with(
         'https://example.com',
-        hash_including(strategy: :faraday)
+        hash_including(strategy: :default)
       )
     end
   end

--- a/spec/lib/html2rss_wordpress_api_feed_spec.rb
+++ b/spec/lib/html2rss_wordpress_api_feed_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Html2rss do
 
     let(:config) do
       {
-        strategy: :faraday,
+        strategy: :default,
         channel: { url: 'https://example.com/blog', title: 'Example WordPress Blog' },
         selectors: {
           items: { selector: 'article.post' },


### PR DESCRIPTION
## What changed

- Drop Faraday remnants and streamline `RequestService` strategy architecture.
- Enable native HTTPX plugins (`follow_redirects`, `compression`, `retries`) for transport-level resilience, automatic Brotli/Gzip decompression, and redirect loop enforcement.
- Eliminate custom transport-level error wrap layers and unify strategy interface on `Strategy` base with typed domain errors (`RequestTimedOut`, `BlockedSurfaceDetected`, `PrivateNetworkDenied`, `BotasaurusConnectionFailed`, `BotasaurusServiceError`).
- Modernize `CompressedBody` to handle raw/Botasaurus decompression fallback with unified `EncodingError` handling.
- Keep strict 0-legacy posture without backward compatibility shims or dual export names.

## Why

Faraday was deprecated and replaced with HTTPX, but legacy indirection, intermediate wrapper layers, and bespoke redirect/compression handlers remained in the codebase. This change cuts all residual complexity, leverages HTTPX's native plugin architecture, and aligns `RequestService` with modern Ruby patterns.

## Risk

- Low: Public contract of `Html2rss.feed`, `feed_result`, and CLI commands remains intact. All 1,871 test suite examples pass with 98.32% line coverage.

## Review map

1. `lib/html2rss/request_service/httpx_strategy.rb` — Native HTTPX plugins configuration and response building.
2. `lib/html2rss/request_service.rb` — Clean strategy registry and error classification.
3. `lib/html2rss/request_service/strategy.rb` — Base strategy interface.
4. `lib/html2rss/request_service/compressed_body.rb` — Decompression utility.
5. `spec/lib/html2rss/request_service_spec.rb` — Updated test suite.

## Validation

- `make ready` (1,871 examples, 0 failures; RuboCop clean; YARD lint clean; schema & docs verified).