### PR TITLE
chore(release): bump version to v0.30.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    html2rss (0.29.1)
+    html2rss (0.30.0)
       addressable (~> 2.7)
       brotli
       dry-validation
@@ -284,7 +284,7 @@ CHECKSUMS
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   hana (1.3.7) sha256=5425db42d651fea08859811c29d20446f16af196308162894db208cac5ce9b0d
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
-  html2rss (0.29.1)
+  html2rss (0.30.0)
   http-2 (1.2.2) sha256=81b5d45f50fd4cd5f8c5d09651184bec9401e3ef169c3eb3e5b003d5614a92b9
   httpx (1.8.3) sha256=cb88f2285c4ef17164d803a640dc393d28722cba7f282ad0e7f9f926cd02dc47
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc

--- a/lib/html2rss/version.rb
+++ b/lib/html2rss/version.rb
@@ -2,6 +2,6 @@
 
 module Html2rss
   # Current application version.
-  VERSION = '0.29.1'
+  VERSION = '0.30.0'
   public_constant :VERSION
 end


### PR DESCRIPTION
Automated version bump to `v0.30.0`.

This PR contains the version update in `lib/html2rss/version.rb` and regenerated schema.

### 🚀 Next Steps
1. Verify that all CI checks pass.
2. Merge this Pull Request.
3. Go to the draft release on GitHub and publish it.